### PR TITLE
feat(phase-2): ThemeProvider, useTheme, ThemeToggle + SSR cookie helpers

### DIFF
--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -57,6 +57,11 @@
       "import": "./dist/providers/index.js",
       "require": "./dist/providers/index.cjs"
     },
+    "./providers/server": {
+      "types": "./dist/providers/server/index.d.ts",
+      "import": "./dist/providers/server/index.js",
+      "require": "./dist/providers/server/index.cjs"
+    },
     "./auth": {
       "types": "./dist/auth/index.d.ts",
       "import": "./dist/auth/index.js",
@@ -104,10 +109,14 @@
       "optional": true
     }
   },
+  "dependencies": {
+    "next-themes": "^0.4.4"
+  },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^22.10.1",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.1",

--- a/packages/next-shell/src/providers/index.ts
+++ b/packages/next-shell/src/providers/index.ts
@@ -1,8 +1,19 @@
+'use client';
+
 /**
- * Provider composer — ThemeProvider, QueryProvider, ToastProvider, etc.
+ * Providers subpath (client-only surface).
  *
- * See the Phase 2 + Phase 6 issues for the full specification.
- * This module is scaffolded during Phase 0 and populated in Phase 2 / Phase 6.
+ * Everything re-exported here is safe to use from a Next.js client component.
+ * Server-only helpers (e.g. cookie readers) live at
+ * `@jonmatum/next-shell/providers/server` so they can be imported from a
+ * Server Component without forcing a client boundary.
  */
 
-export {};
+export { ThemeProvider } from './theme/theme-provider.js';
+export type { ThemeProviderProps } from './theme/theme-provider.js';
+
+export { useTheme } from './theme/use-theme.js';
+export type { ThemeValue, ResolvedTheme, UseThemeResult } from './theme/use-theme.js';
+
+export { ThemeToggle } from './theme/theme-toggle.js';
+export type { ThemeToggleProps } from './theme/theme-toggle.js';

--- a/packages/next-shell/src/providers/server/index.ts
+++ b/packages/next-shell/src/providers/server/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Providers — server-only helpers.
+ *
+ * These helpers do not depend on React and can be called from Next.js
+ * Server Components, Route Handlers, or Middleware. They are deliberately
+ * split out from `@jonmatum/next-shell/providers` so importing them does
+ * not drag a client boundary into a server module.
+ */
+
+export {
+  THEME_COOKIE_NAME,
+  THEME_COOKIE_MAX_AGE,
+  getThemeFromCookies,
+  buildThemeCookieHeader,
+  isThemeValue,
+} from '../theme/theme-cookie.js';
+export type { CookieReader } from '../theme/theme-cookie.js';

--- a/packages/next-shell/src/providers/theme/theme-cookie.ts
+++ b/packages/next-shell/src/providers/theme/theme-cookie.ts
@@ -1,0 +1,61 @@
+/**
+ * SSR-safe theme persistence helpers.
+ *
+ * `next-themes` persists the theme to `localStorage` on the client, which is
+ * only readable after hydration. That leaves a one-frame window on first
+ * paint where the server-rendered HTML uses the default theme, and the
+ * client immediately swaps to the stored preference — the classic "theme
+ * flash" problem.
+ *
+ * The fix: also persist the theme to a cookie, which the server *can* read
+ * before rendering. The consumer app can then render `<html data-theme="…">`
+ * with the correct attribute on the first paint.
+ *
+ * These helpers are deliberately framework-agnostic — pass in any
+ * `cookies()` / `request.cookies` / manual cookie-jar object that exposes
+ * a `get(name)` method.
+ */
+
+import type { ThemeValue } from './use-theme.js';
+
+export const THEME_COOKIE_NAME = 'next-shell-theme';
+
+/** One year, in seconds. */
+export const THEME_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+/**
+ * Minimal interface compatible with Next.js `cookies()` (from `next/headers`)
+ * and standard cookie-jar libraries. Accepts any shape exposing a `get(name)`
+ * method that returns `{ value: string } | undefined`.
+ */
+export interface CookieReader {
+  readonly get: (name: string) => { readonly value: string } | undefined;
+}
+
+/** Type guard for a well-formed `ThemeValue` string. */
+export function isThemeValue(value: unknown): value is ThemeValue {
+  return value === 'light' || value === 'dark' || value === 'system';
+}
+
+/**
+ * Read the persisted theme from a cookie reader. Returns `null` when the
+ * cookie is missing or contains an unknown value.
+ */
+export function getThemeFromCookies(cookies: CookieReader): ThemeValue | null {
+  const cookie = cookies.get(THEME_COOKIE_NAME);
+  if (!cookie) return null;
+  return isThemeValue(cookie.value) ? cookie.value : null;
+}
+
+/**
+ * Build a `Set-Cookie` header value that persists a theme for one year.
+ * Suitable for Next.js Route Handlers or middleware.
+ */
+export function buildThemeCookieHeader(theme: ThemeValue): string {
+  return [
+    `${THEME_COOKIE_NAME}=${theme}`,
+    `Max-Age=${THEME_COOKIE_MAX_AGE}`,
+    'Path=/',
+    'SameSite=Lax',
+  ].join('; ');
+}

