### PR TITLE
feat(phase-4): content surfaces — ContentContainer, PageHeader, Footer, status states

### DIFF
--- a/packages/next-shell/src/layout/content-container.tsx
+++ b/packages/next-shell/src/layout/content-container.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/core/cn';
+
+/**
+ * Max-width + horizontal-padding tiers for the main content column.
+ *
+ * Density-aware padding (CSS variables from the Phase 1 tokens) will land
+ * with the AppShell in 4f, where consumers can switch density per-page.
+ * Until then these tiers use Tailwind's fixed spacing scale, which
+ * resolves through our semantic-token preset anyway.
+ */
+const contentContainerVariants = cva('mx-auto w-full px-4 sm:px-6 lg:px-8', {
+  variants: {
+    size: {
+      sm: 'max-w-3xl',
+      md: 'max-w-5xl',
+      lg: 'max-w-7xl',
+      xl: 'max-w-[96rem]',
+      full: 'max-w-none',
+    },
+  },
+  defaultVariants: {
+    size: 'lg',
+  },
+});
+
+export interface ContentContainerProps
+  extends React.ComponentProps<'div'>, VariantProps<typeof contentContainerVariants> {
+  /**
+   * Render as a different element via Radix-style `asChild` is not supported
+   * here — use the `as` prop for a plain semantic-HTML override.
+   */
+  readonly as?: 'div' | 'section' | 'main' | 'article';
+}
+
+/**
+ * Max-width content column for a page body. Centers itself and applies
+ * responsive horizontal padding. Renders as a `<div>` by default; use
+ * `as="main"` for a Next.js App Router page to get the RSC-friendly
+ * main-landmark.
+ */
+function ContentContainer({ className, size = 'lg', as = 'div', ...props }: ContentContainerProps) {
+  const Tag = as;
+  return (
+    <Tag
+      data-slot="content-container"
+      data-size={size ?? undefined}
+      className={cn(contentContainerVariants({ size }), className)}
+      {...props}
+    />
+  );
+}
+
+export { ContentContainer, contentContainerVariants };

