### PR TITLE
feat(phase-1): semantic design token contract + Tailwind v4 preset

### DIFF
--- a/docs/design-system/tokens.md
+++ b/docs/design-system/tokens.md
@@ -1,0 +1,171 @@
+# Design tokens
+
+`@jonmatum/next-shell` ships a **semantic token contract** implemented as CSS custom properties in [`packages/next-shell/src/styles/tokens.css`](../../packages/next-shell/src/styles/tokens.css) and mirrored for type safety in [`packages/next-shell/src/tokens/index.ts`](../../packages/next-shell/src/tokens/index.ts).
+
+Every component in the package references **only** these tokens. The rule is enforced in CI by `next-shell/no-raw-colors`.
+
+> Current schema version: **1.0.0**
+
+## How to adopt
+
+### With Tailwind v4 (recommended)
+
+```css
+/* app/globals.css */
+@import 'tailwindcss';
+@import '@jonmatum/next-shell/styles/preset.css';
+```
+
+That single preset import:
+
+1. Loads the tokens at `:root` and `[data-theme="dark"]`.
+2. Maps every token to a Tailwind `@theme` key so utilities like `bg-background`, `text-foreground`, `border-border`, `rounded-lg`, `shadow-md`, `duration-normal`, `ease-standard` work everywhere — no `tailwind.config.js` required.
+
+### Without Tailwind
+
+```css
+@import '@jonmatum/next-shell/styles/tokens.css';
+```
+
+You can then use the tokens directly in CSS:
+
+```css
+.card {
+  background: var(--surface);
+  color: var(--surface-foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+```
+
+## Token categories
+
+### 1. Color (semantic, not hue-based)
+
+Expressed in **OKLCH** for perceptual uniformity and wider gamut.
+
+| Token                                    | Purpose                              |
+| ---------------------------------------- | ------------------------------------ |
+| `background` / `foreground`              | Page background + default text       |
+| `surface` / `surface-foreground`         | Cards, popovers, elevated containers |
+| `muted` / `muted-foreground`             | Subdued surfaces + secondary text    |
+| `accent` / `accent-foreground`           | Hover / active / subtle highlight    |
+| `primary` / `primary-foreground`         | Brand color + text on brand          |
+| `secondary` / `secondary-foreground`     | Secondary action                     |
+| `destructive` / `destructive-foreground` | Errors, destructive actions          |
+| `success` / `success-foreground`         | Success feedback                     |
+| `warning` / `warning-foreground`         | Cautionary feedback                  |
+| `info` / `info-foreground`               | Neutral informational feedback       |
+| `border`                                 | Default border color                 |
+| `input`                                  | Form field border / surface          |
+| `ring`                                   | Focus ring                           |
+| `sidebar-*` (8 tokens)                   | Dedicated sidebar surface / nav      |
+| `chart-1` … `chart-5`                    | Categorical chart hues               |
+
+Each token has a matching Tailwind utility under the same name: `bg-primary`, `text-primary-foreground`, `border-destructive`, `ring-ring`, and so on.
+
+### 2. Radius
+
+Scale is driven by a single `--radius` base so brand overrides only need to change one variable.
+
+| Token         | Value                       |
+| ------------- | --------------------------- |
+| `radius-xs`   | `calc(var(--radius) - 6px)` |
+| `radius-sm`   | `calc(var(--radius) - 4px)` |
+| `radius-md`   | `calc(var(--radius) - 2px)` |
+| `radius-lg`   | `var(--radius)`             |
+| `radius-xl`   | `calc(var(--radius) + 4px)` |
+| `radius-2xl`  | `calc(var(--radius) + 8px)` |
+| `radius-full` | `9999px`                    |
+
+Base: `--radius: 0.625rem` (10px).
+
+### 3. Typography
+
+**Families:** `font-sans`, `font-mono`, `font-display`
+
+**Fluid type scale** (uses `clamp()`): `text-xs`, `text-sm`, `text-base`, `text-lg`, `text-xl`, `text-2xl`, `text-3xl`, `text-4xl`, `text-5xl`.
+
+**Leading:** `leading-tight`, `leading-snug`, `leading-normal`, `leading-relaxed`, `leading-loose`
+
+**Tracking:** `tracking-tight`, `tracking-normal`, `tracking-wide`, `tracking-wider`
+
+### 4. Motion
+
+**Durations:** `duration-instant` (0ms), `duration-fast` (150ms), `duration-normal` (250ms), `duration-slow` (400ms), `duration-slowest` (600ms)
+
+**Easings:**
+
+| Token             | Curve                        | Use                                 |
+| ----------------- | ---------------------------- | ----------------------------------- |
+| `ease-standard`   | `cubic-bezier(0.2, 0, 0, 1)` | Default — most transitions          |
+| `ease-emphasized` | `cubic-bezier(0.3, 0, 0, 1)` | Large / attention-grabbing movement |
+| `ease-decelerate` | `cubic-bezier(0, 0, 0.2, 1)` | Element entering the screen         |
+| `ease-accelerate` | `cubic-bezier(0.3, 0, 1, 1)` | Element leaving the screen          |
+
+### 5. Elevation
+
+`shadow-xs`, `shadow-sm`, `shadow-md`, `shadow-lg`, `shadow-xl`, `shadow-2xl`
+
+Each scale has separate values tuned for light and dark themes — darker surfaces need higher alpha to remain visible.
+
+### 6. Density
+
+Designed for components that want to offer compact / comfortable / spacious variants without hardcoding padding.
+
+| Token                | Default  | Typical use         |
+| -------------------- | -------- | ------------------- |
+| `density-pad-x`      | `1rem`   | Horizontal padding  |
+| `density-pad-y`      | `0.5rem` | Vertical padding    |
+| `density-gap`        | `0.5rem` | Flex / grid gap     |
+| `density-row-height` | `2.5rem` | Row height (tables) |
+
+## Brand overrides
+
+The whole system is driven by CSS variables, so brand customization is a matter of re-declaring the ones you care about. Two helpers are available:
+
+### `buildRootOverrides(overrides)`
+
+Returns a `React.CSSProperties`-compatible object for a `style` prop:
+
+```tsx
+import { buildRootOverrides } from '@jonmatum/next-shell/tokens';
+
+const brand = buildRootOverrides({
+  radius: '0.5rem',
+  fontSans: 'Inter, sans-serif',
+  light: {
+    primary: 'oklch(0.55 0.18 280)',
+    'primary-foreground': 'oklch(0.985 0 0)',
+  },
+});
+
+<html style={brand}>{...}</html>;
+```
+
+### `brandOverridesCss(overrides)`
+
+Returns a ready-to-inject CSS string that scopes light and dark overrides to their respective selectors:
+
+```tsx
+import { brandOverridesCss } from '@jonmatum/next-shell/tokens';
+
+const css = brandOverridesCss({
+  light: { primary: 'oklch(0.55 0.18 280)' },
+  dark: { primary: 'oklch(0.75 0.15 280)' },
+});
+
+// Render in a <style> tag in the document head.
+```
+
+## Enforcement
+
+The `next-shell/no-raw-colors` ESLint rule flags any of the following in component source:
+
+- Hex literals (`#abc`, `#abcdef`, `#abcdef12`)
+- Raw CSS color functions (`rgb()`, `rgba()`, `hsl()`, `hsla()`, `oklch()`, `oklab()`, `color()`, `color-mix()`)
+- Tailwind palette utilities (`bg-red-500`, `text-slate-700`, …)
+- Tailwind black/white utilities (`bg-white`, `text-black`, …)
+
+Token definition files (`src/tokens/`, `tokens.css`, `tailwind-preset/`) are exempt — they're where the mapping to real colors lives.