--- a/packages/next-shell/src/providers/theme/theme-provider.tsx
+++ b/packages/next-shell/src/providers/theme/theme-provider.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+import type { ThemeProviderProps as NextThemeProviderProps } from 'next-themes';
+import { brandOverridesCss } from '../../tokens/index.js';
+import type { BrandOverrides } from '../../tokens/index.js';
+
+/**
+ * Props for the next-shell ThemeProvider.
+ *
+ * Extends `next-themes`'s own props but pins sensible defaults so consumers
+ * don't have to configure them every time. The key defaults are:
+ *
+ *   - `attribute="data-theme"`  — matches `[data-theme="dark"]` in `tokens.css`
+ *   - `defaultTheme="system"`   — honor the OS preference on first visit
+ *   - `enableSystem`            — watch prefers-color-scheme media query
+ *   - `disableTransitionOnChange` — suppress a brief transition flash when
+ *                                   flipping theme, keeps the swap crisp
+ *
+ * Consumers can still override any of these by passing the prop explicitly.
+ *
+ * The `brand` prop lets an app override any token value per theme without
+ * forking the package — overrides are injected as a `<style>` tag inside
+ * the provider tree.
+ */
+export interface ThemeProviderProps extends Omit<NextThemeProviderProps, 'attribute' | 'value'> {
+  /**
+   * Brand token overrides. Values apply to `:root` / `[data-theme="light"]`
+   * from the `light` key and `[data-theme="dark"]` from the `dark` key.
+   */
+  readonly brand?: BrandOverrides;
+}
+
+/**
+ * Root-level theme provider for next-shell consumers. Wraps `next-themes`
+ * with defaults tuned for this design system and an optional brand override
+ * API.
+ *
+ * Typical usage in a Next.js 15 App Router `app/layout.tsx`:
+ *
+ * ```tsx
+ * import { ThemeProvider } from '@jonmatum/next-shell/providers';
+ *
+ * export default function RootLayout({ children }: { children: React.ReactNode }) {
+ *   return (
+ *     <html lang="en" suppressHydrationWarning>
+ *       <body>
+ *         <ThemeProvider>{children}</ThemeProvider>
+ *       </body>
+ *     </html>
+ *   );
+ * }
+ * ```
+ */
+export function ThemeProvider({
+  brand,
+  children,
+  defaultTheme = 'system',
+  enableSystem = true,
+  disableTransitionOnChange = true,
+  ...rest
+}: ThemeProviderProps) {
+  const brandCss = brand ? brandOverridesCss(brand) : '';
+
+  return (
+    <NextThemesProvider
+      attribute="data-theme"
+      defaultTheme={defaultTheme}
+      enableSystem={enableSystem}
+      disableTransitionOnChange={disableTransitionOnChange}
+      {...rest}
+    >
+      {brandCss ? (
+        <style data-next-shell-brand="" dangerouslySetInnerHTML={{ __html: brandCss }} />
+      ) : null}
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/packages/next-shell/src/providers/theme/theme-toggle.tsx
+++ b/packages/next-shell/src/providers/theme/theme-toggle.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import type { ButtonHTMLAttributes } from 'react';
+import { useTheme } from './use-theme.js';
+import type { ThemeValue } from './use-theme.js';
+
+const THEME_ORDER: readonly ThemeValue[] = ['light', 'dark', 'system'];
+
+function cn(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ');
+}
+
+function nextTheme(current: ThemeValue): ThemeValue {
+  const index = THEME_ORDER.indexOf(current);
+  return THEME_ORDER[(index + 1) % THEME_ORDER.length] ?? 'system';
+}
+
+const DEFAULT_LABELS: Record<ThemeValue, string> = {
+  light: 'Switch to dark theme',
+  dark: 'Switch to system theme',
+  system: 'Switch to light theme',
+};
+
+export interface ThemeToggleProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children'
+> {
+  /**
+   * Custom accessible labels keyed by current theme. The label describes
+   * what clicking the button will *do* — i.e. the theme it transitions to.
+   */
+  readonly labels?: Partial<Record<ThemeValue, string>>;
+}
+
+/**
+ * Icon button that cycles light → dark → system → light.
+ *
+ * Styling uses only semantic tokens (`text-foreground`, `bg-accent`,
+ * `ring-ring`, etc.). No primitives from Phase 3 are required, so this can
+ * ship immediately alongside the theme provider.
+ *
+ * The dropdown variant (light / dark / system as discrete menu items) will
+ * land in Phase 3 once the DropdownMenu primitive is available.
+ */
+export function ThemeToggle({ labels, className, onClick, ...rest }: ThemeToggleProps) {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+
+  const current = theme ?? 'system';
+  const resolved = resolvedTheme ?? 'light';
+  const target = nextTheme(current);
+  const label = labels?.[current] ?? DEFAULT_LABELS[current];
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      data-theme-value={current}
+      data-resolved-theme={resolved}
+      onClick={(event) => {
+        setTheme(target);
+        onClick?.(event);
+      }}
+      className={cn(
+        'inline-flex size-9 shrink-0 items-center justify-center rounded-md',
+        'text-foreground hover:bg-accent hover:text-accent-foreground',
+        'focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2',
+        'duration-fast ease-standard transition-colors',
+        className,
+      )}
+      {...rest}
+    >
+      <ThemeIcon theme={current} />
+    </button>
+  );
+}
+
+function ThemeIcon({ theme }: { readonly theme: ThemeValue }) {
+  const commonProps = {
+    width: 18,
+    height: 18,
+    viewBox: '0 0 24 24',
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeWidth: 2,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    'aria-hidden': true,
+  };
+
+  if (theme === 'light') {
+    return (
+      <svg {...commonProps}>
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2" />
+        <path d="M12 20v2" />
+        <path d="m4.93 4.93 1.41 1.41" />
+        <path d="m17.66 17.66 1.41 1.41" />
+        <path d="M2 12h2" />
+        <path d="M20 12h2" />
+        <path d="m6.34 17.66-1.41 1.41" />
+        <path d="m19.07 4.93-1.41 1.41" />
+      </svg>
+    );
+  }
+
+  if (theme === 'dark') {
+    return (
+      <svg {...commonProps}>
+        <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+      </svg>
+    );
+  }
+
+  // system
+  return (
+    <svg {...commonProps}>
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <path d="M8 21h8" />
+      <path d="M12 17v4" />
+    </svg>
+  );
+}

--- a/packages/next-shell/src/providers/theme/use-theme.ts
+++ b/packages/next-shell/src/providers/theme/use-theme.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useTheme as useNextTheme } from 'next-themes';
+
+/**
+ * All theme values the provider understands. `"system"` defers to the user's
+ * OS-level `prefers-color-scheme` preference.
+ */
+export type ThemeValue = 'light' | 'dark' | 'system';
+
+/**
+ * Resolved theme — always concrete (`"light"` or `"dark"`), even when the
+ * active preference is `"system"`.
+ */
+export type ResolvedTheme = Exclude<ThemeValue, 'system'>;
+
+export interface UseThemeResult {
+  /** The user's explicit preference, or `undefined` during SSR/first paint. */
+  readonly theme: ThemeValue | undefined;
+  /** Change the theme and persist it to storage (localStorage by default). */
+  readonly setTheme: (theme: ThemeValue) => void;
+  /** The concrete theme applied right now (resolves `"system"`). */
+  readonly resolvedTheme: ResolvedTheme | undefined;
+  /** The current OS-level theme preference, when known. */
+  readonly systemTheme: ResolvedTheme | undefined;
+  /** Available theme values (always `['light', 'dark', 'system']`). */
+  readonly themes: readonly ThemeValue[];
+}
+
+/**
+ * Typed wrapper around `next-themes`'s `useTheme`.
+ *
+ * `next-themes` types `theme`, `setTheme`, etc. as `string` so they can
+ * support arbitrary custom themes. next-shell only ships `"light"`,
+ * `"dark"`, and `"system"`, so we narrow the return type here for better
+ * autocomplete in consumer components.
+ */
+export function useTheme(): UseThemeResult {
+  const next = useNextTheme();
+  return {
+    theme: next.theme as ThemeValue | undefined,
+    setTheme: next.setTheme as (theme: ThemeValue) => void,
+    resolvedTheme: next.resolvedTheme as ResolvedTheme | undefined,
+    systemTheme: next.systemTheme as ResolvedTheme | undefined,
+    themes: (next.themes ?? ['light', 'dark', 'system']) as readonly ThemeValue[],
+  };
+}

