### PR TITLE
feat(phase-3): shadcn foundation — components.json, cn(), card+popover tokens

### DIFF
--- a/packages/next-shell/components.json
+++ b/packages/next-shell/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/styles/tokens.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/primitives",
+    "utils": "@/core/cn",
+    "ui": "@/primitives",
+    "lib": "@/core",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -110,7 +110,9 @@
     }
   },
   "dependencies": {
-    "next-themes": "^0.4.4"
+    "clsx": "^2.1.1",
+    "next-themes": "^0.4.4",
+    "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/packages/next-shell/src/core/cn.ts
+++ b/packages/next-shell/src/core/cn.ts
@@ -1,0 +1,19 @@
+/**
+ * `cn()` — the conventional className helper used by every shadcn/ui primitive
+ * in this package.
+ *
+ * Accepts anything `clsx` accepts (strings, arrays, objects with boolean
+ * keys, conditional ternaries, etc.), then runs the result through
+ * `tailwind-merge` to resolve conflicting Tailwind utilities (e.g.
+ * `cn('px-4', 'px-2')` → `'px-2'`, because the later value wins for the
+ * same utility group).
+ *
+ * Exported from `@jonmatum/next-shell/core` and re-exported at the root.
+ */
+
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/packages/next-shell/src/core/index.ts
+++ b/packages/next-shell/src/core/index.ts
@@ -1,8 +1,6 @@
 /**
  * Core utilities and shared types for the next-shell package.
- *
- * Populated in later phases. For Phase 0 this module exposes only the
- * package version so consumers can verify the installation.
  */
 
 export { packageVersion } from './version.js';
+export { cn } from './cn.js';

--- a/packages/next-shell/src/styles/preset.css
+++ b/packages/next-shell/src/styles/preset.css
@@ -26,6 +26,12 @@
   --color-surface: var(--surface);
   --color-surface-foreground: var(--surface-foreground);
 
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
 

--- a/packages/next-shell/src/styles/tokens.css
+++ b/packages/next-shell/src/styles/tokens.css
@@ -36,6 +36,16 @@
   --surface: oklch(1 0 0);
   --surface-foreground: oklch(0.145 0 0);
 
+  /* Card and Popover — shadcn canonical surface tokens. Kept equal to
+     `--surface` by default so `bg-card` / `bg-popover` produce the same
+     visual layer as the base surface. Consumers can override per-theme via
+     the `brand` prop on ThemeProvider to differentiate them. */
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
 
@@ -173,6 +183,12 @@
 
   --surface: oklch(0.205 0 0);
   --surface-foreground: oklch(0.985 0 0);
+
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
 
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);

--- a/packages/next-shell/src/tokens/index.ts
+++ b/packages/next-shell/src/tokens/index.ts
@@ -36,6 +36,12 @@ export const colorTokens = [
   'surface',
   'surface-foreground',
 
+  'card',
+  'card-foreground',
+
+  'popover',
+  'popover-foreground',
+
   'muted',
   'muted-foreground',
 

--- a/packages/next-shell/tests/cn.test.ts
+++ b/packages/next-shell/tests/cn.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { cn } from '../src/core/cn.js';
+
+describe('cn()', () => {
+  it('joins simple string classes', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar');
+  });
+
+  it('filters out falsy values', () => {
+    const truthy = true;
+    const falsy = false;
+    expect(cn('foo', falsy && 'bar', truthy && 'keep', null, undefined, '', 'baz')).toBe(
+      'foo keep baz',
+    );
+  });
+
+  it('supports object syntax with boolean keys', () => {
+    expect(cn('base', { active: true, disabled: false })).toBe('base active');
+  });
+
+  it('supports array syntax and nested arrays', () => {
+    expect(cn(['foo', ['bar', 'baz']])).toBe('foo bar baz');
+  });
+
+  it('merges conflicting Tailwind utilities — later wins', () => {
+    expect(cn('px-4', 'px-2')).toBe('px-2');
+    expect(cn('text-sm', 'text-lg')).toBe('text-lg');
+    expect(cn('bg-primary', 'bg-destructive')).toBe('bg-destructive');
+  });
+
+  it('preserves non-conflicting utilities across merges', () => {
+    expect(cn('px-4 py-2', 'px-8')).toBe('py-2 px-8');
+  });
+
+  it('handles an empty invocation', () => {
+    expect(cn()).toBe('');
+  });
+
+  it('respects semantic-token utilities introduced by the preset', () => {
+    // Sanity: tailwind-merge must treat our custom `bg-*` tokens as colors
+    // so conflicts resolve correctly.
+    expect(cn('bg-card', 'bg-popover')).toBe('bg-popover');
+    expect(cn('ring-ring', 'ring-destructive')).toBe('ring-destructive');
+  });
+});

--- a/packages/next-shell/tsconfig.json
+++ b/packages/next-shell/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "jsx": "preserve",
     "noEmit": true,
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src/**/*", "tests/**/*"],
   "exclude": ["dist", "node_modules"]

--- a/packages/next-shell/tsup.config.ts
+++ b/packages/next-shell/tsup.config.ts
@@ -10,7 +10,7 @@ import { existsSync } from 'node:fs';
  * when bundling, so we re-add them to these specific entry outputs after
  * the build completes.
  */