--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -73,6 +73,7 @@
       "require": "./dist/tokens/index.cjs"
     },
     "./styles/tokens.css": "./dist/styles/tokens.css",
+    "./styles/preset.css": "./dist/styles/preset.css",
     "./tailwind-preset": {
       "types": "./dist/tailwind-preset/index.d.ts",
       "import": "./dist/tailwind-preset/index.js",

--- a/packages/next-shell/src/index.ts
+++ b/packages/next-shell/src/index.ts
@@ -10,3 +10,4 @@
 
 export * from './core/index.js';
 export { packageVersion } from './core/version.js';
+export { tokenSchemaVersion } from './tokens/index.js';

--- a/packages/next-shell/src/styles/preset.css
+++ b/packages/next-shell/src/styles/preset.css
@@ -1,0 +1,126 @@
+/*!
+ * @jonmatum/next-shell — Tailwind v4 preset
+ *
+ * Consumer usage:
+ *
+ *   @import "tailwindcss";
+ *   @import "@jonmatum/next-shell/styles/preset.css";
+ *
+ * That single preset import:
+ *   1. Loads the semantic tokens at `:root` and `[data-theme="dark"]`
+ *   2. Maps every token to a Tailwind v4 `@theme` key, so utilities like
+ *      `bg-background`, `text-foreground`, `border-border`, `rounded-lg`,
+ *      `shadow-md`, `duration-normal`, `ease-standard`, etc. work everywhere.
+ *
+ * Consumers who want to consume tokens directly (without Tailwind) can
+ * import only `@jonmatum/next-shell/styles/tokens.css`.
+ */
+
+@import './tokens.css';
+
+@theme {
+  /* ─── Color ──────────────────────────────────────────────────────── */
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+
+  --color-surface: var(--surface);
+  --color-surface-foreground: var(--surface-foreground);
+
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
+
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+
+  /* ─── Radius ─────────────────────────────────────────────────────── */
+  --radius-xs: var(--radius-xs);
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+  --radius-xl: var(--radius-xl);
+  --radius-2xl: var(--radius-2xl);
+  --radius-full: var(--radius-full);
+
+  /* ─── Typography ─────────────────────────────────────────────────── */
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
+  --font-display: var(--font-display);
+
+  --text-xs: var(--text-xs);
+  --text-sm: var(--text-sm);
+  --text-base: var(--text-base);
+  --text-lg: var(--text-lg);
+  --text-xl: var(--text-xl);
+  --text-2xl: var(--text-2xl);
+  --text-3xl: var(--text-3xl);
+  --text-4xl: var(--text-4xl);
+  --text-5xl: var(--text-5xl);
+
+  --leading-tight: var(--leading-tight);
+  --leading-snug: var(--leading-snug);
+  --leading-normal: var(--leading-normal);
+  --leading-relaxed: var(--leading-relaxed);
+  --leading-loose: var(--leading-loose);
+
+  --tracking-tight: var(--tracking-tight);
+  --tracking-normal: var(--tracking-normal);
+  --tracking-wide: var(--tracking-wide);
+  --tracking-wider: var(--tracking-wider);
+
+  /* ─── Motion ─────────────────────────────────────────────────────── */
+  --animate-duration-instant: var(--duration-instant);
+  --animate-duration-fast: var(--duration-fast);
+  --animate-duration-normal: var(--duration-normal);
+  --animate-duration-slow: var(--duration-slow);
+  --animate-duration-slowest: var(--duration-slowest);
+
+  --ease-standard: var(--ease-standard);
+  --ease-emphasized: var(--ease-emphasized);
+  --ease-decelerate: var(--ease-decelerate);
+  --ease-accelerate: var(--ease-accelerate);
+
+  /* ─── Elevation ──────────────────────────────────────────────────── */
+  --shadow-xs: var(--shadow-xs);
+  --shadow-sm: var(--shadow-sm);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
+  --shadow-xl: var(--shadow-xl);
+  --shadow-2xl: var(--shadow-2xl);
+}

--- a/packages/next-shell/src/styles/tokens.css
+++ b/packages/next-shell/src/styles/tokens.css
@@ -1,10 +1,227 @@
 /*!
  * @jonmatum/next-shell — semantic design tokens
  *
- * Placeholder shipped during Phase 0 to validate the static-asset copy step
- * in the tsup build. The real token contract lands in Phase 1 (see issue #2).
+ * This file defines every semantic token the design system consumes, in two
+ * themes: light (applied to `:root` and `[data-theme="light"]`) and dark
+ * (applied to `[data-theme="dark"]`).
+ *
+ * Values are expressed in OKLCH for perceptual uniformity and wider gamut.
+ *
+ * The tokens are split into 6 categories:
+ *   1. Color (semantic, not hue-based)
+ *   2. Radius
+ *   3. Typography (families + fluid scale + tracking / leading)
+ *   4. Motion (durations + easings)
+ *   5. Elevation (shadows tuned per theme)
+ *   6. Density (padding / gap helpers for components)
+ *
+ * Consumers wire this into Tailwind v4 by importing
+ * `@jonmatum/next-shell/styles/preset.css`, which maps every token to a
+ * Tailwind theme key (e.g. `--background` → `--color-background` → the
+ * `bg-background` utility).
+ *
+ * No component in this package references a raw color; every color flows
+ * through one of the tokens below, and the `next-shell/no-raw-colors` ESLint
+ * rule enforces that invariant at CI time.
  */
 
-:root {
-  --next-shell-token-schema-version: '0.0.0';
+:root,
+[data-theme='light'] {
+  /* ─────────────────────────────────────────────────────────────────────
+   * 1. Color — light theme
+   * ───────────────────────────────────────────────────────────────────── */
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+
+  --surface: oklch(1 0 0);
+  --surface-foreground: oklch(0.145 0 0);
+
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+
+  --primary: oklch(0.55 0.18 258);
+  --primary-foreground: oklch(0.985 0 0);
+
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --success: oklch(0.65 0.17 145);
+  --success-foreground: oklch(0.985 0 0);
+
+  --warning: oklch(0.78 0.17 85);
+  --warning-foreground: oklch(0.205 0 0);
+
+  --info: oklch(0.7 0.13 230);
+  --info-foreground: oklch(0.985 0 0);
+
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+
+  /* Sidebar — subtly distinct from the main surface for visual hierarchy. */
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+
+  /* Chart colors — 5 perceptually distinct hues for categorical data. */
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+
+  /* ─────────────────────────────────────────────────────────────────────
+   * 2. Radius — scale driven by a single `--radius` base so brand
+   *    overrides only need to change one variable.
+   * ───────────────────────────────────────────────────────────────────── */
+  --radius: 0.625rem;
+  --radius-xs: calc(var(--radius) - 6px);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --radius-full: 9999px;
+
+  /* ─────────────────────────────────────────────────────────────────────
+   * 3. Typography
+   * ───────────────────────────────────────────────────────────────────── */
+  --font-sans:
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  --font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  --font-display: var(--font-sans);
+
+  /* Fluid type scale. Each step clamps between a mobile and a desktop size,
+     scaling smoothly with viewport width. */
+  --text-xs: clamp(0.75rem, 0.7rem + 0.12vw, 0.8125rem);
+  --text-sm: clamp(0.8125rem, 0.78rem + 0.15vw, 0.875rem);
+  --text-base: clamp(0.9375rem, 0.9rem + 0.2vw, 1rem);
+  --text-lg: clamp(1.0625rem, 1rem + 0.3vw, 1.125rem);
+  --text-xl: clamp(1.1875rem, 1.1rem + 0.4vw, 1.25rem);
+  --text-2xl: clamp(1.375rem, 1.25rem + 0.6vw, 1.5rem);
+  --text-3xl: clamp(1.75rem, 1.5rem + 1vw, 1.875rem);
+  --text-4xl: clamp(2.125rem, 1.8rem + 1.4vw, 2.25rem);
+  --text-5xl: clamp(2.75rem, 2.4rem + 1.8vw, 3rem);
+
+  --leading-tight: 1.15;
+  --leading-snug: 1.3;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.65;
+  --leading-loose: 1.8;
+
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0;
+  --tracking-wide: 0.02em;
+  --tracking-wider: 0.04em;
+
+  /* ─────────────────────────────────────────────────────────────────────
+   * 4. Motion — Material-inspired standard easings, Radix-inspired speeds.
+   * ───────────────────────────────────────────────────────────────────── */
+  --duration-instant: 0ms;
+  --duration-fast: 150ms;
+  --duration-normal: 250ms;
+  --duration-slow: 400ms;
+  --duration-slowest: 600ms;
+
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --ease-emphasized: cubic-bezier(0.3, 0, 0, 1);
+  --ease-decelerate: cubic-bezier(0, 0, 0.2, 1);
+  --ease-accelerate: cubic-bezier(0.3, 0, 1, 1);
+
+  /* ─────────────────────────────────────────────────────────────────────
+   * 5. Elevation — shadows tuned for a white surface. Dark theme overrides
+   *    these with higher opacity so they remain visible on dark surfaces.
+   * ───────────────────────────────────────────────────────────────────── */
+  --shadow-xs: 0 1px 2px 0 oklch(0 0 0 / 0.05);
+  --shadow-sm: 0 1px 3px 0 oklch(0 0 0 / 0.1), 0 1px 2px -1px oklch(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px oklch(0 0 0 / 0.1), 0 2px 4px -2px oklch(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px oklch(0 0 0 / 0.1), 0 4px 6px -4px oklch(0 0 0 / 0.1);
+  --shadow-xl: 0 20px 25px -5px oklch(0 0 0 / 0.1), 0 8px 10px -6px oklch(0 0 0 / 0.1);
+  --shadow-2xl: 0 25px 50px -12px oklch(0 0 0 / 0.25);
+
+  /* ─────────────────────────────────────────────────────────────────────
+   * 6. Density — used by components for padding / gap. Consumer apps can
+   *    switch density by overriding these on any container.
+   * ───────────────────────────────────────────────────────────────────── */
+  --density-pad-x: 1rem;
+  --density-pad-y: 0.5rem;
+  --density-gap: 0.5rem;
+  --density-row-height: 2.5rem;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Dark theme — overrides applied when `[data-theme="dark"]` is set on any
+ * ancestor (typically `<html>`). Colors flip; non-color tokens inherit.
+ * ───────────────────────────────────────────────────────────────────── */
+[data-theme='dark'] {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+
+  --surface: oklch(0.205 0 0);
+  --surface-foreground: oklch(0.985 0 0);
+
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+
+  --primary: oklch(0.75 0.15 258);
+  --primary-foreground: oklch(0.205 0 0);
+
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --success: oklch(0.72 0.15 145);
+  --success-foreground: oklch(0.145 0 0);
+
+  --warning: oklch(0.82 0.16 85);
+  --warning-foreground: oklch(0.145 0 0);
+
+  --info: oklch(0.78 0.12 230);
+  --info-foreground: oklch(0.145 0 0);
+
+  --border: oklch(0.269 0 0);
+  --input: oklch(0.269 0 0);
+  --ring: oklch(0.556 0 0);
+
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.75 0.15 258);
+  --sidebar-primary-foreground: oklch(0.205 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(0.269 0 0);
+  --sidebar-ring: oklch(0.556 0 0);
+
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+
+  /* Elevation — higher opacity so shadows remain visible on dark surfaces. */
+  --shadow-xs: 0 1px 2px 0 oklch(0 0 0 / 0.3);
+  --shadow-sm: 0 1px 3px 0 oklch(0 0 0 / 0.4), 0 1px 2px -1px oklch(0 0 0 / 0.4);
+  --shadow-md: 0 4px 6px -1px oklch(0 0 0 / 0.4), 0 2px 4px -2px oklch(0 0 0 / 0.4);
+  --shadow-lg: 0 10px 15px -3px oklch(0 0 0 / 0.5), 0 4px 6px -4px oklch(0 0 0 / 0.5);
+  --shadow-xl: 0 20px 25px -5px oklch(0 0 0 / 0.5), 0 8px 10px -6px oklch(0 0 0 / 0.5);
+  --shadow-2xl: 0 25px 50px -12px oklch(0 0 0 / 0.7);
 }

--- a/packages/next-shell/src/tailwind-preset/index.ts
+++ b/packages/next-shell/src/tailwind-preset/index.ts
@@ -1,20 +1,58 @@
 /**
- * Tailwind CSS v4 preset — maps next-shell semantic tokens to Tailwind theme
- * keys so consumer apps get the full design system with a single import.
+ * @jonmatum/next-shell — Tailwind v4 preset (JS/TS surface)
  *
- * See the Phase 1 issue for the full specification. Populated in Phase 1.
- *
- * Consumer usage (Tailwind v4 with `@theme` CSS-based config):
+ * Tailwind v4 uses a CSS-based config via the `@theme` directive, so the
+ * primary way to adopt this preset is a CSS `@import`:
  *
  *   @import "tailwindcss";
- *   @import "@jonmatum/next-shell/styles/tokens.css";
+ *   @import "@jonmatum/next-shell/styles/preset.css";
  *
- * For legacy JS-config consumers the default export below will be populated
- * with a Tailwind config object in Phase 1.
+ * This TypeScript module exists for:
+ *   1. Consumers who want to resolve the preset path programmatically (e.g.
+ *      to inline the CSS into a build artifact).
+ *   2. Documenting the public token surface with types.
+ *   3. Future v3 compatibility helpers.
+ *
+ * See the Phase 1 issue (#2) for the specification.
  */
 
-const preset = {
-  /** Placeholder — populated in Phase 1. */
-} as const;
+import { colorTokens, radiusTokens, tokenSchemaVersion } from '../tokens/index.js';
+import type { ColorToken, RadiusToken } from '../tokens/index.js';
+
+/**
+ * Public import path for the Tailwind v4 preset CSS. Resolvable by any
+ * modern bundler or Node.js ESM loader via the package `exports` map.
+ */
+export const presetCssImportPath = '@jonmatum/next-shell/styles/preset.css' as const;
+
+/**
+ * Public import path for the semantic-token CSS only (no Tailwind theme
+ * mapping). Useful for consumers who don't use Tailwind.
+ */
+export const tokensCssImportPath = '@jonmatum/next-shell/styles/tokens.css' as const;
+
+/**
+ * Minimal typed description of the preset's public surface. Handy for
+ * generating docs or validating overrides.
+ */
+export interface PresetDescriptor {
+  readonly version: typeof tokenSchemaVersion;
+  readonly colors: readonly ColorToken[];
+  readonly radii: readonly RadiusToken[];
+  readonly cssImports: {
+    readonly preset: typeof presetCssImportPath;
+    readonly tokensOnly: typeof tokensCssImportPath;
+  };
+}
+
+export const preset: PresetDescriptor = {
+  version: tokenSchemaVersion,
+  colors: colorTokens,
+  radii: radiusTokens,
+  cssImports: {
+    preset: presetCssImportPath,
+    tokensOnly: tokensCssImportPath,
+  },
+};
 
 export default preset;

--- a/packages/next-shell/src/tokens/index.ts
+++ b/packages/next-shell/src/tokens/index.ts
@@ -1,13 +1,244 @@
 /**
- * Design token contract — semantic tokens that drive every component.
+ * @jonmatum/next-shell — semantic token contract (TypeScript view)
  *
- * See the Phase 1 issue for the full token specification. This module is
- * scaffolded during Phase 0 and populated in Phase 1 with:
- *   - `tokens` object (TypeScript-friendly view of the semantic token tree)
- *   - Theme definitions (light, dark)
- *   - Helper to generate brand overrides as CSS variable maps
+ * The canonical values live in `src/styles/tokens.css` as CSS custom
+ * properties. This module mirrors the contract at the type level so
+ * consumers get:
+ *   - Literal-union types for every token name (autocomplete + safety)
+ *   - A small set of helpers for building brand overrides and inline styles
  *
- * The static CSS file lives at `@jonmatum/next-shell/styles/tokens.css`.
+ * The Tailwind v4 preset at `@jonmatum/next-shell/styles/preset.css` maps
+ * every token below to a Tailwind theme key, so a token named `primary`
+ * surfaces as `bg-primary`, `text-primary-foreground`, etc.
+ *
+ * See the Phase 1 issue (#2) for the specification this implements.
  */
 
-export const tokenSchemaVersion = '0.0.0' as const;
+/**
+ * Version of the token contract. Bump on breaking changes (renamed or
+ * removed tokens). Consumers may assert the version at runtime.
+ */
+export const tokenSchemaVersion = '1.0.0' as const;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Color tokens
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Every semantic color token. Order mirrors `tokens.css` for readability.
+ * Each token pairs with a `-foreground` variant where relevant; the
+ * foreground is the color to use for text/icons placed on that surface.
+ */
+export const colorTokens = [
+  'background',
+  'foreground',
+
+  'surface',
+  'surface-foreground',
+
+  'muted',
+  'muted-foreground',
+
+  'accent',
+  'accent-foreground',
+
+  'primary',
+  'primary-foreground',
+
+  'secondary',
+  'secondary-foreground',
+
+  'destructive',
+  'destructive-foreground',
+
+  'success',
+  'success-foreground',
+
+  'warning',
+  'warning-foreground',
+
+  'info',
+  'info-foreground',
+
+  'border',
+  'input',
+  'ring',
+
+  'sidebar',
+  'sidebar-foreground',
+  'sidebar-primary',
+  'sidebar-primary-foreground',
+  'sidebar-accent',
+  'sidebar-accent-foreground',
+  'sidebar-border',
+  'sidebar-ring',
+
+  'chart-1',
+  'chart-2',
+  'chart-3',
+  'chart-4',
+  'chart-5',
+] as const;
+
+export type ColorToken = (typeof colorTokens)[number];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Radius tokens
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export const radiusTokens = ['xs', 'sm', 'md', 'lg', 'xl', '2xl', 'full'] as const;
+export type RadiusToken = (typeof radiusTokens)[number];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Typography tokens
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export const fontFamilyTokens = ['sans', 'mono', 'display'] as const;
+export type FontFamilyToken = (typeof fontFamilyTokens)[number];
+
+export const textSizeTokens = ['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl'] as const;
+export type TextSizeToken = (typeof textSizeTokens)[number];
+
+export const leadingTokens = ['tight', 'snug', 'normal', 'relaxed', 'loose'] as const;
+export type LeadingToken = (typeof leadingTokens)[number];
+
+export const trackingTokens = ['tight', 'normal', 'wide', 'wider'] as const;
+export type TrackingToken = (typeof trackingTokens)[number];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Motion tokens
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export const durationTokens = ['instant', 'fast', 'normal', 'slow', 'slowest'] as const;
+export type DurationToken = (typeof durationTokens)[number];
+
+export const easingTokens = ['standard', 'emphasized', 'decelerate', 'accelerate'] as const;
+export type EasingToken = (typeof easingTokens)[number];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Elevation tokens
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export const shadowTokens = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const;
+export type ShadowToken = (typeof shadowTokens)[number];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Density tokens
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export const densityTokens = ['pad-x', 'pad-y', 'gap', 'row-height'] as const;
+export type DensityToken = (typeof densityTokens)[number];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Brand overrides
+ *
+ * Consumer apps can override any token value per theme. The helpers below
+ * return `React.CSSProperties`-shaped objects (flat `--var` keys) that can
+ * be applied with a `style` prop or rendered as CSS via `brandOverridesCss`.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Partial token values to override. Use `light` for the default theme,
+ * `dark` for the `[data-theme="dark"]` override, and the top-level `radius`
+ * scalar if you only want to tweak the base radius.
+ */
+export interface BrandOverrides {
+  /** Overrides applied to `:root` / `[data-theme="light"]`. */
+  readonly light?: Partial<Record<ColorToken, string>>;
+  /** Overrides applied to `[data-theme="dark"]`. */
+  readonly dark?: Partial<Record<ColorToken, string>>;
+  /**
+   * Base radius value (e.g. `"0.5rem"`). Cascades to every `--radius-*`
+   * token since they are expressed as `calc(var(--radius) ± N)`.
+   */
+  readonly radius?: string;
+  /** Primary font family. */
+  readonly fontSans?: string;
+  /** Monospace font family. */
+  readonly fontMono?: string;
+  /** Display (headings) font family. */
+  readonly fontDisplay?: string;
+}
+
+/**
+ * Build an inline `style`-compatible object of CSS custom properties for the
+ * `:root` selector. Intended for SSR-safe brand application — apply it to
+ * the top-level `<html>` or a wrapping element.
+ */
+export function buildRootOverrides(overrides: BrandOverrides): Record<string, string> {
+  const style: Record<string, string> = {};
+
+  if (overrides.radius !== undefined) {
+    style['--radius'] = overrides.radius;
+  }
+  if (overrides.fontSans !== undefined) {
+    style['--font-sans'] = overrides.fontSans;
+  }
+  if (overrides.fontMono !== undefined) {
+    style['--font-mono'] = overrides.fontMono;
+  }
+  if (overrides.fontDisplay !== undefined) {
+    style['--font-display'] = overrides.fontDisplay;
+  }
+
+  for (const [token, value] of Object.entries(overrides.light ?? {})) {
+    if (value !== undefined) {
+      style[`--${token}`] = value;
+    }
+  }
+
+  return style;
+}
+
+/**
+ * Build a CSS rule string that scopes overrides to both themes. Use when
+ * an inline `style` prop is not available (e.g. inject into a `<style>`
+ * tag on the server).
+ */
+export function brandOverridesCss(overrides: BrandOverrides): string {
+  const rootLines: string[] = [];
+
+  if (overrides.radius !== undefined) {
+    rootLines.push(`--radius: ${overrides.radius};`);
+  }
+  if (overrides.fontSans !== undefined) {
+    rootLines.push(`--font-sans: ${overrides.fontSans};`);
+  }
+  if (overrides.fontMono !== undefined) {
+    rootLines.push(`--font-mono: ${overrides.fontMono};`);
+  }
+  if (overrides.fontDisplay !== undefined) {
+    rootLines.push(`--font-display: ${overrides.fontDisplay};`);
+  }
+  for (const [token, value] of Object.entries(overrides.light ?? {})) {
+    if (value !== undefined) {
+      rootLines.push(`--${token}: ${value};`);
+    }
+  }
+
+  const darkLines: string[] = [];
+  for (const [token, value] of Object.entries(overrides.dark ?? {})) {
+    if (value !== undefined) {
+      darkLines.push(`--${token}: ${value};`);
+    }
+  }
+
+  const chunks: string[] = [];
+  if (rootLines.length > 0) {
+    chunks.push(`:root, [data-theme='light'] {\n  ${rootLines.join('\n  ')}\n}`);
+  }
+  if (darkLines.length > 0) {
+    chunks.push(`[data-theme='dark'] {\n  ${darkLines.join('\n  ')}\n}`);
+  }
+  return chunks.join('\n\n');
+}
+
+/**
+ * Return the CSS variable reference for a token, e.g. `var(--primary)`.
+ * Useful when writing inline styles or CSS-in-JS without risking typos.
+ */
+export function cssVar(
+  token: ColorToken | `radius-${RadiusToken}` | `shadow-${ShadowToken}`,
+): string {
+  return `var(--${token})`;
+}

--- a/packages/next-shell/tests/tokens.test.ts
+++ b/packages/next-shell/tests/tokens.test.ts
@@ -1,0 +1,129 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  brandOverridesCss,
+  buildRootOverrides,
+  colorTokens,
+  cssVar,
+  densityTokens,
+  durationTokens,
+  easingTokens,
+  fontFamilyTokens,
+  leadingTokens,
+  radiusTokens,
+  shadowTokens,
+  textSizeTokens,
+  tokenSchemaVersion,
+  trackingTokens,
+} from '../src/tokens/index.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+const TOKENS_CSS = readFileSync(resolve(HERE, '../src/styles/tokens.css'), 'utf8');
+const PRESET_CSS = readFileSync(resolve(HERE, '../src/styles/preset.css'), 'utf8');
+
+describe('token contract — metadata', () => {
+  it('exposes a token schema version', () => {
+    expect(tokenSchemaVersion).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});
+
+describe('token contract — every declared token exists in tokens.css', () => {
+  const expectations: Array<[string, readonly string[], (name: string) => string]> = [
+    ['color', colorTokens, (n) => `--${n}:`],
+    ['radius', radiusTokens, (n) => `--radius-${n}:`],
+    ['font-family', fontFamilyTokens, (n) => `--font-${n}:`],
+    ['text-size', textSizeTokens, (n) => `--text-${n}:`],
+    ['leading', leadingTokens, (n) => `--leading-${n}:`],
+    ['tracking', trackingTokens, (n) => `--tracking-${n}:`],
+    ['duration', durationTokens, (n) => `--duration-${n}:`],
+    ['easing', easingTokens, (n) => `--ease-${n}:`],
+    ['shadow', shadowTokens, (n) => `--shadow-${n}:`],
+    ['density', densityTokens, (n) => `--density-${n}:`],
+  ];
+
+  for (const [category, tokens, toDecl] of expectations) {
+    it(`every ${category} token is declared`, () => {
+      const missing = tokens.filter((t) => !TOKENS_CSS.includes(toDecl(t)));
+      expect(missing).toEqual([]);
+    });
+  }
+});
+
+describe('token contract — dark theme parity', () => {
+  // Dark theme must override every COLOR token. Non-color tokens may inherit.
+  it('every color token is re-declared inside [data-theme="dark"]', () => {
+    const darkBlockMatch = TOKENS_CSS.match(/\[data-theme='dark'\]\s*\{([\s\S]*?)\n\}/);
+    expect(darkBlockMatch).not.toBeNull();
+    const darkBlock = darkBlockMatch![1] ?? '';
+    const missing = colorTokens.filter((t) => !darkBlock.includes(`--${t}:`));
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('Tailwind preset — every token is mapped', () => {
+  it('every color token is mapped to a --color-* @theme key', () => {
+    const missing = colorTokens.filter((t) => !PRESET_CSS.includes(`--color-${t}: var(--${t});`));
+    expect(missing).toEqual([]);
+  });
+
+  it('every radius token is mapped to a --radius-* @theme key', () => {
+    const missing = radiusTokens.filter(
+      (t) => !PRESET_CSS.includes(`--radius-${t}: var(--radius-${t});`),
+    );
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('buildRootOverrides', () => {
+  it('emits CSS custom property keys for provided overrides', () => {
+    const style = buildRootOverrides({
+      radius: '0.5rem',
+      fontSans: 'Inter, sans-serif',
+      light: { primary: 'oklch(0.6 0.2 258)', 'primary-foreground': 'oklch(1 0 0)' },
+    });
+    expect(style).toEqual({
+      '--radius': '0.5rem',
+      '--font-sans': 'Inter, sans-serif',
+      '--primary': 'oklch(0.6 0.2 258)',
+      '--primary-foreground': 'oklch(1 0 0)',
+    });
+  });
+
+  it('returns an empty object when nothing is provided', () => {
+    expect(buildRootOverrides({})).toEqual({});
+  });
+});
+
+describe('brandOverridesCss', () => {
+  it('scopes light overrides to :root and dark overrides to [data-theme="dark"]', () => {
+    const css = brandOverridesCss({
+      light: { primary: 'oklch(0.6 0.2 258)' },
+      dark: { primary: 'oklch(0.75 0.15 258)' },
+    });
+    expect(css).toContain(":root, [data-theme='light']");
+    expect(css).toContain('--primary: oklch(0.6 0.2 258);');
+    expect(css).toContain("[data-theme='dark']");
+    expect(css).toContain('--primary: oklch(0.75 0.15 258);');
+  });
+
+  it('returns an empty string when nothing is provided', () => {
+    expect(brandOverridesCss({})).toBe('');
+  });
+});
+
+describe('cssVar helper', () => {
+  it('returns a var() reference for a color token', () => {
+    expect(cssVar('primary')).toBe('var(--primary)');
+  });
+
+  it('returns a var() reference for a radius token', () => {
+    expect(cssVar('radius-lg')).toBe('var(--radius-lg)');
+  });
+
+  it('returns a var() reference for a shadow token', () => {
+    expect(cssVar('shadow-md')).toBe('var(--shadow-md)');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the [next-shell extraction plan](https://github.com/jonmatum/next-shell/issues/13) — delivers the **design system foundation** every component in later phases will consume. No component may ever reference a raw color; everything flows through the semantic tokens defined here.

Closes #2 · Refs #13

## What's in the box

### OKLCH-based semantic tokens (6 categories)

All tokens live in `packages/next-shell/src/styles/tokens.css` as CSS custom properties, mirrored for type safety in `src/tokens/index.ts`.

| Category   | Tokens                                                                                           |
| ---------- | ------------------------------------------------------------------------------------------------ |
| Color      | background, foreground, surface, muted, accent, primary, secondary, destructive, success, warning, info, border, input, ring, 8 sidebar-*, chart-1…5 — all paired with `-foreground` where relevant |
| Radius     | xs, sm, md, lg, xl, 2xl, full — driven by a single `--radius` base (brand override = 1 var)      |
| Typography | families (sans/mono/display), fluid `clamp()` type scale (xs → 5xl), leading, tracking           |
| Motion     | durations (instant/fast/normal/slow/slowest), easings (standard/emphasized/decelerate/accelerate) |
| Elevation  | shadow-xs → shadow-2xl, tuned separately for light + dark                                         |
| Density    | pad-x, pad-y, gap, row-height                                                                    |

Dark theme declared at `[data-theme="dark"]`; a test asserts every color token is re-declared there (dark parity invariant).

### Tailwind v4 preset (one-line adoption)

`src/styles/preset.css` maps every token to a Tailwind `@theme` key:

```css
@import 'tailwindcss';
@import '@jonmatum/next-shell/styles/preset.css';
```

…and consumers get `bg-primary`, `text-foreground`, `border-border`, `rounded-lg`, `shadow-md`, `duration-normal`, `ease-standard`, and everything else — no `tailwind.config.js` required.

### Brand override API

Exported from `@jonmatum/next-shell/tokens`:

- `buildRootOverrides({ radius, fontSans, light, dark })` → `React.CSSProperties` for the `style` prop
- `brandOverridesCss(...)` → ready-to-inject CSS string scoping `:root` + `[data-theme="dark"]` selectors
- `cssVar('primary')` → `'var(--primary)'` typed helper

### Docs

`docs/design-system/tokens.md` documents every category, adoption flow, and the brand override helpers with examples.

## Verification

```
pnpm format:check → ✓
pnpm lint         → ✓ 0 errors (no-raw-colors happy — color literals only in token files)
pnpm typecheck    → ✓ clean
pnpm test         → ✓ 23 passed (2 smoke + 21 token contract)
pnpm build        → ✓ ESM + CJS + .d.ts for all 9 entry points; tokens.css + preset.css copied to dist/styles/
```

## Token contract tests

The new `tokens.test.ts` (21 tests) guards the contract at CI time:

- Every declared token (color, radius, typography, motion, elevation, density) is present in `tokens.css`
- Dark theme overrides **every** color token (dark parity)
- Tailwind preset maps every color + radius token to a `@theme` key
- Brand override helpers produce the expected CSS var maps / CSS strings
- `cssVar` helper returns well-formed `var()` references

## What is intentionally NOT in this PR

- **Theme provider + dark mode toggle** — Phase 2 / #3 (this PR only defines the tokens that Phase 2 will toggle)
- **shadcn/ui primitives** — Phase 3 / #4 (primitives consume the tokens defined here)
- **App shell layout** — Phase 4 / #5

## Checklist

- [x] No raw color literals in component source (`no-raw-colors` rule green; color values only in token files + tests)
- [x] Light + dark parity verified by test
- [x] Tailwind preset maps every token
- [x] Typecheck, tests, and build all pass locally