--- a/packages/next-shell/tests/setup.ts
+++ b/packages/next-shell/tests/setup.ts
@@ -1,1 +1,22 @@
 import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+// jsdom doesn't implement `matchMedia`, which next-themes uses to watch the
+// `prefers-color-scheme` media query. Provide a minimal stub that reports
+// the OS theme as light by default. Tests that need dark OS preference can
+// override `window.matchMedia` per-test.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}

--- a/packages/next-shell/tests/theme-cookie.test.ts
+++ b/packages/next-shell/tests/theme-cookie.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildThemeCookieHeader,
+  getThemeFromCookies,
+  isThemeValue,
+  THEME_COOKIE_MAX_AGE,
+  THEME_COOKIE_NAME,
+} from '../src/providers/theme/theme-cookie.js';
+
+function makeCookies(store: Record<string, string>) {
+  return {
+    get(name: string) {
+      const value = store[name];
+      return value === undefined ? undefined : { value };
+    },
+  };
+}
+
+describe('theme cookie — isThemeValue', () => {
+  it.each(['light', 'dark', 'system'])('accepts %s as a valid theme', (value) => {
+    expect(isThemeValue(value)).toBe(true);
+  });
+
+  it.each(['', 'sepia', 'auto', 42, null, undefined, {}])('rejects %p', (value) => {
+    expect(isThemeValue(value)).toBe(false);
+  });
+});
+
+describe('theme cookie — getThemeFromCookies', () => {
+  it('returns the stored value when a valid cookie is present', () => {
+    expect(getThemeFromCookies(makeCookies({ [THEME_COOKIE_NAME]: 'dark' }))).toBe('dark');
+  });
+
+  it('returns null when the cookie is missing', () => {
+    expect(getThemeFromCookies(makeCookies({}))).toBeNull();
+  });
+
+  it('returns null when the cookie contains an unknown value', () => {
+    expect(getThemeFromCookies(makeCookies({ [THEME_COOKIE_NAME]: 'sepia' }))).toBeNull();
+  });
+});
+
+describe('theme cookie — buildThemeCookieHeader', () => {
+  it('builds a Set-Cookie header with the expected attributes', () => {
+    const header = buildThemeCookieHeader('dark');
+    expect(header).toContain(`${THEME_COOKIE_NAME}=dark`);
+    expect(header).toContain(`Max-Age=${THEME_COOKIE_MAX_AGE}`);
+    expect(header).toContain('Path=/');
+    expect(header).toContain('SameSite=Lax');
+  });
+
+  it('sets Max-Age to one year', () => {
+    expect(THEME_COOKIE_MAX_AGE).toBe(60 * 60 * 24 * 365);
+  });
+});

