### PR TITLE
docs(readme): update both READMEs to reflect current Phase 3 / in-progress Phase 4 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,36 @@
 
 Monorepo for [`@jonmatum/next-shell`](./packages/next-shell) — a reusable Next.js app shell built on **shadcn/ui** primitives with a strict **semantic-token** design system.
 
-> Status: **Phase 0 — scaffolding in progress.** Track the rollout in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
+> **Status:** Phases 0–3 landed on `main`; Phase 4 (app-shell layout) is in progress. Track phase-by-phase progress in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
 
-## What's in the box
+## What's in the box today
 
-- **All 69+ shadcn/ui components**, each audited to use only semantic tokens
-- **No hardcoded colors anywhere** — enforced in CI by a custom ESLint rule (`next-shell/no-raw-colors`)
-- **Latest stack** — Next.js 15, React 19, TypeScript 5.x, Tailwind CSS v4
-- **App shell layout** — `AppShell`, `Sidebar`, `TopBar`, `CommandBar`, `PageHeader`, and more
-- **Pluggable adapters** for auth and i18n so consumer apps stay decoupled
-- **Tree-shakeable** subpath exports, **RSC-friendly** by default
+| Phase | Surface                                                                                                                                                                                | Status                               |
+| ----: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+|     0 | Monorepo scaffold + CI + publishing skeleton                                                                                                                                           | ✅ Landed                            |
+|     1 | Semantic-token contract + Tailwind v4 preset + OKLCH color tokens                                                                                                                      | ✅ Landed                            |
+|     2 | `ThemeProvider` · `useTheme` · `ThemeToggle` (cycle + dropdown) · SSR cookie helpers                                                                                                   | ✅ Landed                            |
+|     3 | **42 shadcn/ui primitives** vendored from [`shadcn-ui/ui@84d1d476`](https://github.com/shadcn-ui/ui/commit/84d1d476b1d1c6a01c6eeadd95885ce109969b08), each token-audited               | ✅ Landed                            |
+|     4 | Layout primitives: `ContentContainer`, `PageHeader`, `Footer`, `EmptyState`/`ErrorState`/`LoadingState` · SSR sidebar-state cookies · AppShell / Sidebar / TopBar / CommandBar pending | 🟡 In progress                       |
+|     5 | Auth adapters                                                                                                                                                                          | ⏳ Queued                            |
+|     6 | Providers composer                                                                                                                                                                     | ⏳ Queued                            |
+|     7 | Cross-cutting hooks                                                                                                                                                                    | ⏳ Queued                            |
+|     8 | Utilities (`cn`, formatters, guards)                                                                                                                                                   | ⏳ Queued (`cn` shipped in Phase 3a) |
+|     9 | Docs site + Storybook                                                                                                                                                                  | ⏳ Queued                            |
+|    10 | Publishing + changeset release workflow                                                                                                                                                | ⏳ Queued                            |
+|    11 | Integration back into Smart Pad Rules                                                                                                                                                  | ⏳ Queued                            |
+
+**42 primitives shipping today** (#20–#27): Accordion, Alert, AlertDialog, AspectRatio, Avatar, Badge, Breadcrumb, Button, Calendar, Card, Carousel, Chart, Checkbox, Collapsible, Command, ContextMenu, Dialog, Drawer, DropdownMenu, Form, HoverCard, Input, InputOTP, Label, Menubar, NavigationMenu, Pagination, Popover, Progress, RadioGroup, Resizable, ScrollArea, Select, Separator, Sheet, Skeleton, Slider, Switch, Table, Tabs, Textarea, Toaster (Sonner), Toggle, ToggleGroup, Tooltip. **328+ unit tests** cover render + interaction + export-surface completeness.
+
+Deliberately **not** vendored (composed patterns documented as consumer-side recipes): DatePicker (Popover + Calendar + Button), DataTable (Table + `@tanstack/react-table`), Typography (styling-guide h1/h2/p patterns).
+
+## Design principles
+
+- **No hardcoded colors anywhere.** Every color reaches the DOM through semantic tokens (`bg-background`, `text-foreground`, `border-border`, …). A custom ESLint rule (`next-shell/no-raw-colors`) fails CI on regressions.
+- **Latest stack.** Next.js 15, React 19, TypeScript 5.x, Tailwind CSS v4, Radix UI (via the `radix-ui` unified package).
+- **Tree-shakeable subpaths.** Every surface area has its own export entry so consumers pay only for what they import.
+- **RSC-friendly by default.** Server-safe helpers live under `<subpath>/server/` so they can be imported from a Server Component without dragging a client boundary.
+- **Motion + opacity tokens.** `duration-fast|normal|slow`, `ease-standard|emphasized|decelerate|accelerate`, and the animation utilities from `tw-animate-css` are wired in via the preset.
 
 ## Workspace layout
 
@@ -21,27 +41,45 @@ next-shell/
 │   └── next-shell/               # The published @jonmatum/next-shell package
 ├── tools/
 │   └── eslint-plugin-next-shell/ # Custom ESLint rules (no-raw-colors)
-├── eslint.config.js              # Flat config, used at the repo root
+├── .claude/skills/               # Repo-local Claude Code skills
+├── CLAUDE.md                     # Session onboarding guide
+├── eslint.config.js              # Flat ESLint config
 ├── tsconfig.base.json            # Shared TS compiler options
 └── pnpm-workspace.yaml
 ```
 
-## Quick start (development)
+## Quick start (contributors)
 
 ```bash
-nvm use
+nvm use              # Node version from .nvmrc
 pnpm install
-pnpm build
-pnpm test
+pnpm lint            # eslint --max-warnings=0
+pnpm typecheck
+pnpm test            # vitest run (328 tests)
+pnpm build           # tsup + tailwind preset + DTS
 ```
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full day-to-day workflow.
+`lint-staged` runs automatically on `git commit` (Husky). You still want `pnpm test` + `pnpm build` locally before committing — the hook only checks staged files.
 
-## The semantic-token rule
+## For AI-assisted contributions
 
-Every component in this repo uses semantic tokens (`bg-background`, `text-foreground`, `border-border`, ...) — **never** a hex literal, raw CSS color function, or Tailwind palette utility like `bg-slate-500`. The rule is enforced at `pnpm lint` time.
+This repo is set up for Claude Code sessions with a handful of durable conventions:
 
-Token definitions land in Phase 1 (see [issue #2](https://github.com/jonmatum/next-shell/issues/2)).
+- **[`CLAUDE.md`](./CLAUDE.md)** — session onboarding. Hard rules (no raw colors, client/server boundaries, a11y), standing auto-merge rule for green PRs, verification pipeline, shadcn vendor workflow, JSDOM test shims inventory, common-breakage troubleshooting, phase-issue quick-links.
+- **[`.claude/skills/`](./.claude/skills/)** — repo-local skills:
+  - `shadcn-next-shell` — semantic-token discipline + cva + client/server split specifics for this repo
+  - `next-shell-contributor` — phase model, branch / commit / PR conventions, verification pipeline
+- **[`.mcp.json`](./.mcp.json)** — the official shadcn MCP server is registered automatically so every session gets the canonical shadcn catalog.
+- **GitHub MCP is restricted to this repo** — sessions can't accidentally open PRs elsewhere.
+
+New session picking up the work: `git pull`, read `CLAUDE.md`, check the most recently merged phase PR for the current state, then continue on a `claude/phase-N-<slug>` branch.
+
+## Links
+
+- Package README · [`packages/next-shell/README.md`](./packages/next-shell/README.md)
+- Session onboarding · [`CLAUDE.md`](./CLAUDE.md)
+- Extraction plan · [Epic #13](https://github.com/jonmatum/next-shell/issues/13)
+- Per-phase tracking issues · [#1](https://github.com/jonmatum/next-shell/issues/1) · [#2](https://github.com/jonmatum/next-shell/issues/2) · [#3](https://github.com/jonmatum/next-shell/issues/3) · [#4](https://github.com/jonmatum/next-shell/issues/4) · [#5](https://github.com/jonmatum/next-shell/issues/5) · [#6](https://github.com/jonmatum/next-shell/issues/6) · [#7](https://github.com/jonmatum/next-shell/issues/7) · [#8](https://github.com/jonmatum/next-shell/issues/8) · [#9](https://github.com/jonmatum/next-shell/issues/9) · [#10](https://github.com/jonmatum/next-shell/issues/10) · [#11](https://github.com/jonmatum/next-shell/issues/11) · [#12](https://github.com/jonmatum/next-shell/issues/12)
 
 ## License
 

--- a/packages/next-shell/README.md
+++ b/packages/next-shell/README.md
@@ -2,32 +2,158 @@
 
 Reusable Next.js app shell built on **shadcn/ui** primitives with a strict **semantic-token** design system.
 
-> Status: Phase 0 (scaffolding). Follow progress in the [Epic tracker](https://github.com/jonmatum/next-shell/issues/13).
+> **Status:** Phases 1–3 usable today (tokens, theming, 42 primitives). Phase 4 (app-shell layout) in progress. Follow the rollout in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
 
 ## Install
 
 ```bash
 pnpm add @jonmatum/next-shell
-# peers
-pnpm add next react react-dom
-# optional
-pnpm add tailwindcss
+# Required peers
+pnpm add next@^15 react@^19 react-dom@^19
+# Recommended
+pnpm add tailwindcss@^4
 ```
+
+Runtime deps (pulled in automatically): `radix-ui`, `class-variance-authority`, `clsx`, `tailwind-merge`, `tw-animate-css`, `lucide-react`, `vaul`, `cmdk`, `sonner`, `date-fns`, `react-hook-form`, `react-day-picker`, `input-otp`, `embla-carousel-react`, `react-resizable-panels`, `recharts`, `next-themes`.
+
+## Quick start
+
+### 1. Load the preset (Tailwind v4)
+
+```css
+/* app/globals.css */
+@import 'tailwindcss';
+@import '@jonmatum/next-shell/styles/preset.css';
+```
+
+The preset pulls in `tokens.css` + `tw-animate-css` and wires every semantic token to the Tailwind `@theme` scale. Utilities like `bg-background`, `text-foreground`, `border-border`, `ring-ring`, `animate-in`, and `duration-fast` are now live.
+
+### 2. Mount the theme provider (client)
+
+```tsx
+// app/providers.tsx
+'use client';
+
+import { ThemeProvider } from '@jonmatum/next-shell/providers';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider defaultTheme="system" enableSystem disableTransitionOnChange>
+      {children}
+    </ThemeProvider>
+  );
+}
+```
+
+### 3. Optional: SSR-safe theme via cookie (no first-paint flash)
+
+```tsx
+// app/layout.tsx  (Server Component)
+import { cookies } from 'next/headers';
+import { getThemeFromCookies } from '@jonmatum/next-shell/providers/server';
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const theme = getThemeFromCookies(await cookies()) ?? 'system';
+  return (
+    <html lang="en" data-theme={theme} suppressHydrationWarning>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}
+```
+
+### 4. Import primitives
+
+```tsx
+import { Button, Card, CardContent, CardHeader, CardTitle } from '@jonmatum/next-shell/primitives';
+
+export function UserCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>User</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Button variant="outline" size="sm">
+          Invite
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+Every primitive ships with `data-slot` attributes for custom-styling hooks, `aria-*` semantics preserved from Radix, and variant systems driven by `class-variance-authority`.
 
 ## Subpath entry points
 