-const CLIENT_ENTRIES = ['providers/index'] as const;
+const CLIENT_ENTRIES = ['providers/index', 'primitives/index'] as const;
 
 async function prependUseClient(path: string) {
   if (!existsSync(path)) return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,15 @@ importers:
 
   packages/next-shell:
     dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tailwind-merge:
+        specifier: ^3.3.0
+        version: 3.5.0
     devDependencies:
       '@testing-library/dom':
         specifier: ^10.4.0
@@ -1187,6 +1193,10 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2386,6 +2396,9 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
@@ -3495,6 +3508,8 @@ snapshots:
       string-width: 7.2.0
 
   client-only@0.0.1: {}
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -4868,6 +4883,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
 


### PR DESCRIPTION
## Summary

Phase 3a of the [next-shell extraction plan](https://github.com/jonmatum/next-shell/issues/13) — foundation for the upcoming shadcn primitive vendoring work. **No components yet**; this PR only lays the groundwork so subsequent PRs (3b, 3c, ...) can vendor primitives without friction.

Refs #4 · Refs #13

## What's in the box

### `components.json`

```json
{
  "style": "new-york",
  "rsc": true,
  "tsx": true,
  "tailwind": {
    "css": "src/styles/tokens.css",
    "cssVariables": true,
    "baseColor": "neutral"
  },
  "aliases": {
    "components": "@/primitives",
    "utils": "@/core/cn",
    "ui": "@/primitives",
    "lib": "@/core",
    "hooks": "@/hooks"
  },
  "iconLibrary": "lucide"
}
```

Hand-authored (not `shadcn init`-generated) to match our repo layout. With this in place, the shadcn CLI + MCP server + skill (all wired in #17/#18) are fully operational in this repo.

### `cn()` utility — `src/core/cn.ts`

```ts
import { clsx, type ClassValue } from 'clsx';
import { twMerge } from 'tailwind-merge';

export function cn(...inputs: ClassValue[]): string {
  return twMerge(clsx(inputs));
}
```

- Exported from `@jonmatum/next-shell/core` and re-exported at the root
- `components.json` points `aliases.utils` at `@/core/cn`, so every shadcn-generated component will `import { cn } from "@/core/cn"` correctly
- 8 unit tests cover: basic join, falsy filtering, object + array syntax, tailwind conflict resolution, and our own semantic-token utilities (`bg-card` vs `bg-popover`, `ring-ring` vs `ring-destructive`)

### Four new semantic tokens

`--card`, `--card-foreground`, `--popover`, `--popover-foreground` — tracks upstream shadcn parity so `bg-card` / `bg-popover` from the vendored output work without any retheming. Initially aliased to `--surface` / `--foreground`; consumers can differentiate per-theme via the `brand` prop on `ThemeProvider`.

Declared in both light + dark blocks of `tokens.css`, mapped in `preset.css` (as `--color-card`, `--color-popover`, etc.), and added to the `colorTokens` TS literal array so the existing token-contract tests auto-cover them (the `every color token is declared` / `every color token is re-declared inside [data-theme='dark']` / `every color token is mapped to a --color-* @theme key` tests all pass).

### `tsconfig.json` path aliases

```json
{
  "baseUrl": ".",
  "paths": { "@/*": ["src/*"] }
}
```

Required for shadcn CLI-generated files that import `@/core/cn`, `@/primitives/...`, `@/hooks/...` to resolve under both `tsc` and `tsup`.

### `tsup.config.ts`

`CLIENT_ENTRIES` now includes `primitives/index`. Every vendored primitive will be a client component, so the post-build hook re-prepends `'use client'` to the bundled `primitives/index.{js,cjs}` entry.

### New runtime dependencies

| Package          | Version    | Why                                                             |
| ---------------- | ---------- | --------------------------------------------------------------- |
| `clsx`           | `^2.1.1`   | Conventional conditional classname join (~230 B gzipped)        |
| `tailwind-merge` | `^3.3.0`   | Resolves conflicting Tailwind utilities — **v3 = Tailwind v4**  |

## What's intentionally NOT in this PR

- **Any actual primitive** (Button, Dialog, Tooltip, …) — those land in 3b onwards per the PR plan
- **`shadcn init` output** — `components.json` is hand-authored to match our repo; running `init` would have clobbered existing `src/styles/` assets
- **Updates to the `shadcn-next-shell` skill doc** — the skill still says "`src/primitives/<component-name>/`" (folder-per-component); I'll reconcile the flat-vs-folder decision in 3b when we actually add the first primitive

## Verification

```
pnpm format     ok
pnpm lint       ok (0 warnings, 0 errors)
pnpm typecheck  ok
pnpm test       ok 55 passed (+8 vs main)
pnpm build      ok (DTS + JS — core/index.d.ts grew 216 B → 807 B reflecting the new cn export)
```

## Checklist

- [x] No raw color literals (no component code in this PR; tokens are OKLCH)
- [x] Light + dark blocks both declare the four new tokens
- [x] Token-contract tests auto-cover the new tokens via the `colorTokens` array
- [x] `cn()` resolves Tailwind v4 conflicts correctly (tested)
- [x] Path aliases work under `tsc` (typecheck green)
- [x] `primitives/index` added to CLIENT_ENTRIES
- [x] Two new deps are both MIT, widely-used, and small

## Next up

- **3b** — `claude/phase-3-primitives-base` — Button, Tooltip, Label, Input, Textarea, Separator, Skeleton. Button unlocks the deferred `ThemeToggle` dropdown variant from #16.