--- a/packages/next-shell/tests/theme-provider.test.tsx
+++ b/packages/next-shell/tests/theme-provider.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ThemeProvider } from '../src/providers/theme/theme-provider.js';
+
+describe('ThemeProvider', () => {
+  it('renders children', () => {
+    render(
+      <ThemeProvider>
+        <span data-testid="child">hello</span>
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('child')).toHaveTextContent('hello');
+  });
+
+  it('injects a brand override <style> tag when brand overrides are provided', () => {
+    const { container } = render(
+      <ThemeProvider
+        brand={{
+          light: { primary: 'oklch(0.6 0.2 258)' },
+          dark: { primary: 'oklch(0.75 0.15 258)' },
+        }}
+      >
+        <span>child</span>
+      </ThemeProvider>,
+    );
+    const style = container.querySelector('style[data-next-shell-brand]');
+    expect(style).not.toBeNull();
+    expect(style?.innerHTML).toContain('--primary: oklch(0.6 0.2 258);');
+    expect(style?.innerHTML).toContain('--primary: oklch(0.75 0.15 258);');
+  });
+
+  it('does NOT inject a <style> tag when no brand overrides are provided', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <span>child</span>
+      </ThemeProvider>,
+    );
+    expect(container.querySelector('style[data-next-shell-brand]')).toBeNull();
+  });
+
+  it('forwards arbitrary next-themes props through', () => {
+    // If the prop threading breaks, next-themes will warn in console.
+    render(
+      <ThemeProvider defaultTheme="dark" storageKey="my-theme">
+        <span>child</span>
+      </ThemeProvider>,
+    );
+    expect(screen.getByText('child')).toBeInTheDocument();
+  });
+});

