### PR TITLE
feat(phase-4): layout/server subpath + SSR sidebar-state cookie helpers

### DIFF
--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -47,6 +47,11 @@
       "import": "./dist/layout/index.js",
       "require": "./dist/layout/index.cjs"
     },
+    "./layout/server": {
+      "types": "./dist/layout/server/index.d.ts",
+      "import": "./dist/layout/server/index.js",
+      "require": "./dist/layout/server/index.cjs"
+    },
     "./primitives": {
       "types": "./dist/primitives/index.d.ts",
       "import": "./dist/primitives/index.js",

--- a/packages/next-shell/src/layout/index.ts
+++ b/packages/next-shell/src/layout/index.ts
@@ -1,8 +1,20 @@
 /**
- * Layout primitives — AppShell, Sidebar, TopBar, CommandBar, PageHeader, etc.
+ * Layout — client surface.
  *
- * See the Phase 4 issue for the full specification.
- * This module is scaffolded during Phase 0 and populated in Phase 4.
+ * Subpath: `@jonmatum/next-shell/layout`
+ *
+ * The app-shell composition surface (Phase 4): AppShell, Sidebar, TopBar,
+ * CommandBar, PageHeader, ContentContainer, Footer, EmptyState,
+ * ErrorState, LoadingState. Currently only the types + isomorphic cookie
+ * helpers are exposed; the components land in subsequent 4b–4f PRs.
+ *
+ * Server-only counterparts (SSR cookie readers) live at
+ * `@jonmatum/next-shell/layout/server`.
  */
 
-export {};
+export type { SidebarState } from './sidebar-state-cookie.js';
+export {
+  SIDEBAR_STATE_COOKIE_NAME,
+  SIDEBAR_STATE_COOKIE_MAX_AGE,
+  isSidebarState,
+} from './sidebar-state-cookie.js';

--- a/packages/next-shell/src/layout/server/index.ts
+++ b/packages/next-shell/src/layout/server/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Layout — server-only helpers.
+ *
+ * These helpers do not depend on React and can be called from Next.js
+ * Server Components, Route Handlers, or Middleware. They are deliberately
+ * split out from `@jonmatum/next-shell/layout` so importing them does not
+ * drag a client boundary into a server module.
+ *
+ * Currently exposes the SSR-safe sidebar state cookie helpers. Future
+ * layout-level SSR helpers (density, topbar state, …) will surface here.
+ */
+
+export {
+  SIDEBAR_STATE_COOKIE_NAME,
+  SIDEBAR_STATE_COOKIE_MAX_AGE,
+  getSidebarStateFromCookies,
+  buildSidebarStateCookieHeader,
+  isSidebarState,
+} from '../sidebar-state-cookie.js';
+export type { SidebarState } from '../sidebar-state-cookie.js';

--- a/packages/next-shell/src/layout/sidebar-state-cookie.ts
+++ b/packages/next-shell/src/layout/sidebar-state-cookie.ts
@@ -1,0 +1,52 @@
+/**
+ * SSR-safe sidebar-state persistence helpers.
+ *
+ * The layout shell needs to know whether the sidebar is `"open"` or
+ * `"closed"` **before** the first paint so the server-rendered HTML
+ * matches the client state — avoiding a layout flash when the Sidebar
+ * component hydrates and toggles from its default.
+ *
+ * Persist the state to a cookie (not `localStorage`) so the server can
+ * read it during SSR. These helpers are framework-agnostic: pass in any
+ * `cookies()` / `request.cookies` / manual cookie-jar object that
+ * exposes a `get(name)` method.
+ */
+
+import type { CookieReader } from '../providers/server/index.js';
+
+export type SidebarState = 'open' | 'closed';
+
+export const SIDEBAR_STATE_COOKIE_NAME = 'next-shell-sidebar-state';
+
+/** One year, in seconds. */
+export const SIDEBAR_STATE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+/** Type guard for a well-formed `SidebarState` string. */
+export function isSidebarState(value: unknown): value is SidebarState {
+  return value === 'open' || value === 'closed';
+}
+
+/**
+ * Read the persisted sidebar state from a cookie reader. Returns `null`
+ * when the cookie is missing or contains an unknown value, letting the
+ * caller fall back to a sensible default (typically `"open"` on desktop,
+ * `"closed"` on mobile).
+ */
+export function getSidebarStateFromCookies(cookies: CookieReader): SidebarState | null {
+  const cookie = cookies.get(SIDEBAR_STATE_COOKIE_NAME);
+  if (!cookie) return null;
+  return isSidebarState(cookie.value) ? cookie.value : null;
+}
+
+/**
+ * Build a `Set-Cookie` header value that persists the sidebar state for
+ * one year. Suitable for Next.js Route Handlers or middleware.
+ */
+export function buildSidebarStateCookieHeader(state: SidebarState): string {
+  return [
+    `${SIDEBAR_STATE_COOKIE_NAME}=${state}`,
+    `Max-Age=${SIDEBAR_STATE_COOKIE_MAX_AGE}`,
+    'Path=/',
+    'SameSite=Lax',
+  ].join('; ');
+}

--- a/packages/next-shell/tests/sidebar-state-cookie.test.ts
+++ b/packages/next-shell/tests/sidebar-state-cookie.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SIDEBAR_STATE_COOKIE_MAX_AGE,
+  SIDEBAR_STATE_COOKIE_NAME,
+  buildSidebarStateCookieHeader,
+  getSidebarStateFromCookies,
+  isSidebarState,
+  type SidebarState,
+} from '../src/layout/sidebar-state-cookie.js';
+
+function mockCookies(entries: Record<string, string>) {
+  return {
+    get(name: string) {
+      return entries[name] !== undefined ? { value: entries[name]! } : undefined;
+    },
+  };
+}
+
+describe('sidebar-state cookie — metadata', () => {
+  it('exposes a stable cookie name', () => {
+    expect(SIDEBAR_STATE_COOKIE_NAME).toBe('next-shell-sidebar-state');
+  });
+
+  it('exposes a one-year max-age in seconds', () => {
+    expect(SIDEBAR_STATE_COOKIE_MAX_AGE).toBe(60 * 60 * 24 * 365);
+  });
+});
+
+describe('isSidebarState', () => {
+  it('accepts the two canonical values', () => {
+    expect(isSidebarState('open')).toBe(true);
+    expect(isSidebarState('closed')).toBe(true);
+  });
+
+  it('rejects anything else', () => {
+    expect(isSidebarState('OPEN')).toBe(false);
+    expect(isSidebarState('collapsed')).toBe(false);
+    expect(isSidebarState('')).toBe(false);
+    expect(isSidebarState(null)).toBe(false);
+    expect(isSidebarState(undefined)).toBe(false);
+    expect(isSidebarState(0)).toBe(false);
+    expect(isSidebarState(true)).toBe(false);
+  });
+});
+
+describe('getSidebarStateFromCookies', () => {
+  it('returns the value when the cookie is "open"', () => {
+    expect(getSidebarStateFromCookies(mockCookies({ 'next-shell-sidebar-state': 'open' }))).toBe(
+      'open',
+    );
+  });
+
+  it('returns the value when the cookie is "closed"', () => {
+    expect(getSidebarStateFromCookies(mockCookies({ 'next-shell-sidebar-state': 'closed' }))).toBe(
+      'closed',
+    );
+  });
+
+  it('returns null when the cookie is missing', () => {
+    expect(getSidebarStateFromCookies(mockCookies({}))).toBeNull();
+  });
+
+  it('returns null when the cookie contains an unknown value', () => {
+    expect(
+      getSidebarStateFromCookies(mockCookies({ 'next-shell-sidebar-state': 'bogus' })),
+    ).toBeNull();
+  });
+
+  it('ignores other cookies', () => {
+    expect(
+      getSidebarStateFromCookies(
+        mockCookies({
+          'next-shell-theme': 'dark',
+          some: 'other',
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('buildSidebarStateCookieHeader', () => {
+  it('emits a well-formed Set-Cookie value for "open"', () => {
+    const header = buildSidebarStateCookieHeader('open');
+    expect(header).toContain('next-shell-sidebar-state=open');
+    expect(header).toContain(`Max-Age=${SIDEBAR_STATE_COOKIE_MAX_AGE}`);
+    expect(header).toContain('Path=/');
+    expect(header).toContain('SameSite=Lax');
+  });
+
+  it('emits a well-formed Set-Cookie value for "closed"', () => {
+    expect(buildSidebarStateCookieHeader('closed')).toContain('next-shell-sidebar-state=closed');
+  });
+
+  it('accepts the full SidebarState union without narrowing loss', () => {
+    const states: SidebarState[] = ['open', 'closed'];
+    for (const state of states) {
+      expect(buildSidebarStateCookieHeader(state)).toMatch(/^next-shell-sidebar-state=/);
+    }
+  });
+});

--- a/packages/next-shell/tsup.config.ts
+++ b/packages/next-shell/tsup.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     index: 'src/index.ts',
     'core/index': 'src/core/index.ts',
     'layout/index': 'src/layout/index.ts',
+    'layout/server/index': 'src/layout/server/index.ts',
     'primitives/index': 'src/primitives/index.ts',
     'providers/index': 'src/providers/index.ts',
     'providers/server/index': 'src/providers/server/index.ts',


### PR DESCRIPTION
## Summary

Phase 4a — the foundation for the app-shell layout work. Mirrors the 3a pattern: **no components yet**, just the SSR plumbing so subsequent 4b–4f PRs have a stable place to stand.

Closes nothing. Refs #5 · Refs #13.

## What's in

### `src/layout/sidebar-state-cookie.ts` — isomorphic SSR-safe cookie helpers

Shape mirrors `providers/theme/theme-cookie.ts` exactly, so consumers see one consistent API across the library's SSR-state concerns.

```ts
export type SidebarState = 'open' | 'closed';

export const SIDEBAR_STATE_COOKIE_NAME = 'next-shell-sidebar-state';
export const SIDEBAR_STATE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year

export function isSidebarState(value: unknown): value is SidebarState;

// Accepts Next.js `cookies()`, Express `req.cookies`, or any { get(name) }
export function getSidebarStateFromCookies(cookies: CookieReader): SidebarState | null;

// Emits 'next-shell-sidebar-state=open; Max-Age=…; Path=/; SameSite=Lax'
export function buildSidebarStateCookieHeader(state: SidebarState): string;
```

Reuses `CookieReader` from the Phase 2 providers/server module — single source of truth, no type duplication.

### New subpath: `@jonmatum/next-shell/layout/server`

Server-only barrel so consumer Server Components can import SSR cookie readers without dragging a client boundary. Not in `CLIENT_ENTRIES`.

### Subpath wiring

- `tsup.config.ts` — new `layout/server/index` entry → `dist/layout/server/index.{js,cjs,d.ts}`
- `package.json` — new `./layout/server` export with types/import/require
- `src/layout/index.ts` (client barrel) — exposes type + constants + guard

## What's intentionally NOT in this PR

- **No React hook for sidebar state.** `useSidebarState()` ships with the Sidebar component in **4d**, co-located with its consumer.
- **No density tokens / helpers.** Density cookies will land together with the per-container `data-density="…"` CSS-variable overrides — that's a Phase 1 tokens-contract change + consumption in AppShell/ContentContainer, scoping them together keeps the surface coherent.
- **No components.** 4b adds ContentContainer, PageHeader, Footer, EmptyState, ErrorState, LoadingState (6 inline surfaces).

## Tests (+12 new → 340 total)

- **Metadata**: cookie name + one-year max-age constants
- **`isSidebarState`**: accepts `'open'`/`'closed'`, rejects uppercase / empty / `null` / numbers / booleans
- **`getSidebarStateFromCookies`**: round-trips both states, returns `null` for missing or invalid values, ignores unrelated cookies
- **`buildSidebarStateCookieHeader`**: Set-Cookie format correct for both states; accepts the full `SidebarState` union

## Verification

```
pnpm format     ok
pnpm lint       ok
pnpm typecheck  ok
pnpm test       ok 340 passed (+12 vs main)
pnpm build      ok (dist/layout/server/index.d.cts 269 B emitted)
```

## Checklist

- [x] No raw color literals (no component code in this PR)
- [x] SSR cookie helpers mirror the Phase 2 theme-cookie shape exactly
- [x] `CookieReader` reused, not redefined
- [x] Server barrel stays out of `CLIENT_ENTRIES`
- [x] New subpath wired in both `tsup.config.ts` and `package.json#exports`

## Phase 4 slicing ahead

| PR | Slug | Components |
| -- | ---- | ---------- |
| 4a | _this PR_ | SSR foundation |
| 4b | `claude/phase-4-content-surfaces` | ContentContainer, PageHeader, Footer, EmptyState, ErrorState, LoadingState |
| 4c | `claude/phase-4-topbar` | TopBar (slotted) |
| 4d | `claude/phase-4-sidebar` | Sidebar (4 variants + mobile drawer + cookie-persisted state) |
| 4e | `claude/phase-4-commandbar` | CommandBar (⌘K on top of Command) |
| 4f | `claude/phase-4-appshell` | AppShell root orchestrator |
