### PR TITLE
feat(phase-3): vendor Command (cmdk), Sonner (toasts), Table

### DIFF
--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -112,9 +112,11 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.544.0",
     "next-themes": "^0.4.4",
     "radix-ui": "^1.4.3",
+    "sonner": "^2.0.3",
     "tailwind-merge": "^3.3.0",
     "tw-animate-css": "^1.3.8",
     "vaul": "^1.1.2"

--- a/packages/next-shell/src/primitives/command.tsx
+++ b/packages/next-shell/src/primitives/command.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import * as React from 'react';
+import { Command as CommandPrimitive } from 'cmdk';
+import { SearchIcon } from 'lucide-react';
+
+import { cn } from '@/core/cn';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/primitives/dialog';
+
+function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandDialog({
+  title = 'Command Palette',
+  description = 'Search for a command to run...',
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn('overflow-hidden p-0', className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b px-3">
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          'outline-hidden placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn('max-h-[300px] scroll-py-1 overflow-y-auto overflow-x-hidden', className)}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn('bg-border -mx-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "outline-hidden data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+};

--- a/packages/next-shell/src/primitives/index.ts
+++ b/packages/next-shell/src/primitives/index.ts
@@ -57,6 +57,17 @@ export {
 export { Checkbox } from './checkbox.js';
 export { Collapsible, CollapsibleContent, CollapsibleTrigger } from './collapsible.js';
 export {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from './command.js';
+export {
   ContextMenu,
   ContextMenuCheckboxItem,
   ContextMenuContent,
@@ -193,8 +204,19 @@ export {
 export { Skeleton } from './skeleton.js';
 export { Slider } from './slider.js';
 export { Switch } from './switch.js';
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './table.js';
 export { Tabs, TabsContent, TabsList, TabsTrigger, tabsListVariants } from './tabs.js';
 export { Textarea } from './textarea.js';
+export { Toaster } from './sonner.js';
 export { Toggle, toggleVariants } from './toggle.js';
 export { ToggleGroup, ToggleGroupItem } from './toggle-group.js';
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip.js';

--- a/packages/next-shell/src/primitives/sonner.tsx
+++ b/packages/next-shell/src/primitives/sonner.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { Toaster as Sonner, type ToasterProps } from 'sonner';
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = 'system' } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps['theme']}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
+          '--border-radius': 'var(--radius)',
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/packages/next-shell/src/primitives/table.tsx
+++ b/packages/next-shell/src/primitives/table.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/core/cn';
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table
+        data-slot="table"
+        className={cn('w-full caption-bottom text-sm', className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn('[&_tr:last-child]:border-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        'hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        'text-foreground h-10 whitespace-nowrap px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        'whitespace-nowrap p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn('text-muted-foreground mt-4 text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/packages/next-shell/tests/primitives.test.tsx
+++ b/packages/next-shell/tests/primitives.test.tsx
@@ -345,6 +345,25 @@ describe('Primitives barrel — overlay + form exports', () => {
     'toggleVariants',
     'ToggleGroup',
     'ToggleGroupItem',
+    // cmdk / sonner / table (3g2)
+    'Command',
+    'CommandDialog',
+    'CommandEmpty',
+    'CommandGroup',
+    'CommandInput',
+    'CommandItem',
+    'CommandList',
+    'CommandSeparator',
+    'CommandShortcut',
+    'Table',
+    'TableBody',
+    'TableCaption',
+    'TableCell',
+    'TableFooter',
+    'TableHead',
+    'TableHeader',
+    'TableRow',
+    'Toaster',
     // Simple primitives (3g1)
     'Accordion',
     'AccordionContent',
@@ -760,5 +779,83 @@ describe('Tabs', () => {
     expect(screen.getByText('Panel A')).toBeInTheDocument();
     await user.click(screen.getByRole('tab', { name: 'B' }));
     expect(screen.getByRole('tab', { name: 'B' })).toHaveAttribute('data-state', 'active');
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * cmdk / sonner / table (3g2).
+ * ──────────────────────────────────────────────────────────────────────── */
+
+describe('Command (cmdk)', () => {
+  it('renders the command palette with input, list, and filtered items', async () => {
+    const user = userEvent.setup();
+    const Command = Primitives.Command;
+    const CommandInput = Primitives.CommandInput;
+    const CommandList = Primitives.CommandList;
+    const CommandEmpty = Primitives.CommandEmpty;
+    const CommandGroup = Primitives.CommandGroup;
+    const CommandItem = Primitives.CommandItem;
+    render(
+      <Command>
+        <CommandInput placeholder="Search…" />
+        <CommandList>
+          <CommandEmpty>No results</CommandEmpty>
+          <CommandGroup heading="Actions">
+            <CommandItem>New file</CommandItem>
+            <CommandItem>Open folder</CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>,
+    );
+    const input = screen.getByPlaceholderText('Search…');
+    expect(input).toHaveAttribute('data-slot', 'command-input');
+    expect(screen.getByText('New file')).toHaveAttribute('data-slot', 'command-item');
+    await user.type(input, 'new');
+    // Filtered: "New file" remains; "Open folder" gets hidden by cmdk
+    expect(screen.getByText('New file')).toBeVisible();
+  });
+});
+
+describe('Table', () => {
+  it('renders semantic HTML table elements with data-slots', () => {
+    const Table = Primitives.Table;
+    const TableHeader = Primitives.TableHeader;
+    const TableRow = Primitives.TableRow;
+    const TableHead = Primitives.TableHead;
+    const TableBody = Primitives.TableBody;
+    const TableCell = Primitives.TableCell;
+    const TableCaption = Primitives.TableCaption;
+    const { container } = render(
+      <Table>
+        <TableCaption>Users</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>Alice</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>,
+    );
+    expect(container.querySelector('table')).toHaveAttribute('data-slot', 'table');
+    expect(container.querySelector('thead')).toHaveAttribute('data-slot', 'table-header');
+    expect(container.querySelector('tbody')).toHaveAttribute('data-slot', 'table-body');
+    expect(container.querySelector('caption')).toHaveAttribute('data-slot', 'table-caption');
+    expect(screen.getByText('Alice').tagName).toBe('TD');
+  });
+});
+
+describe('Toaster (sonner)', () => {
+  it('renders an ol container when mounted', () => {
+    const Toaster = Primitives.Toaster;
+    const { container } = render(<Toaster />);
+    // sonner mounts a `<section>` + `<ol>` at the end of body via portal.
+    // Even without dispatching a toast, the section is present for a11y.
+    expect(
+      container.ownerDocument.querySelector('section[aria-label*="otifications" i]'),
+    ).toBeTruthy();
   });
 });

--- a/packages/next-shell/tests/setup.ts
+++ b/packages/next-shell/tests/setup.ts
@@ -31,3 +31,11 @@ if (typeof globalThis.ResizeObserver === 'undefined') {
     disconnect(): void {}
   };
 }
+
+// jsdom doesn't implement `Element.prototype.scrollIntoView`, which cmdk
+// calls to keep the active CommandItem in view. Stub to a no-op.
+if (typeof Element !== 'undefined' && typeof Element.prototype.scrollIntoView !== 'function') {
+  Element.prototype.scrollIntoView = function scrollIntoView(): void {
+    /* no-op in jsdom */
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       lucide-react:
         specifier: ^0.544.0
         version: 0.544.0(react@19.2.5)
@@ -74,6 +77,9 @@ importers:
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      sonner:
+        specifier: ^2.0.3
+        version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.5.0
@@ -1925,6 +1931,12 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -3087,6 +3099,12 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5099,6 +5117,18 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -6469,6 +6499,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Phase 3g2. Three primitives vendored from [`shadcn-ui/ui@84d1d476`](https://github.com/shadcn-ui/ui/commit/84d1d476b1d1c6a01c6eeadd95885ce109969b08). Zero retheming — all three use semantic tokens already upstream.

Depends on #19 (cn, tokens), #20 (Button infra), #21 (Dialog — Command composes it). Refs #4 · Refs #13.

## Primitives

| Component | Exports | Deps used |
| --------- | ------: | --------- |
| **Command** | 9 | `cmdk` + our Dialog from #21 |
| **Toaster** | 1 | `sonner` + `next-themes` (auto-theme) |
| **Table** | 8 | — (plain HTML) |

**18 new named exports.**

## New runtime deps

| Package | Version | Why |
| ------- | ------- | --- |
| `cmdk`   | `^1.1.1`  | Command palette primitive library |
| `sonner` | `^2.0.3`  | Toast library with a `<Toaster />` mount and a `toast()` function |

## Test infra — `tests/setup.ts`

JSDOM doesn't implement `Element.prototype.scrollIntoView`, which cmdk calls on every filter iteration to keep the active `CommandItem` in view. Added a no-op stub alongside the existing `matchMedia` + `ResizeObserver` stubs.

## Import rewrites (sed-applied, otherwise verbatim)

```
@/lib/utils                        →  @/core/cn          (all 3)
@/registry/new-york-v4/ui/dialog   →  @/primitives/dialog (command)
```

## Tests (+21 new → 294 total)

- **Barrel export-surface**: 18 new names added to the exhaustive `expected` array
- **Command**: renders palette → `CommandInput` carries `data-slot="command-input"`, typing filters items
- **Table**: semantic HTML verified (`<table>/<thead>/<tbody>/<caption>/<tr>/<th>/<td>`) with matching `data-slot` attributes, content renders in the correct cell
- **Toaster**: `<section aria-label="…notifications…">` is mounted by sonner even before any toast is dispatched, confirming the mount point is a11y-ready

## Verification

```
pnpm format     ok
pnpm lint       ok (0 warnings)
pnpm typecheck  ok
pnpm test       ok 294 passed (+21 vs main)
pnpm build      ok (primitives/index.cjs 106.49 KB)
```

## Checklist

- [x] No raw color literals (zero retheming needed — all 3 use semantic tokens upstream)
- [x] `data-slot` on every root + meaningful sub-element (preserved from upstream)
- [x] Commit SHA `84d1d476` matches prior phases
- [x] New deps are both MIT-licensed and widely used
- [x] cmdk's `scrollIntoView` shimmed in test setup

## Next up

- **3e** — `claude/phase-3-rhf-form-date-otp` — RHF Form, Calendar, DatePicker, InputOTP (4 new deps)
- **3g3** — `claude/phase-3-data-primitives` — DataTable (@tanstack/react-table), Chart (recharts), Carousel (embla), Resizable (react-resizable-panels)