--- a/packages/next-shell/tests/theme-toggle.test.tsx
+++ b/packages/next-shell/tests/theme-toggle.test.tsx
@@ -1,0 +1,72 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ThemeProvider } from '../src/providers/theme/theme-provider.js';
+import { ThemeToggle } from '../src/providers/theme/theme-toggle.js';
+
+function renderToggle(defaultTheme = 'light') {
+  return render(
+    <ThemeProvider defaultTheme={defaultTheme} disableTransitionOnChange>
+      <ThemeToggle />
+    </ThemeProvider>,
+  );
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders a button with an accessible label', () => {
+    renderToggle('light');
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-label');
+    expect(btn.getAttribute('aria-label')).toMatch(/theme/i);
+  });
+
+  it('carries data-theme-value matching the current preference', async () => {
+    renderToggle('dark');
+    // ThemeProvider needs a tick to mount and hydrate state.
+    await act(async () => {});
+    expect(screen.getByRole('button')).toHaveAttribute('data-theme-value', 'dark');
+  });
+
+  it('cycles light → dark → system → light on successive clicks', async () => {
+    renderToggle('light');
+    const user = userEvent.setup();
+    const btn = screen.getByRole('button');
+
+    await act(async () => {});
+    expect(btn).toHaveAttribute('data-theme-value', 'light');
+
+    await user.click(btn);
+    expect(btn).toHaveAttribute('data-theme-value', 'dark');
+
+    await user.click(btn);
+    expect(btn).toHaveAttribute('data-theme-value', 'system');
+
+    await user.click(btn);
+    expect(btn).toHaveAttribute('data-theme-value', 'light');
+  });
+
+  it('uses only semantic-token classNames (no raw colors)', () => {
+    renderToggle('light');
+    const cls = screen.getByRole('button').className;
+    // The className must reference only semantic tokens — not palette
+    // utilities like `bg-slate-*` or `text-white`.
+    expect(cls).not.toMatch(
+      /(bg|text|border)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d+/,
+    );
+    expect(cls).not.toMatch(/(bg|text|border)-(white|black)\b/);
+    expect(cls).toMatch(/text-foreground|bg-accent|ring-ring/);
+  });
+
+  it('respects a custom className prop', () => {
+    render(
+      <ThemeProvider defaultTheme="light">
+        <ThemeToggle className="custom-extra" data-testid="toggle" />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('toggle').className).toContain('custom-extra');
+  });
+});

