### PR TITLE
feat(phase-3): ThemeToggleDropdown — dropdown variant of ThemeToggle

### DIFF
--- a/packages/next-shell/src/providers/index.ts
+++ b/packages/next-shell/src/providers/index.ts
@@ -17,3 +17,6 @@ export type { ThemeValue, ResolvedTheme, UseThemeResult } from './theme/use-them
 
 export { ThemeToggle } from './theme/theme-toggle.js';
 export type { ThemeToggleProps } from './theme/theme-toggle.js';
+
+export { ThemeToggleDropdown } from './theme/theme-toggle-dropdown.js';
+export type { ThemeToggleDropdownProps } from './theme/theme-toggle-dropdown.js';

--- a/packages/next-shell/src/providers/theme/theme-toggle-dropdown.tsx
+++ b/packages/next-shell/src/providers/theme/theme-toggle-dropdown.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import { Monitor, Moon, Sun } from 'lucide-react';
+
+import { Button } from '@/primitives/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/primitives/dropdown-menu';
+
+import { useTheme } from './use-theme.js';
+import type { ThemeValue } from './use-theme.js';
+
+const ITEMS: ReadonlyArray<{ readonly value: ThemeValue; readonly label: string }> = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+];
+
+const ICONS: Record<ThemeValue, typeof Sun> = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+};
+
+export interface ThemeToggleDropdownProps extends Omit<ComponentProps<typeof Button>, 'children'> {
+  /**
+   * Accessible label applied to the trigger button. Describes the overall
+   * purpose, not the current theme. Defaults to `"Theme"`.
+   */
+  readonly label?: string;
+  /**
+   * Optional per-item label overrides (e.g. for i18n).
+   * Defaults: `"Light"`, `"Dark"`, `"System"`.
+   */
+  readonly itemLabels?: Partial<Record<ThemeValue, string>>;
+}
+
+/**
+ * Dropdown variant of `ThemeToggle`. Renders a Button trigger that opens a
+ * menu with three discrete items: Light, Dark, System. The current theme
+ * is marked with `aria-current="true"` and the `data-theme-item` attribute.
+ *
+ * Unlocked by the DropdownMenu primitive vendored in Phase 3c (#21).
+ *
+ * Styled exclusively through semantic tokens via the Button primitive;
+ * `no-raw-colors` lint passes.
+ */
+export function ThemeToggleDropdown({
+  label = 'Theme',
+  itemLabels,
+  variant = 'ghost',
+  size = 'icon',
+  ...rest
+}: ThemeToggleDropdownProps) {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+
+  const current = theme ?? 'system';
+  const resolved = resolvedTheme ?? 'light';
+  const TriggerIcon = ICONS[current];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant={variant}
+          size={size}
+          aria-label={label}
+          data-theme-value={current}
+          data-resolved-theme={resolved}
+          {...rest}
+        >
+          <TriggerIcon aria-hidden className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {ITEMS.map(({ value, label: defaultLabel }) => {
+          const Icon = ICONS[value];
+          const itemLabel = itemLabels?.[value] ?? defaultLabel;
+          return (
+            <DropdownMenuItem
+              key={value}
+              data-theme-item={value}
+              aria-current={current === value ? 'true' : undefined}
+              onClick={() => setTheme(value)}
+            >
+              <Icon aria-hidden className="size-4" />
+              {itemLabel}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/next-shell/src/providers/theme/theme-toggle.tsx
+++ b/packages/next-shell/src/providers/theme/theme-toggle.tsx
@@ -36,11 +36,12 @@ export interface ThemeToggleProps extends Omit<
  * Icon button that cycles light → dark → system → light.
  *
  * Styling uses only semantic tokens (`text-foreground`, `bg-accent`,
- * `ring-ring`, etc.). No primitives from Phase 3 are required, so this can
- * ship immediately alongside the theme provider.
+ * `ring-ring`, etc.). Has zero dependency on Phase 3 primitives so it can
+ * be used anywhere without pulling DropdownMenu into the bundle.
  *
- * The dropdown variant (light / dark / system as discrete menu items) will
- * land in Phase 3 once the DropdownMenu primitive is available.
+ * For a menu-based variant (light / dark / system as discrete items), see
+ * `ThemeToggleDropdown` — added in Phase 3f once the DropdownMenu primitive
+ * became available.
  */
 export function ThemeToggle({ labels, className, onClick, ...rest }: ThemeToggleProps) {
   const { theme, resolvedTheme, setTheme } = useTheme();

--- a/packages/next-shell/tests/theme-toggle-dropdown.test.tsx
+++ b/packages/next-shell/tests/theme-toggle-dropdown.test.tsx
@@ -1,0 +1,59 @@
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ThemeProvider } from '../src/providers/theme/theme-provider.js';
+import { ThemeToggleDropdown } from '../src/providers/theme/theme-toggle-dropdown.js';
+
+function renderDropdown(defaultTheme = 'light') {
+  return render(
+    <ThemeProvider defaultTheme={defaultTheme} disableTransitionOnChange>
+      <ThemeToggleDropdown />
+    </ThemeProvider>,
+  );
+}
+
+describe('ThemeToggleDropdown', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders a trigger button with the default "Theme" accessible label', () => {
+    renderDropdown('light');
+    const trigger = screen.getByRole('button', { name: 'Theme' });
+    expect(trigger).toHaveAttribute('data-slot', 'dropdown-menu-trigger');
+  });
+
+  it('accepts a custom label prop', () => {
+    render(
+      <ThemeProvider defaultTheme="light">
+        <ThemeToggleDropdown label="Choose theme" />
+      </ThemeProvider>,
+    );
+    expect(screen.getByRole('button', { name: 'Choose theme' })).toBeInTheDocument();
+  });
+
+  it('exposes data-theme-value reflecting the current theme preference', async () => {
+    renderDropdown('dark');
+    await act(async () => {});
+    const trigger = screen.getByRole('button', { name: 'Theme' });
+    expect(trigger).toHaveAttribute('data-theme-value', 'dark');
+  });
+
+  it('uses only semantic-token classNames (no raw palette utilities)', () => {
+    renderDropdown('light');
+    const trigger = screen.getByRole('button', { name: 'Theme' });
+    expect(trigger.className).not.toMatch(
+      /(bg|text|border)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d+/,
+    );
+    expect(trigger.className).not.toMatch(/(bg|text|border)-(white|black)\b/);
+  });
+
+  it('forwards extra props to the trigger button', () => {
+    render(
+      <ThemeProvider defaultTheme="light">
+        <ThemeToggleDropdown data-testid="tt" className="custom-extra" />
+      </ThemeProvider>,
+    );
+    const trigger = screen.getByTestId('tt');
+    expect(trigger.className).toContain('custom-extra');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3f. Wires up the **dropdown variant of `ThemeToggle`** that was deferred in #16 pending the `DropdownMenu` primitive (landed in #21).

Depends on #19 (cn, components.json), #20 (Button), #21 (DropdownMenu). Refs #3 · Refs #4 · Refs #13.

## New export

```tsx
import { ThemeToggleDropdown } from '@jonmatum/next-shell/providers';

<ThemeToggleDropdown />                                 // defaults
<ThemeToggleDropdown label="Choose theme" />            // custom trigger label
<ThemeToggleDropdown variant="outline" />               // pass-through Button prop
<ThemeToggleDropdown itemLabels={{ system: 'Auto' }} />  // i18n overrides
```

Renders a `Button` trigger that opens a three-item menu: **Light / Dark / System**. Icons via `lucide-react` (Sun / Moon / Monitor — already a dep since #21). Current theme marked with `aria-current="true"` + `data-theme-item="<value>"`.

Trigger carries `data-theme-value` + `data-resolved-theme` so the existing ThemeToggle test patterns work here unchanged.

## API

```ts
export interface ThemeToggleDropdownProps
  extends Omit<ComponentProps<typeof Button>, 'children'> {
  readonly label?: string;                                 // default: 'Theme'
  readonly itemLabels?: Partial<Record<ThemeValue, string>>;
}
```

Inherits every Button prop — `variant`, `size`, `className`, `disabled`, event handlers, etc. Defaults: `variant="ghost"`, `size="icon"`.

## Coexistence with the cycle variant

`ThemeToggle` (the existing `light → dark → system → light` cycling button) stays unchanged — no dependency on DropdownMenu, smallest possible bundle for apps that only want a single icon button.

`ThemeToggleDropdown` opts into `DropdownMenu` and `Button` from `@/primitives/*`. Consumers who import only `ThemeToggle` don't pay for the DropdownMenu code (tree-shaking handles it).

Updated the doc comment on `ThemeToggle` to remove the stale "will land in Phase 3" pointer and point to `ThemeToggleDropdown` instead.

## Tests (+5 in a new `tests/theme-toggle-dropdown.test.tsx`)

- Trigger renders with default `"Theme"` a11y label and `data-slot="dropdown-menu-trigger"`
- Custom `label` prop overrides the a11y label
- `data-theme-value` reflects `defaultTheme` (exercised with `"dark"`)
- Trigger className contains no raw palette / white / black utilities (same regex guard as the cycle variant)
- `className`, `data-testid`, and other extra props pass through to the trigger

**Not tested here**: open-state menu interaction (click trigger → click item → verify theme change). Radix + Portals in JSDOM is flaky enough that full click-through belongs in Storybook + Playwright VR in Phase 9.

## Verification

```
pnpm format     ok
pnpm lint       ok (no-raw-colors green)
pnpm typecheck  ok
pnpm test       ok 213 passed (+5 vs main)
pnpm build      ok
```

Build note: `dist/button-Ao-FxLYI.d.cts` emerges as a shared chunk because Button's type surface is now reached from both `providers/` and `primitives/` subpaths. That's tsup splitting working correctly — no action needed.

## Checklist

- [x] No raw color literals
- [x] Tree-shakeable: cycle variant stays independent of DropdownMenu
- [x] `data-theme-value`/`data-resolved-theme` parity with cycle variant
- [x] `aria-current="true"` on the selected menu item
- [x] Pass-through for every Button prop

## Next up

- **3e** — RHF Form + Calendar + DatePicker + InputOTP (4 new deps)
- **3g** — remaining primitives (Accordion, Alert, Card, Tabs, Sonner, Table, Chart, …)