-| Import                                   | Purpose                                           |
-| ---------------------------------------- | ------------------------------------------------- |
-| `@jonmatum/next-shell`                   | Main barrel (re-exports the core surface)         |
-| `@jonmatum/next-shell/core`              | Core utilities and shared types                   |
-| `@jonmatum/next-shell/layout`            | AppShell, Sidebar, TopBar, CommandBar, etc.       |
-| `@jonmatum/next-shell/primitives`        | shadcn/ui primitives (token-audited re-exports)   |
-| `@jonmatum/next-shell/providers`         | Theme, Query, Toast, ErrorBoundary, Tooltip, I18n |
-| `@jonmatum/next-shell/auth`              | Auth adapter interface + first-party adapters     |
-| `@jonmatum/next-shell/hooks`             | Cross-cutting hooks + formatters                  |
-| `@jonmatum/next-shell/tokens`            | Semantic token contract (TS view)                 |
-| `@jonmatum/next-shell/tailwind-preset`   | Tailwind v4 preset (maps tokens → theme)          |
-| `@jonmatum/next-shell/styles/tokens.css` | Token CSS (CSS variables for :root + dark)        |
+| Import                                   | Surface                                                                            | Status     |
+| ---------------------------------------- | ---------------------------------------------------------------------------------- | ---------- |
+| `@jonmatum/next-shell`                   | Root barrel — `cn`, `packageVersion`, `tokenSchemaVersion`                         | ✅         |
+| `@jonmatum/next-shell/core`              | `cn`, `packageVersion`                                                             | ✅         |
+| `@jonmatum/next-shell/primitives`        | 42 shadcn/ui primitives (client)                                                   | ✅         |
+| `@jonmatum/next-shell/providers`         | `ThemeProvider`, `ThemeToggle`, `ThemeToggleDropdown`, `useTheme` (client)         | ✅         |
+| `@jonmatum/next-shell/providers/server`  | SSR theme cookie helpers (server-safe)                                             | ✅         |
+| `@jonmatum/next-shell/layout`            | `ContentContainer`, `PageHeader`, `Footer`, status states + sidebar state types    | 🟡 partial |
+| `@jonmatum/next-shell/layout/server`     | SSR sidebar-state cookie helpers (server-safe)                                     | ✅         |
+| `@jonmatum/next-shell/tokens`            | TS view of the semantic-token contract — literal unions, `cssVar`, brand overrides | ✅         |
+| `@jonmatum/next-shell/tailwind-preset`   | Tailwind v4 preset (maps tokens → `@theme` keys)                                   | ✅         |
+| `@jonmatum/next-shell/styles/tokens.css` | Token CSS (custom properties for `:root` + `[data-theme="dark"]`)                  | ✅         |
+| `@jonmatum/next-shell/styles/preset.css` | Combined preset (tokens + `tw-animate-css` + Tailwind `@theme` mappings)           | ✅         |
+| `@jonmatum/next-shell/auth`              | Auth adapter interface                                                             | ⏳ Phase 5 |
+| `@jonmatum/next-shell/hooks`             | Cross-cutting hooks                                                                | ⏳ Phase 7 |
+
+Subpath imports tree-shake cleanly — importing only `@jonmatum/next-shell/primitives` does not pull in providers, and vice versa.
+
+## Semantic tokens
+
+Every color reaches the DOM through one of the semantic tokens declared in `styles/tokens.css`:
+
+```
+background        foreground
+surface           surface-foreground
+card              card-foreground
+popover           popover-foreground
+muted             muted-foreground
+accent            accent-foreground
+primary           primary-foreground
+secondary         secondary-foreground
+destructive       destructive-foreground
+success           success-foreground
+warning           warning-foreground
+info              info-foreground
+border  input  ring  overlay
+sidebar + 7 sidebar-* surfaces
+chart-1..chart-5
+```
+
+Plus radius (7 sizes on a single `--radius` base), typography (3 families, 9-step fluid type scale, leading, tracking), motion (5 durations + 4 easings), elevation (6 shadow sizes), and density (4 scalars).
+
+**No raw color literals** in library code — the `next-shell/no-raw-colors` ESLint rule fails CI on regressions. If a color concept doesn't fit an existing token, the token set grows; consumers never hardcode.
+
+### Brand overrides
+
+```tsx
+import { ThemeProvider } from '@jonmatum/next-shell/providers';
+import type { BrandOverrides } from '@jonmatum/next-shell/tokens';
+
+const brand: BrandOverrides = {
+  light: { primary: 'oklch(0.6 0.2 258)', 'primary-foreground': 'oklch(1 0 0)' },
+  dark: { primary: 'oklch(0.75 0.15 258)' },
+  radius: '0.5rem',
+  fontSans: 'Inter, sans-serif',
+};
+
+<ThemeProvider brand={brand}>{children}</ThemeProvider>;
+```
+
+Brand overrides cascade via CSS custom properties — zero JS re-render on theme switch.
+
+## Contributing
+
+See the root [`CONTRIBUTING.md`](../../CONTRIBUTING.md) for day-to-day workflow, and the repo-local skills under [`.claude/skills/`](../../.claude/skills/) if you're iterating with Claude Code.
 
 ## License
 