--- a/packages/next-shell/tsup.config.ts
+++ b/packages/next-shell/tsup.config.ts
@@ -1,6 +1,23 @@
 import { defineConfig } from 'tsup';
-import { cp } from 'node:fs/promises';
+import { cp, readFile, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+
+/**
+ * Entry paths whose bundled output must be client-only (RSC `'use client'`
+ * directive prepended). Listed relative to `dist/`, without the extension.
+ *
+ * tsup/esbuild strips `'use client'` directives from non-entry source files
+ * when bundling, so we re-add them to these specific entry outputs after
+ * the build completes.
+ */
+const CLIENT_ENTRIES = ['providers/index'] as const;
+
+async function prependUseClient(path: string) {
+  if (!existsSync(path)) return;
+  const body = await readFile(path, 'utf8');
+  if (body.startsWith("'use client'") || body.startsWith('"use client"')) return;
+  await writeFile(path, `'use client';\n${body}`, 'utf8');
+}
 
 export default defineConfig({
   entry: {
@@ -9,6 +26,7 @@ export default defineConfig({
     'layout/index': 'src/layout/index.ts',
     'primitives/index': 'src/primitives/index.ts',
     'providers/index': 'src/providers/index.ts',
+    'providers/server/index': 'src/providers/server/index.ts',
     'auth/index': 'src/auth/index.ts',
     'hooks/index': 'src/hooks/index.ts',
     'tokens/index': 'src/tokens/index.ts',
@@ -26,6 +44,13 @@ export default defineConfig({
     // Copy static CSS assets into dist/styles/.
     if (existsSync('src/styles')) {
       await cp('src/styles', 'dist/styles', { recursive: true });
+    }
+
+    // Re-apply `'use client'` to bundled client entries so Next.js RSC
+    // correctly treats them as client modules.
+    for (const entry of CLIENT_ENTRIES) {
+      await prependUseClient(`dist/${entry}.js`);
+      await prependUseClient(`dist/${entry}.cjs`);
     }
   },
 });

--- a/packages/next-shell/vitest.config.ts
+++ b/packages/next-shell/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  esbuild: {
+    // tsconfig keeps `jsx: "preserve"` so tsup/Next can handle the pass-through,
+    // but Vitest needs the automatic runtime so tests don't require a manual
+    // `import React`.
+    jsx: 'automatic',
+  },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,10 @@ importers:
         version: 8.58.2(eslint@9.39.4)(typescript@5.9.3)
 
   packages/next-shell:
+    dependencies:
+      next-themes:
+        specifier: ^0.4.4
+        version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
       '@testing-library/dom':
         specifier: ^10.4.0
@@ -68,6 +72,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^22.10.1
         version: 22.19.17
@@ -891,6 +898,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -1878,6 +1891,12 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@15.5.15:
     resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
@@ -3139,6 +3158,10 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@types/aria-query@5.0.4': {}
 
   '@types/estree@1.0.8': {}
@@ -4330,6 +4353,11 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  next-themes@0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## Summary

Phase 2 of the [next-shell extraction plan](https://github.com/jonmatum/next-shell/issues/13) — wraps `next-themes` with defaults tuned for our design system, adds a **brand override API** so consumers can customize any token per theme without forking, and ships **SSR-safe cookie helpers** for zero-flicker first paint.

Closes #3 · Refs #13

## What's in the box

### `ThemeProvider` (client)

```tsx
// app/layout.tsx
import { ThemeProvider } from '@jonmatum/next-shell/providers';

<ThemeProvider>{children}</ThemeProvider>
```

Wraps `next-themes` with attributes matching our tokens:

| Default                     | Why                                                         |
| --------------------------- | ----------------------------------------------------------- |
| `attribute="data-theme"`    | Matches `[data-theme="dark"]` selector in `tokens.css`      |
| `defaultTheme="system"`     | Respect OS preference on first visit                        |
| `enableSystem`              | Watch `prefers-color-scheme`                                |
| `disableTransitionOnChange` | Crisp theme swap — no brief transition flash                |

Accepts a `brand` prop of shape `BrandOverrides`; overrides render as a scoped `<style data-next-shell-brand>` tag so they apply before first paint.

### `useTheme` (typed hook)

```ts
const { theme, setTheme, resolvedTheme, systemTheme } = useTheme();
// theme: 'light' | 'dark' | 'system' | undefined
// resolvedTheme: 'light' | 'dark' | undefined
```

Narrows `next-themes`' `string` types to our concrete theme unions.

### `ThemeToggle` (icon button)

Cycles `light → dark → system → light`. Uses only semantic tokens (`text-foreground`, `bg-accent`, `ring-ring`, `duration-fast`, `ease-standard`). Inline SVG for sun/moon/monitor — no icon library dependency yet.

The dropdown variant (light / dark / system as discrete menu items) will land in Phase 3 once the DropdownMenu primitive is available.

### SSR cookie helpers (`@jonmatum/next-shell/providers/server`)

```ts
import { cookies } from 'next/headers';
import { getThemeFromCookies, buildThemeCookieHeader } from '@jonmatum/next-shell/providers/server';

// Server component
const theme = getThemeFromCookies(await cookies()) ?? 'system';
```

Framework-agnostic — accepts any object exposing `get(name)`. Works with Next.js `cookies()`, `request.cookies`, or custom cookie jars.

## Client / server split

Cookie helpers must NOT be pulled into a client boundary, so the module is deliberately split:

| Entry point                             | What                                                   |
| --------------------------------------- | ------------------------------------------------------ |
| `@jonmatum/next-shell/providers`        | **Client** — ThemeProvider, ThemeToggle, useTheme      |
| `@jonmatum/next-shell/providers/server` | **Server** — cookie readers and header builders        |

`tsup.config.ts` has a post-build hook that prepends `'use client'` to the `providers/index` bundles (esbuild strips inner-module directives during bundling). An allowlist keeps the server entry untouched.

Verified in `dist/`:
```
$ head -2 dist/providers/index.js
'use client';
import { ThemeProvider as ThemeProvider$1, useTheme as useTheme$1 } from 'next-themes';

$ head -2 dist/providers/server/index.js
// src/providers/theme/theme-cookie.ts
var THEME_COOKIE_NAME = "next-shell-theme";
```

## Verification

```
pnpm lint       → ✓
pnpm typecheck  → ✓
pnpm test       → ✓ 47 passed (24 new + 23 existing)
pnpm build      → ✓ ESM + CJS + .d.ts for all 10 entry points
```

### Tests added (24)

- **ThemeProvider** (4): renders children, injects brand `<style>` only when brand prop is given, omits it otherwise, forwards arbitrary next-themes props
- **ThemeToggle** (5): accessible label, data-theme-value matches current preference, cycles light→dark→system→light, uses only semantic-token classNames (regex-guarded against palette + white/black), respects className prop
- **theme-cookie** (15): type-guard for all valid/invalid inputs, get returns stored value / null for missing / null for unknown, buildThemeCookieHeader sets the expected attributes, Max-Age equals one year

### Infra fixes

- `setup.ts` now installs a `matchMedia` jsdom stub unconditionally (next-themes subscribes to `prefers-color-scheme` via `matchMedia.addListener`)
- `vitest.config.ts` uses `esbuild { jsx: 'automatic' }` so JSX-using tests don't need `import React`
- `@testing-library/user-event` added as dev dep for keyboard/click simulation in toggle tests
- Fixed bug during development where `vi.restoreAllMocks()` in an afterEach wiped the matchMedia stub mid-suite

## What is intentionally NOT in this PR

- **Dropdown variant of ThemeToggle** — requires DropdownMenu primitive (Phase 3 / #4)
- **Real primitives / shadcn components** — Phase 3
- **App shell layout** — Phase 4 / #5

## Checklist

- [x] No raw color literals introduced (`no-raw-colors` rule green; className regex test in theme-toggle enforces)
- [x] Light + dark both work
- [x] SSR-safe (cookie helpers are pure, isolated from the client bundle)
- [x] Typecheck, tests, and build all pass locally