--- a/packages/next-shell/src/layout/footer.tsx
+++ b/packages/next-shell/src/layout/footer.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+import { cn } from '@/core/cn';
+
+export type FooterProps = React.ComponentProps<'footer'>;
+
+/**
+ * App-shell footer slot. Thin wrapper around `<footer>` with the token
+ * border + muted-foreground text color applied by default. Stateless and
+ * server-renderable.
+ */
+function Footer({ className, ...props }: FooterProps) {
+  return (
+    <footer
+      data-slot="footer"
+      className={cn(
+        'border-border text-muted-foreground mt-auto flex flex-col gap-3 border-t px-4 py-6 text-sm sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Footer };

--- a/packages/next-shell/src/layout/index.ts
+++ b/packages/next-shell/src/layout/index.ts
@@ -5,12 +5,24 @@
  *
  * The app-shell composition surface (Phase 4): AppShell, Sidebar, TopBar,
  * CommandBar, PageHeader, ContentContainer, Footer, EmptyState,
- * ErrorState, LoadingState. Currently only the types + isomorphic cookie
- * helpers are exposed; the components land in subsequent 4b–4f PRs.
+ * ErrorState, LoadingState. Currently the stateless content surfaces +
+ * types + isomorphic cookie helpers are exposed. The interactive islands
+ * (Sidebar, TopBar, CommandBar, AppShell) land in subsequent 4c–4f PRs.
  *
- * Server-only counterparts (SSR cookie readers) live at
+ * Every component in this module is server-renderable — safe to import
+ * from a Next.js Server Component without forcing a client boundary.
+ * Server-only SSR cookie helpers also live at
  * `@jonmatum/next-shell/layout/server`.
  */
+
+export { ContentContainer, contentContainerVariants } from './content-container.js';
+export type { ContentContainerProps } from './content-container.js';
+export { Footer } from './footer.js';
+export type { FooterProps } from './footer.js';
+export { PageHeader } from './page-header.js';
+export type { PageHeaderProps } from './page-header.js';
+export { EmptyState, ErrorState, LoadingState } from './status-states.js';
+export type { EmptyStateProps, ErrorStateProps, LoadingStateProps } from './status-states.js';
 
 export type { SidebarState } from './sidebar-state-cookie.js';
 export {

--- a/packages/next-shell/src/layout/page-header.tsx
+++ b/packages/next-shell/src/layout/page-header.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+
+import { cn } from '@/core/cn';
+
+export interface PageHeaderProps extends Omit<React.ComponentProps<'header'>, 'title'> {
+  /**
+   * Required page title. Rendered as `<h1>` with the semantic typography
+   * scale — override the heading level via `headingAs` if the page needs
+   * a different document outline.
+   */
+  readonly title: React.ReactNode;
+  /** Optional short description rendered under the title. */
+  readonly description?: React.ReactNode;
+  /**
+   * Optional breadcrumb / eyebrow slot rendered **above** the title
+   * (e.g. a `<Breadcrumb>` from `@jonmatum/next-shell/primitives`).
+   */
+  readonly breadcrumb?: React.ReactNode;
+  /**
+   * Optional action slot rendered to the right of the title on desktop,
+   * stacked below on mobile (e.g. a "Create" button or a button group).
+   */
+  readonly actions?: React.ReactNode;
+  /** Heading level used for the title. Defaults to `"h1"`. */
+  readonly headingAs?: 'h1' | 'h2' | 'h3';
+}
+
+/**
+ * Standardized page-level heading block. Title is required; everything
+ * else is an optional slot. Stateless and server-renderable — safe to
+ * use directly in a Next.js Server Component.
+ */
+function PageHeader({
+  className,
+  title,
+  description,
+  breadcrumb,
+  actions,
+  headingAs: HeadingTag = 'h1',
+  ...props
+}: PageHeaderProps) {
+  return (
+    <header
+      data-slot="page-header"
+      className={cn(
+        'border-border flex flex-col gap-4 border-b pb-4 sm:flex-row sm:items-end sm:justify-between sm:gap-6',
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex min-w-0 flex-col gap-2">
+        {breadcrumb !== undefined && breadcrumb !== null ? (
+          <div data-slot="page-header-breadcrumb" className="text-muted-foreground text-sm">
+            {breadcrumb}
+          </div>
+        ) : null}
+        <HeadingTag
+          data-slot="page-header-title"
+          className="text-foreground text-2xl font-semibold tracking-tight sm:text-3xl"
+        >
+          {title}
+        </HeadingTag>
+        {description !== undefined && description !== null ? (
+          <p
+            data-slot="page-header-description"
+            className="text-muted-foreground max-w-prose text-sm sm:text-base"
+          >
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {actions !== undefined && actions !== null ? (
+        <div data-slot="page-header-actions" className="flex shrink-0 flex-wrap items-center gap-2">
+          {actions}
+        </div>
+      ) : null}
+    </header>
+  );
+}
+
+export { PageHeader };

--- a/packages/next-shell/src/layout/status-states.tsx
+++ b/packages/next-shell/src/layout/status-states.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { AlertTriangle, Inbox, Loader2 } from 'lucide-react';
+
+import { cn } from '@/core/cn';
+
+/**
+ * Shared primitive for the three status surfaces (Empty / Error / Loading).
+ * Not exported directly — consumers use the tone-specific wrappers below.
+ */
+interface StatusSurfaceProps extends Omit<React.ComponentProps<'div'>, 'title' | 'role'> {
+  readonly dataSlot: string;
+  readonly icon?: React.ReactNode;
+  readonly title?: React.ReactNode;
+  readonly description?: React.ReactNode;
+  readonly action?: React.ReactNode;
+  readonly iconClassName?: string;
+}
+
+function StatusSurface({
+  className,
+  dataSlot,
+  icon,
+  title,
+  description,
+  action,
+  iconClassName,
+  children,
+  ...props
+}: StatusSurfaceProps) {
+  return (
+    <div
+      data-slot={dataSlot}
+      role={dataSlot === 'error-state' ? 'alert' : 'status'}
+      className={cn(
+        'border-border bg-card text-card-foreground flex flex-col items-center justify-center gap-4 rounded-lg border p-8 text-center sm:p-12',
+        className,
+      )}
+      {...props}
+    >
+      {icon !== undefined && icon !== null ? (
+        <div
+          data-slot={`${dataSlot}-icon`}
+          className={cn(
+            'text-muted-foreground flex size-12 items-center justify-center [&>svg]:size-6',
+            iconClassName,
+          )}
+        >
+          {icon}
+        </div>
+      ) : null}
+      {title !== undefined && title !== null ? (
+        <div data-slot={`${dataSlot}-title`} className="text-foreground text-lg font-semibold">
+          {title}
+        </div>
+      ) : null}
+      {description !== undefined && description !== null ? (
+        <p data-slot={`${dataSlot}-description`} className="text-muted-foreground max-w-sm text-sm">
+          {description}
+        </p>
+      ) : null}
+      {action !== undefined && action !== null ? (
+        <div data-slot={`${dataSlot}-action`} className="mt-2 flex flex-wrap gap-2">
+          {action}
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * EmptyState — neutral surface, for "no results" / "nothing here yet".
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export type EmptyStateProps = Omit<StatusSurfaceProps, 'dataSlot'>;
+
+function EmptyState({ icon, ...props }: EmptyStateProps) {
+  return <StatusSurface dataSlot="empty-state" icon={icon ?? <Inbox aria-hidden />} {...props} />;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * ErrorState — destructive-tinted, for recoverable runtime errors.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export type ErrorStateProps = Omit<StatusSurfaceProps, 'dataSlot'>;
+
+function ErrorState({ icon, iconClassName, ...props }: ErrorStateProps) {
+  return (
+    <StatusSurface
+      dataSlot="error-state"
+      icon={icon ?? <AlertTriangle aria-hidden />}
+      iconClassName={cn('text-destructive', iconClassName)}
+      {...props}
+    />
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * LoadingState — animated spinner; content is secondary.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export type LoadingStateProps = Omit<StatusSurfaceProps, 'dataSlot'>;
+
+function LoadingState({ icon, iconClassName, ...props }: LoadingStateProps) {
+  return (
+    <StatusSurface
+      dataSlot="loading-state"
+      icon={icon ?? <Loader2 aria-hidden className="animate-spin" />}
+      iconClassName={cn('text-muted-foreground', iconClassName)}
+      {...props}
+    />
+  );
+}
+
+export { EmptyState, ErrorState, LoadingState };

--- a/packages/next-shell/tests/layout-surfaces.test.tsx
+++ b/packages/next-shell/tests/layout-surfaces.test.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import {
+  ContentContainer,
+  EmptyState,
+  ErrorState,
+  Footer,
+  LoadingState,
+  PageHeader,
+  contentContainerVariants,
+} from '../src/layout/index.js';
+
+describe('ContentContainer', () => {
+  it('renders a div with the default lg size and data-slot', () => {
+    render(<ContentContainer data-testid="cc">child</ContentContainer>);
+    const el = screen.getByTestId('cc');
+    expect(el.tagName).toBe('DIV');
+    expect(el).toHaveAttribute('data-slot', 'content-container');
+    expect(el).toHaveAttribute('data-size', 'lg');
+    expect(el.className).toMatch(/max-w-7xl/);
+  });
+
+  it('switches max-width via the size prop', () => {
+    render(
+      <ContentContainer size="sm" data-testid="cc">
+        x
+      </ContentContainer>,
+    );
+    const el = screen.getByTestId('cc');
+    expect(el).toHaveAttribute('data-size', 'sm');
+    expect(el.className).toMatch(/max-w-3xl/);
+  });
+
+  it('renders as a main landmark when `as="main"`', () => {
+    render(
+      <ContentContainer as="main" data-testid="cc">
+        x
+      </ContentContainer>,
+    );
+    expect(screen.getByTestId('cc').tagName).toBe('MAIN');
+  });
+
+  it('exposes contentContainerVariants as a standalone cva function', () => {
+    expect(typeof contentContainerVariants).toBe('function');
+    expect(contentContainerVariants({ size: 'xl' })).toMatch(/max-w-\[96rem\]/);
+    expect(contentContainerVariants({ size: 'full' })).toMatch(/max-w-none/);
+  });
+});
+
+describe('PageHeader', () => {
+  it('renders a header element with an h1 title by default', () => {
+    render(<PageHeader title="Users" />);
+    const hdr = screen.getByRole('banner');
+    expect(hdr).toHaveAttribute('data-slot', 'page-header');
+    const h1 = screen.getByRole('heading', { level: 1, name: 'Users' });
+    expect(h1).toHaveAttribute('data-slot', 'page-header-title');
+  });
+
+  it('renders breadcrumb + description + actions slots when provided', () => {
+    render(
+      <PageHeader
+        breadcrumb={<nav data-testid="bc">Home / Users</nav>}
+        title="Users"
+        description="Manage user accounts."
+        actions={<button>New user</button>}
+      />,
+    );
+    expect(screen.getByTestId('bc').parentElement).toHaveAttribute(
+      'data-slot',
+      'page-header-breadcrumb',
+    );
+    expect(screen.getByText('Manage user accounts.')).toHaveAttribute(
+      'data-slot',
+      'page-header-description',
+    );
+    expect(screen.getByRole('button', { name: 'New user' }).parentElement).toHaveAttribute(
+      'data-slot',
+      'page-header-actions',
+    );
+  });
+
+  it('omits optional slots when not provided', () => {
+    const { container } = render(<PageHeader title="Solo" />);
+    expect(container.querySelector('[data-slot="page-header-breadcrumb"]')).toBeNull();
+    expect(container.querySelector('[data-slot="page-header-description"]')).toBeNull();
+    expect(container.querySelector('[data-slot="page-header-actions"]')).toBeNull();
+  });
+
+  it('supports a different heading level via headingAs', () => {
+    render(<PageHeader title="Sub" headingAs="h2" />);
+    expect(screen.getByRole('heading', { level: 2, name: 'Sub' })).toBeInTheDocument();
+  });
+});
+
+describe('Footer', () => {
+  it('renders a footer element with data-slot', () => {
+    render(<Footer>© 2026</Footer>);
+    const ft = screen.getByRole('contentinfo');
+    expect(ft).toHaveAttribute('data-slot', 'footer');
+    expect(ft).toHaveTextContent('© 2026');
+  });
+});
+
+describe('EmptyState', () => {
+  it('renders a status surface with a default Inbox icon', () => {
+    render(
+      <EmptyState
+        data-testid="empty"
+        title="No results"
+        description="Try adjusting your filters."
+      />,
+    );
+    const el = screen.getByTestId('empty');
+    expect(el).toHaveAttribute('data-slot', 'empty-state');
+    expect(el).toHaveAttribute('role', 'status');
+    expect(screen.getByText('No results')).toHaveAttribute('data-slot', 'empty-state-title');
+    expect(screen.getByText('Try adjusting your filters.')).toHaveAttribute(
+      'data-slot',
+      'empty-state-description',
+    );
+  });
+
+  it('accepts a custom icon + action slot', () => {
+    render(
+      <EmptyState
+        title="Search"
+        icon={<svg data-testid="custom-icon" />}
+        action={<button>Clear</button>}
+      />,
+    );
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear' }).parentElement).toHaveAttribute(
+      'data-slot',
+      'empty-state-action',
+    );
+  });
+});
+
+describe('ErrorState', () => {
+  it('renders with role=alert and destructive-tinted icon wrapper', () => {
+    const { container } = render(
+      <ErrorState title="Something went wrong" description="Please try again." />,
+    );
+    const el = container.querySelector('[data-slot="error-state"]');
+    expect(el).toHaveAttribute('role', 'alert');
+    const iconWrapper = container.querySelector('[data-slot="error-state-icon"]') as HTMLElement;
+    expect(iconWrapper.className).toMatch(/text-destructive/);
+  });
+});
+
+describe('LoadingState', () => {
+  it('renders with an animated spinner icon by default', () => {
+    const { container } = render(<LoadingState title="Loading…" />);
+    const el = container.querySelector('[data-slot="loading-state"]');
+    expect(el).toHaveAttribute('role', 'status');
+    const icon = container.querySelector('[data-slot="loading-state-icon"] svg');
+    expect(icon?.getAttribute('class')).toMatch(/animate-spin/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4b. Six stateless layout surfaces. **Every component is server-renderable** — safe to import from a Next.js Server Component without forcing a client boundary.

Depends on #29. Refs #5 · Refs #13.

## Components

| Component | Shape |
| --------- | ----- |
| **ContentContainer** | `max-w-{3xl,5xl,7xl,96rem,none}` + responsive horizontal padding; renders as `div`/`section`/`main`/`article` via `as` prop; exposes `contentContainerVariants` cva function |
| **PageHeader** | `<header role="banner">`, required `title`, optional `description` / `breadcrumb` / `actions` slots, `headingAs="h1"\|"h2"\|"h3"` for document-outline control |
| **Footer** | `<footer role="contentinfo">` wrapper with token border + muted-foreground typography |
| **EmptyState** | `role="status"`, default `Inbox` icon, slots: `icon` / `title` / `description` / `action` |
| **ErrorState** | `role="alert"`, default `AlertTriangle` icon (destructive-tinted wrapper) |
| **LoadingState** | `role="status"`, default `Loader2` icon with `animate-spin` |

Shared private `StatusSurface` primitive backs the three status states; the exports differ only in default icon + role + icon color.

## Design choices

### Server-renderable by default

No `'use client'` directive on the barrel or any of the component files. Stateless through and through, so RSC-safe. The Sidebar in 4d will force a decision about client/server splits in the layout subpath; for now the barrel stays server-safe.

### `icon` is a slot, not a string

Consumers pass a React node (typically a lucide-react icon), and the wrapper applies size + color. Defaults are sensible per flavor but trivially overridable — no lock-in to one icon set.

### PageHeader doesn't wrap Breadcrumb

The `breadcrumb` prop is a raw slot, not a composed `<Breadcrumb>` from our primitives. Consumers wire up their own breadcrumb component (ours or otherwise) and pass the rendered subtree. Keeps PageHeader independent of the primitives subpath.

### `StatusSurfaceProps` type quirk

`React.ComponentProps<'div'>` declares `title?: string`. Our component overrides `title: React.ReactNode`, so the base type's `title` is `Omit`-ed out. Same for `role` (each flavor picks its own).

## What's intentionally NOT in this PR

- **No density-aware padding yet** — ContentContainer uses Tailwind's fixed spacing scale (`px-4 sm:px-6 lg:px-8`). Density variants come with AppShell in 4f, where density is a first-class concern.
- **No interactive islands** — Sidebar (4d), TopBar (4c), CommandBar (4e), AppShell (4f) remain separate slices.

## Tests (+13 new → 353 total)

- **ContentContainer**: default size, `size` switching (sm/xl/full), `as="main"` landmark, cva standalone function
- **PageHeader**: banner landmark, h1 title by default, all four slots rendered when provided, omitted when absent, `headingAs` override
- **Footer**: contentinfo landmark + children
- **EmptyState**: `data-slot` + `role="status"` + default icon + custom icon slot + action slot
- **ErrorState**: `role="alert"` + `text-destructive` on icon wrapper
- **LoadingState**: `role="status"` + `animate-spin` on icon

## Verification

```
pnpm format     ok
pnpm lint       ok
pnpm typecheck  ok
pnpm test       ok 353 passed (+13 vs main)
pnpm build      ok (layout/index.d.cts 1.68 KB)
```

## Checklist

- [x] No raw color literals
- [x] `data-slot` on every meaningful element (including nested slots like `page-header-title`, `empty-state-icon`, etc.)
- [x] a11y roles: banner, contentinfo, status, alert, heading
- [x] All components RSC-safe (no `'use client'`)
- [x] `title` prop conflict with HTML attribute resolved by Omit

## Next up

- **4c** — `claude/phase-4-topbar` — TopBar (slotted)
- **4d** — `claude/phase-4-sidebar` — Sidebar (4 variants + mobile drawer + cookie-persisted state). Likely the largest of the phase.
- **4e** — `claude/phase-4-commandbar` — CommandBar (⌘K on top of Command)
- **4f** — `claude/phase-4-appshell` — AppShell root orchestrator + density wiring
