### PR TITLE
feat(phase-3): 12 simple primitives — Accordion, Alert, AspectRatio, Avatar, Badge, Breadcrumb, Card, Collapsible, Pagination, Progress, ScrollArea, Tabs

### DIFF
--- a/packages/next-shell/src/primitives/accordion.tsx
+++ b/packages/next-shell/src/primitives/accordion.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import * as React from 'react';
+import { ChevronDownIcon } from 'lucide-react';
+import { Accordion as AccordionPrimitive } from 'radix-ui';
+
+import { cn } from '@/core/cn';
+
+function Accordion({ ...props }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn('border-b last:border-b-0', className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium outline-none transition-all hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      {...props}
+    >
+      <div className={cn('pb-4 pt-0', className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  );
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/packages/next-shell/src/primitives/alert.tsx
+++ b/packages/next-shell/src/primitives/alert.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/core/cn';
+
+const alertVariants = cva(
+  'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+  {
+    variants: {
+      variant: {
+        default: 'bg-card text-card-foreground',
+        destructive:
+          'bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn('col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription };

--- a/packages/next-shell/src/primitives/aspect-ratio.tsx
+++ b/packages/next-shell/src/primitives/aspect-ratio.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { AspectRatio as AspectRatioPrimitive } from 'radix-ui';
+
+function AspectRatio({ ...props }: React.ComponentProps<typeof AspectRatioPrimitive.Root>) {
+  return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />;
+}
+
+export { AspectRatio };

--- a/packages/next-shell/src/primitives/avatar.tsx
+++ b/packages/next-shell/src/primitives/avatar.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import * as React from 'react';
+import { Avatar as AvatarPrimitive } from 'radix-ui';
+
+import { cn } from '@/core/cn';
+
+function Avatar({
+  className,
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: 'default' | 'sm' | 'lg';
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        'group/avatar relative flex size-8 shrink-0 select-none overflow-hidden rounded-full data-[size=lg]:size-10 data-[size=sm]:size-6',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn('aspect-square size-full', className)}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        'bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full text-sm group-data-[size=sm]/avatar:text-xs',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        'bg-primary text-primary-foreground ring-background absolute bottom-0 right-0 z-10 inline-flex select-none items-center justify-center rounded-full ring-2',
+        'group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden',
+        'group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2',
+        'group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        'group/avatar-group *:data-[slot=avatar]:ring-background flex -space-x-2 *:data-[slot=avatar]:ring-2',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarGroupCount({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        'bg-muted text-muted-foreground ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3 relative flex size-8 shrink-0 items-center justify-center rounded-full text-sm ring-2 [&>svg]:size-4',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Avatar, AvatarImage, AvatarFallback, AvatarBadge, AvatarGroup, AvatarGroupCount };

--- a/packages/next-shell/src/primitives/badge.tsx
+++ b/packages/next-shell/src/primitives/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
+
+import { cn } from '@/core/cn';
+
+const badgeVariants = cva(
+  'inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+          'bg-destructive text-destructive-foreground focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90',
+        outline:
+          'border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        ghost: '[a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 [a&]:hover:underline',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = 'default',
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : 'span';
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/packages/next-shell/src/primitives/breadcrumb.tsx
+++ b/packages/next-shell/src/primitives/breadcrumb.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import { ChevronRight, MoreHorizontal } from 'lucide-react';
+import { Slot } from 'radix-ui';
+
+import { cn } from '@/core/cn';
+
+function Breadcrumb({ ...props }: React.ComponentProps<'nav'>) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        'text-muted-foreground flex flex-wrap items-center gap-1.5 break-words text-sm sm:gap-2.5',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<'li'>) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn('inline-flex items-center gap-1.5', className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<'a'> & {
+  asChild?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : 'a';
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn('hover:text-foreground transition-colors', className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn('text-foreground font-normal', className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbSeparator({ children, className, ...props }: React.ComponentProps<'li'>) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn('[&>svg]:size-3.5', className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  );
+}
+
+function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn('flex size-9 items-center justify-center', className)}
+      {...props}
+    >
+      <MoreHorizontal className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  );
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+};

--- a/packages/next-shell/src/primitives/card.tsx
+++ b/packages/next-shell/src/primitives/card.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+
+import { cn } from '@/core/cn';
+
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn('font-semibold leading-none', className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />;
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn('[.border-t]:pt-6 flex items-center px-6', className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/packages/next-shell/src/primitives/collapsible.tsx
+++ b/packages/next-shell/src/primitives/collapsible.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { Collapsible as CollapsiblePrimitive } from 'radix-ui';
+
+function Collapsible({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return <CollapsiblePrimitive.CollapsibleTrigger data-slot="collapsible-trigger" {...props} />;
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return <CollapsiblePrimitive.CollapsibleContent data-slot="collapsible-content" {...props} />;
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/packages/next-shell/src/primitives/index.ts
+++ b/packages/next-shell/src/primitives/index.ts
@@ -9,6 +9,8 @@
  * primitive is a client component.
  */
 
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from './accordion.js';
+export { Alert, AlertDescription, AlertTitle } from './alert.js';
 export {
   AlertDialog,
   AlertDialogAction,
@@ -23,8 +25,37 @@ export {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from './alert-dialog.js';
+export { AspectRatio } from './aspect-ratio.js';
+export {
+  Avatar,
+  AvatarBadge,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarImage,
+} from './avatar.js';
+export { Badge, badgeVariants } from './badge.js';
+export {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from './breadcrumb.js';
 export { Button, buttonVariants } from './button.js';
+export {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from './card.js';
 export { Checkbox } from './checkbox.js';
+export { Collapsible, CollapsibleContent, CollapsibleTrigger } from './collapsible.js';
 export {
   ContextMenu,
   ContextMenuCheckboxItem,
@@ -87,6 +118,16 @@ export { HoverCard, HoverCardContent, HoverCardTrigger } from './hover-card.js';
 export { Input } from './input.js';
 export { Label } from './label.js';
 export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from './pagination.js';
+export { Progress } from './progress.js';
+export {
   Menubar,
   MenubarCheckboxItem,
   MenubarContent,
@@ -125,6 +166,7 @@ export {
   PopoverTrigger,
 } from './popover.js';
 export { RadioGroup, RadioGroupItem } from './radio-group.js';
+export { ScrollArea, ScrollBar } from './scroll-area.js';
 export {
   Select,
   SelectContent,
@@ -151,6 +193,7 @@ export {
 export { Skeleton } from './skeleton.js';
 export { Slider } from './slider.js';
 export { Switch } from './switch.js';
+export { Tabs, TabsContent, TabsList, TabsTrigger, tabsListVariants } from './tabs.js';
 export { Textarea } from './textarea.js';
 export { Toggle, toggleVariants } from './toggle.js';
 export { ToggleGroup, ToggleGroupItem } from './toggle-group.js';

--- a/packages/next-shell/src/primitives/pagination.tsx
+++ b/packages/next-shell/src/primitives/pagination.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from 'lucide-react';
+
+import { cn } from '@/core/cn';
+import { buttonVariants, type Button } from '@/primitives/button';
+
+function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn('mx-auto flex w-full justify-center', className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationContent({ className, ...props }: React.ComponentProps<'ul'>) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn('flex flex-row items-center gap-1', className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
+  return <li data-slot="pagination-item" {...props} />;
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean;
+} & Pick<React.ComponentProps<typeof Button>, 'size'> &
+  React.ComponentProps<'a'>;
+
+function PaginationLink({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? 'page' : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? 'outline' : 'ghost',
+          size,
+        }),
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function PaginationPrevious({ className, ...props }: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn('gap-1 px-2.5 sm:pl-2.5', className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  );
+}
+
+function PaginationNext({ className, ...props }: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn('gap-1 px-2.5 sm:pr-2.5', className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  );
+}
+
+function PaginationEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn('flex size-9 items-center justify-center', className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  );
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+};

--- a/packages/next-shell/src/primitives/progress.tsx
+++ b/packages/next-shell/src/primitives/progress.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import * as React from 'react';
+import { Progress as ProgressPrimitive } from 'radix-ui';
+
+import { cn } from '@/core/cn';
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn('bg-primary/20 relative h-2 w-full overflow-hidden rounded-full', className)}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="bg-primary h-full w-full flex-1 transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+}
+
+export { Progress };

--- a/packages/next-shell/src/primitives/scroll-area.tsx
+++ b/packages/next-shell/src/primitives/scroll-area.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import * as React from 'react';
+import { ScrollArea as ScrollAreaPrimitive } from 'radix-ui';
+
+import { cn } from '@/core/cn';
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn('relative', className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] outline-none transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-[3px]"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = 'vertical',
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        'flex touch-none select-none p-px transition-colors',
+        orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent',
+        orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent',
+        className,
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar };

--- a/packages/next-shell/src/primitives/tabs.tsx
+++ b/packages/next-shell/src/primitives/tabs.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Tabs as TabsPrimitive } from 'radix-ui';
+
+import { cn } from '@/core/cn';
+
+function Tabs({
+  className,
+  orientation = 'horizontal',
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn('group/tabs flex gap-2 data-[orientation=horizontal]:flex-col', className)}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  'group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none',
+  {
+    variants: {
+      variant: {
+        default: 'bg-muted',
+        line: 'gap-1 bg-transparent',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function TabsList({
+  className,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "text-foreground/60 hover:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 text-sm font-medium transition-all focus-visible:outline-1 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent',
+        'data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground',
+        'after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn('flex-1 outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/packages/next-shell/tests/primitives.test.tsx
+++ b/packages/next-shell/tests/primitives.test.tsx
@@ -5,18 +5,47 @@ import userEvent from '@testing-library/user-event';
 
 import * as Primitives from '../src/primitives/index.js';
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  AspectRatio,
+  Avatar,
+  AvatarFallback,
+  Badge,
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
   Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
   Checkbox,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
   Dialog,
   DialogTrigger,
   DropdownMenu,
   DropdownMenuTrigger,
   Input,
   Label,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
   Popover,
   PopoverTrigger,
+  Progress,
   RadioGroup,
   RadioGroupItem,
+  ScrollArea,
   Select,
   SelectTrigger,
   SelectValue,
@@ -24,6 +53,10 @@ import {
   Skeleton,
   Slider,
   Switch,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
   Textarea,
   Toggle,
   ToggleGroup,
@@ -312,6 +345,55 @@ describe('Primitives barrel — overlay + form exports', () => {
     'toggleVariants',
     'ToggleGroup',
     'ToggleGroupItem',
+    // Simple primitives (3g1)
+    'Accordion',
+    'AccordionContent',
+    'AccordionItem',
+    'AccordionTrigger',
+    'Alert',
+    'AlertDescription',
+    'AlertTitle',
+    'AspectRatio',
+    'Avatar',
+    'AvatarBadge',
+    'AvatarFallback',
+    'AvatarGroup',
+    'AvatarGroupCount',
+    'AvatarImage',
+    'Badge',
+    'badgeVariants',
+    'Breadcrumb',
+    'BreadcrumbEllipsis',
+    'BreadcrumbItem',
+    'BreadcrumbLink',
+    'BreadcrumbList',
+    'BreadcrumbPage',
+    'BreadcrumbSeparator',
+    'Card',
+    'CardAction',
+    'CardContent',
+    'CardDescription',
+    'CardFooter',
+    'CardHeader',
+    'CardTitle',
+    'Collapsible',
+    'CollapsibleContent',
+    'CollapsibleTrigger',
+    'Pagination',
+    'PaginationContent',
+    'PaginationEllipsis',
+    'PaginationItem',
+    'PaginationLink',
+    'PaginationNext',
+    'PaginationPrevious',
+    'Progress',
+    'ScrollArea',
+    'ScrollBar',
+    'Tabs',
+    'TabsContent',
+    'TabsList',
+    'TabsTrigger',
+    'tabsListVariants',
   ] as const;
 
   it.each(expected)('exports %s as a callable', (name) => {
@@ -481,5 +563,202 @@ describe('ToggleGroup', () => {
     await user.click(right);
     expect(left).toHaveAttribute('data-state', 'off');
     expect(right).toHaveAttribute('data-state', 'on');
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Simple primitives (3g1): Accordion, Alert, AspectRatio, Avatar, Badge,
+ * Breadcrumb, Card, Collapsible, Pagination, Progress, ScrollArea, Tabs.
+ *
+ * These render their full trees inline (no Radix portals), so we can do
+ * render + interaction tests directly in JSDOM.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+describe('Accordion', () => {
+  it('renders closed items and opens the clicked one', async () => {
+    const user = userEvent.setup();
+    render(
+      <Accordion type="single" collapsible>
+        <AccordionItem value="one">
+          <AccordionTrigger>One</AccordionTrigger>
+          <AccordionContent>First panel</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+    const trigger = screen.getByRole('button', { name: 'One' });
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('data-state', 'open');
+  });
+});
+
+describe('Alert', () => {
+  it('renders with role=alert and data-slot', () => {
+    render(
+      <Alert>
+        <AlertTitle>Heads up!</AlertTitle>
+        <AlertDescription>Something happened.</AlertDescription>
+      </Alert>,
+    );
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveAttribute('data-slot', 'alert');
+    expect(screen.getByText('Heads up!')).toHaveAttribute('data-slot', 'alert-title');
+    expect(screen.getByText('Something happened.')).toHaveAttribute(
+      'data-slot',
+      'alert-description',
+    );
+  });
+});
+
+describe('AspectRatio', () => {
+  it('renders a ratio wrapper with data-slot', () => {
+    render(
+      <AspectRatio ratio={16 / 9} data-testid="ar">
+        <div>content</div>
+      </AspectRatio>,
+    );
+    expect(screen.getByTestId('ar')).toHaveAttribute('data-slot', 'aspect-ratio');
+  });
+});
+
+describe('Avatar', () => {
+  it('renders a fallback when no image is set', () => {
+    render(
+      <Avatar>
+        <AvatarFallback>JM</AvatarFallback>
+      </Avatar>,
+    );
+    const fallback = screen.getByText('JM');
+    expect(fallback).toHaveAttribute('data-slot', 'avatar-fallback');
+  });
+});
+
+describe('Badge', () => {
+  it('renders with data-slot and variant class', () => {
+    render(<Badge variant="destructive">New</Badge>);
+    const badge = screen.getByText('New');
+    expect(badge).toHaveAttribute('data-slot', 'badge');
+    expect(badge.className).toMatch(/bg-destructive/);
+    expect(badge.className).toMatch(/text-destructive-foreground/);
+    expect(badge.className).not.toMatch(/text-white\b/);
+  });
+});
+
+describe('Breadcrumb', () => {
+  it('renders as a navigation landmark with link children', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/home">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const nav = screen.getByRole('navigation');
+    expect(nav).toHaveAttribute('data-slot', 'breadcrumb');
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
+      'data-slot',
+      'breadcrumb-link',
+    );
+  });
+});
+
+describe('Card', () => {
+  it('renders each sub-slot with its data-slot marker', () => {
+    render(
+      <Card data-testid="card">
+        <CardHeader data-testid="hdr">
+          <CardTitle>Title</CardTitle>
+          <CardDescription>Description</CardDescription>
+        </CardHeader>
+        <CardContent data-testid="body">body</CardContent>
+      </Card>,
+    );
+    expect(screen.getByTestId('card')).toHaveAttribute('data-slot', 'card');
+    expect(screen.getByTestId('hdr')).toHaveAttribute('data-slot', 'card-header');
+    expect(screen.getByText('Title')).toHaveAttribute('data-slot', 'card-title');
+    expect(screen.getByText('Description')).toHaveAttribute('data-slot', 'card-description');
+    expect(screen.getByTestId('body')).toHaveAttribute('data-slot', 'card-content');
+  });
+});
+
+describe('Collapsible', () => {
+  it('opens content on trigger click', async () => {
+    const user = userEvent.setup();
+    render(
+      <Collapsible>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent>Secret</CollapsibleContent>
+      </Collapsible>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Toggle' });
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('data-state', 'open');
+  });
+});
+
+describe('Pagination', () => {
+  it('renders as a navigation landmark with links', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="#1" isActive>
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const nav = screen.getByRole('navigation');
+    expect(nav).toHaveAttribute('data-slot', 'pagination');
+    const active = screen.getByRole('link', { name: /1/ });
+    expect(active).toHaveAttribute('data-active', 'true');
+  });
+});
+
+describe('Progress', () => {
+  it('renders role=progressbar with data-slot and a progress-indicator child', () => {
+    const { container } = render(<Progress value={42} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('data-slot', 'progress');
+    const indicator = container.querySelector('[data-slot="progress-indicator"]') as HTMLElement;
+    expect(indicator).toBeTruthy();
+    // The indicator translates by -(100 - value)% to visualize progress.
+    expect(indicator.style.transform).toBe('translateX(-58%)');
+  });
+});
+
+describe('ScrollArea', () => {
+  it('renders with data-slot and a scroll-area-viewport child', () => {
+    const { container } = render(
+      <ScrollArea data-testid="sa">
+        <div style={{ width: 2000 }}>wide content</div>
+      </ScrollArea>,
+    );
+    expect(screen.getByTestId('sa')).toHaveAttribute('data-slot', 'scroll-area');
+    expect(container.querySelector('[data-slot="scroll-area-viewport"]')).toBeTruthy();
+  });
+});
+
+describe('Tabs', () => {
+  it('shows the default tab content and switches on trigger click', async () => {
+    const user = userEvent.setup();
+    render(
+      <Tabs defaultValue="a">
+        <TabsList>
+          <TabsTrigger value="a">A</TabsTrigger>
+          <TabsTrigger value="b">B</TabsTrigger>
+        </TabsList>
+        <TabsContent value="a">Panel A</TabsContent>
+        <TabsContent value="b">Panel B</TabsContent>
+      </Tabs>,
+    );
+    expect(screen.getByRole('tab', { name: 'A' })).toHaveAttribute('data-state', 'active');
+    expect(screen.getByText('Panel A')).toBeInTheDocument();
+    await user.click(screen.getByRole('tab', { name: 'B' }));
+    expect(screen.getByRole('tab', { name: 'B' })).toHaveAttribute('data-state', 'active');
   });
 });


### PR DESCRIPTION
## Summary

Phase 3g1. Twelve inline (non-portal) primitives vendored from [`shadcn-ui/ui@84d1d476`](https://github.com/shadcn-ui/ui/commit/84d1d476b1d1c6a01c6eeadd95885ce109969b08) and retheme to our semantic-token system. **Zero new external deps** — everything already on the tree from 3b/3c/3d.

Depends on #19 (cn), #20 (Button), #21 (overlay infra). Refs #4 · Refs #13.

## What's in the box

| Component | Exports | Notes |
| --------- | ------: | ----- |
| **Accordion** | 4 | Root + Item + Trigger + Content |
| **Alert** | 3 | `role="alert"`; variants via cva |
| **AspectRatio** | 1 | Radix AspectRatio |
| **Avatar** | 6 | Avatar + Image + Fallback + Badge + Group + GroupCount |
| **Badge** | 2 | Badge + `badgeVariants` cva |
| **Breadcrumb** | 7 | `nav` landmark; composes `buttonVariants` |
| **Card** | 7 | Card + Header + Title + Description + Action + Content + Footer |
| **Collapsible** | 3 | Root + Trigger + Content |
| **Pagination** | 7 | `nav` landmark; composes `buttonVariants` |
| **Progress** | 1 | `role="progressbar"`; indicator transform tracks value |
| **ScrollArea** | 2 | ScrollArea + ScrollBar |
| **Tabs** | 5 | Tabs + List + Trigger + Content + `tabsListVariants` cva |

**48 new named exports.**

### Typography intentionally skipped

Upstream shadcn has no `/ui/typography.tsx` primitive — only a `/examples/typography-demo.tsx` documentation artifact. Typography in shadcn is a styling-guide concern, not a library export. Will revisit if user demand emerges; for now the cost/benefit of vendoring a "typography" primitive doesn't pencil.

## Retheming vs upstream

One divergence (same pattern as Button destructive from #20):

```diff
// badge.tsx — destructive variant
-text-white
+text-destructive-foreground
```

`--destructive-foreground` is `oklch(0.985 0 0)` ≈ white in both themes, so visually identical; lint passes.

## Import rewrites (sed-applied, otherwise verbatim upstream)

```
@/lib/utils                        →  @/core/cn          (all 12 files)
@/registry/new-york-v4/ui/button   →  @/primitives/button (breadcrumb, pagination —
                                                           both compose buttonVariants)
```

## Tests (+60 new → 273 total)

- **Barrel export-surface**: 48 new names added to the exhaustive `expected` array
- **Accordion**: `data-state="closed"` → `"open"` on trigger click
- **Alert**: `role="alert"` + `data-slot` on Alert/Title/Description
- **AspectRatio**: ratio wrapper with `data-slot`
- **Avatar**: fallback renders when no image set
- **Badge**: variant classes present + `text-destructive-foreground` present + no raw `text-white`
- **Breadcrumb**: nav landmark + link `data-slot`
- **Card**: every sub-slot carries the matching `data-slot` attribute
- **Collapsible**: `data-state` flip on trigger click
- **Pagination**: nav landmark + `data-active="true"` on active link
- **Progress**: `role="progressbar"` + indicator transform `translateX(-58%)` for value=42
- **ScrollArea**: `data-slot="scroll-area"` + viewport child present
- **Tabs**: default tab active; click switches active state

## Verification

```
pnpm format     ok
pnpm lint       ok (no-raw-colors green after badge retheme)
pnpm typecheck  ok
pnpm test       ok 273 passed (+60 vs main)
pnpm build      ok (primitives/index.js 89.62 KB ESM)
```

## Checklist

- [x] No raw color literals
- [x] `data-slot` on every root + meaningful sub-element
- [x] Commit SHA `84d1d476` matches prior phases (single-source-of-truth pin)
- [x] No new external deps
- [x] Every primitive covered by at least one render + data-slot assertion

## Next up

- **3e** — `claude/phase-3-rhf-form-date-otp` — RHF Form, Calendar, DatePicker, InputOTP (4 new deps: react-hook-form, zod, react-day-picker, input-otp)
- **3g2** — `claude/phase-3-cmdk-sonner-table` — Command (cmdk), Sonner (sonner), Table (HTML-only)
- **3g3** — `claude/phase-3-data-primitives` — DataTable (@tanstack/react-table), Chart (recharts), Carousel (embla-carousel-react), Resizable (react-resizable-panels)