### PR DESCRIPTION
## Summary

Both READMEs were stuck at "Phase 0 — scaffolding in progress" even though Phases 1–3 are fully on `main` and Phase 4 is well underway. Replacing them with accurate, useful documentation.

Pure documentation PR — no code changes. Refs #13.

## What's in the box

### Root `README.md`

- **Accurate status line**: "Phases 0–3 landed; Phase 4 in progress"
- **Phase-by-phase status table** with current state (landed / in progress / queued) for all 12 phases
- **Complete primitive inventory** — the 42 primitives that actually shipped in #20–#27, named, plus the three composed patterns we skipped (`DatePicker`, `DataTable`, `Typography`) with their composition recipes
- **Design principles** — no hardcoded colors, latest stack, tree-shakeable subpaths, RSC-friendly, motion + opacity tokens
- **Workspace layout diagram** updated to include `.claude/skills/` + `CLAUDE.md`
- **New "For AI-assisted contributions" section** — links `CLAUDE.md`, the repo-local skills, `.mcp.json`; documents how a future session picks up the work (`git pull` → read CLAUDE.md → continue on `claude/phase-N-<slug>` branch)
- **Accurate quick-start commands** matching the verification pipeline used throughout Phase 3

### Package `README.md`

- **Status line** + install block now specifies peer versions (`next@^15`, `react@^19`, `react-dom@^19`, `tailwindcss@^4`) and lists the full runtime-deps cascade (17 deps)
- **Four-step Quick Start** — Tailwind preset import, `ThemeProvider` mount, SSR cookie setup for zero-flicker theme, primitive import example. Each step is runnable code a consumer can paste.
- **Subpath table gains a Status column** — `✅` / `🟡 partial` / `⏳ Phase N` so consumers see at a glance what's ready vs pending
- **New rows** for `providers/server`, `layout`, `layout/server`, `styles/preset.css` (all missing from the Phase 0 table)
- **Semantic-token catalog block** — names every token explicitly
- **Brand-overrides example** showing `light` / `dark` / `radius` / `fontSans` flowing through CSS custom properties

## Verification

```
pnpm format     ok
pnpm lint       ok
pnpm test       ok 353 passed (no regression)
```

## Checklist

- [x] Phase status is accurate as of `f15033b` (Phase 4b merged)
- [x] Every vendored primitive is named
- [x] Every subpath is listed with current status
- [x] Quick-start steps are copy-paste runnable
- [x] AI-assistance section points at `CLAUDE.md` + skills + `.mcp.json`
- [x] `CONTRIBUTING.md` link verified to exist
