### PR TITLE
feat(phase-4): TopBar with left / center / right slots

### DIFF
--- a/packages/next-shell/src/layout/index.ts
+++ b/packages/next-shell/src/layout/index.ts
@@ -23,6 +23,8 @@ export { PageHeader } from './page-header.js';
 export type { PageHeaderProps } from './page-header.js';
 export { EmptyState, ErrorState, LoadingState } from './status-states.js';
 export type { EmptyStateProps, ErrorStateProps, LoadingStateProps } from './status-states.js';
+export { TopBar } from './topbar.js';
+export type { TopBarProps } from './topbar.js';
 
 export type { SidebarState } from './sidebar-state-cookie.js';
 export {

--- a/packages/next-shell/src/layout/topbar.tsx
+++ b/packages/next-shell/src/layout/topbar.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+
+import { cn } from '@/core/cn';
+
+export interface TopBarProps extends Omit<React.ComponentProps<'header'>, 'children'> {
+  /**
+   * Left-anchored slot — typically the brand + breadcrumb.
+   */
+  readonly left?: React.ReactNode;
+  /**
+   * Center slot — typically a search input or `CommandBar` trigger.
+   * Stretches to fill available horizontal space between `left` and
+   * `right`.
+   */
+  readonly center?: React.ReactNode;
+  /**
+   * Right-anchored slot — typically the theme toggle, user menu,
+   * notifications, etc.
+   */
+  readonly right?: React.ReactNode;
+  /**
+   * Sticky positioning at the top of the viewport. Defaults to `true`.
+   * Set `false` if the consumer wants to control positioning externally
+   * (e.g. from within a scroll container).
+   */
+  readonly sticky?: boolean;
+}
+
+/**
+ * App-shell top bar. Renders a `<header>` with three anchored slots:
+ * `left` (brand), `center` (search), and `right` (user/theme/menu).
+ *
+ * Stateless and RSC-safe — the interactive islands (theme toggle, user
+ * menu, ⌘K trigger) are rendered as children. Token-driven styling
+ * (`bg-background`, `border-border`) keeps the bar consistent across
+ * both themes without any raw color literals.
+ *
+ * Pairs with `ContentContainer` + `Sidebar` (4d) + `AppShell` (4f) to
+ * form the complete chrome.
+ */
+function TopBar({ className, left, center, right, sticky = true, ...props }: TopBarProps) {
+  const hasCenter = center !== undefined && center !== null;
+  const hasLeft = left !== undefined && left !== null;
+  const hasRight = right !== undefined && right !== null;
+
+  return (
+    <header
+      data-slot="topbar"
+      className={cn(
+        'bg-background border-border flex h-14 items-center gap-4 border-b px-4 sm:px-6 lg:px-8',
+        sticky && 'sticky top-0 z-40',
+        className,
+      )}
+      {...props}
+    >
+      {hasLeft ? (
+        <div data-slot="topbar-left" className="flex min-w-0 shrink-0 items-center gap-2">
+          {left}
+        </div>
+      ) : null}
+      {hasCenter ? (
+        <div data-slot="topbar-center" className="flex min-w-0 flex-1 items-center justify-center">
+          {center}
+        </div>
+      ) : (
+        <div aria-hidden className="flex-1" />
+      )}
+      {hasRight ? (
+        <div data-slot="topbar-right" className="flex min-w-0 shrink-0 items-center gap-2">
+          {right}
+        </div>
+      ) : null}
+    </header>
+  );
+}
+
+export { TopBar };

--- a/packages/next-shell/tests/topbar.test.tsx
+++ b/packages/next-shell/tests/topbar.test.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { TopBar } from '../src/layout/index.js';
+
+describe('TopBar', () => {
+  it('renders a banner landmark with data-slot and sticky positioning by default', () => {
+    render(<TopBar left={<span>Brand</span>} />);
+    const bar = screen.getByRole('banner');
+    expect(bar).toHaveAttribute('data-slot', 'topbar');
+    expect(bar.className).toMatch(/sticky/);
+    expect(bar.className).toMatch(/top-0/);
+  });
+
+  it('omits sticky classes when sticky={false}', () => {
+    render(<TopBar left={<span>Brand</span>} sticky={false} />);
+    const bar = screen.getByRole('banner');
+    expect(bar.className).not.toMatch(/sticky/);
+  });
+
+  it('renders all three slots with their data-slot attributes when provided', () => {
+    render(
+      <TopBar
+        left={<span data-testid="brand">Brand</span>}
+        center={<input data-testid="search" placeholder="Search" />}
+        right={<button data-testid="user">User</button>}
+      />,
+    );
+    expect(screen.getByTestId('brand').parentElement).toHaveAttribute('data-slot', 'topbar-left');
+    expect(screen.getByTestId('search').parentElement).toHaveAttribute(
+      'data-slot',
+      'topbar-center',
+    );
+    expect(screen.getByTestId('user').parentElement).toHaveAttribute('data-slot', 'topbar-right');
+  });
+
+  it('omits optional slots when not provided', () => {
+    const { container } = render(<TopBar left={<span>Brand</span>} right={<span>User</span>} />);
+    expect(container.querySelector('[data-slot="topbar-left"]')).toBeTruthy();
+    expect(container.querySelector('[data-slot="topbar-center"]')).toBeNull();
+    expect(container.querySelector('[data-slot="topbar-right"]')).toBeTruthy();
+  });
+
+  it('inserts a flex spacer when center is absent so right stays right-aligned', () => {
+    const { container } = render(<TopBar left={<span>L</span>} right={<span>R</span>} />);
+    const header = container.querySelector('[data-slot="topbar"]');
+    const spacer = header?.querySelector('[aria-hidden]');
+    expect(spacer).toBeTruthy();
+    expect(spacer?.className).toMatch(/flex-1/);
+  });
+
+  it('uses semantic tokens only (no raw palette / white / black)', () => {
+    render(<TopBar left={<span>x</span>} />);
+    const bar = screen.getByRole('banner');
+    expect(bar.className).not.toMatch(
+      /(bg|text|border)-(slate|gray|zinc|neutral|stone|red|blue|indigo|violet|purple)-\d+/,
+    );
+    expect(bar.className).not.toMatch(/(bg|text|border)-(white|black)\b/);
+    expect(bar.className).toMatch(/bg-background/);
+    expect(bar.className).toMatch(/border-border/);
+  });
+
+  it('passes extra props through to the underlying header element', () => {
+    render(<TopBar data-testid="t" aria-label="Application header" />);
+    const bar = screen.getByTestId('t');
+    expect(bar).toHaveAttribute('aria-label', 'Application header');
+    expect(bar.tagName).toBe('HEADER');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4c. Stateless app-shell top bar that anchors three slots around a sticky `<header>`.

Depends on #29, #30. Refs #5 · Refs #13.

## API

```tsx
<TopBar
  left={<Brand />}
  center={<CommandBarTrigger />}
  right={<>
    <ThemeToggle />
    <UserMenu />
  </>}
/>
```

## Design choices

- **Prop-slots over children composition** — three explicit anchor props (`left` / `center` / `right`) make intent clear at call sites and eliminate ordering foot-guns. Consumers who want free-form composition can always drop down to a plain `<header>`.
- **Sticky by default** — `sticky={false}` opts out for consumers rendering inside a scroll container.
- **`center` with graceful fallback** — when absent, an `aria-hidden` `flex-1` spacer takes its place so `right` still anchors right-of-center. When present, `center` stretches to fill and centers its children.
- **RSC-safe** — no state, no hooks, no `'use client'` directive. The interactive islands (ThemeToggle, menus, ⌘K triggers) come in as children and keep their own client boundaries.
- **Token-driven styling only** — `bg-background`, `border-border`, responsive horizontal padding matching `ContentContainer`.
- **Fixed `h-14` height** — density-aware height comes with AppShell in 4f.

## Tests (+7 new → 360 total)

- Banner landmark + `data-slot="topbar"` + default sticky classes
- `sticky={false}` removes sticky classes
- All three slots render with matching `data-slot` attributes
- Omitted slots don't render
- `aria-hidden` `flex-1` spacer appears when center is absent
- No-raw-colors assertion (palette + white/black) + presence of `bg-background` / `border-border`
- Extra props passthrough (`aria-label`, `data-testid`) onto the `<header>`

## Verification

```
pnpm format     ok
pnpm lint       ok
pnpm typecheck  ok
pnpm test       ok 360 passed (+7 vs main)
pnpm build      ok
```

## Checklist

- [x] No raw color literals
- [x] `data-slot` on root + each active anchor
- [x] Banner landmark preserved
- [x] RSC-safe (no `'use client'`)
- [x] Graceful layout when any subset of slots is absent

## Next up

- **4d** — `claude/phase-4-sidebar` — Sidebar (4 variants + mobile drawer + cookie-persisted state). The largest Phase 4 slice.
- **4e** — `claude/phase-4-commandbar` — CommandBar on top of Command primitive.
- **4f** — `claude/phase-4-appshell` — AppShell root orchestrator + density wiring.
