### PR TITLE
feat(phase-4): CommandBar — ⌘K palette with registerable action providers

### DIFF
--- a/packages/next-shell/src/layout/command-bar.tsx
+++ b/packages/next-shell/src/layout/command-bar.tsx
@@ -1,0 +1,353 @@
+'use client';
+
+import * as React from 'react';
+import { SearchIcon } from 'lucide-react';
+
+import { cn } from '@/core/cn';
+import { Button } from '@/primitives/button';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from '@/primitives/command';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Action contract
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * A single action surfaced in the command bar.
+ *
+ * Actions are registered imperatively via `useCommandBarActions` — any
+ * component in the tree below a `CommandBarProvider` can contribute. The
+ * bar filters and groups them; `perform()` is invoked when an item is
+ * selected, and the dialog closes automatically unless the action calls
+ * `event.preventDefault()` on the provided event.
+ */
+export interface CommandAction {
+  /** Stable identifier. Used as React key + duplicate-registration guard. */
+  readonly id: string;
+  /** Group heading label. Actions without a group render at the top. */
+  readonly group?: string;
+  /** Visible label (first-class search term). */
+  readonly label: string;
+  /** Additional keywords to match against during search. */
+  readonly keywords?: ReadonlyArray<string>;
+  /** Optional leading icon. */
+  readonly icon?: React.ReactNode;
+  /** Display-only shortcut hint (e.g. `"⌘S"`). Not wired as a real listener. */
+  readonly shortcut?: string;
+  /** Optional ordering within the group. Lower = earlier. */
+  readonly priority?: number;
+  /** Whether the item is disabled. */
+  readonly disabled?: boolean;
+  /**
+   * Invoked when the item is selected. The command bar closes afterwards;
+   * call `event.preventDefault()` on the passed event to keep it open
+   * (e.g. for multi-step flows).
+   */
+  readonly perform: (event: { preventDefault: () => void }) => void | Promise<void>;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Context + registry
+ * ──────────────────────────────────────────────────────────────────────── */
+
+interface CommandBarContextValue {
+  readonly open: boolean;
+  readonly setOpen: (open: boolean) => void;
+  readonly toggle: () => void;
+  readonly actions: ReadonlyArray<CommandAction>;
+  readonly register: (actions: ReadonlyArray<CommandAction>) => () => void;
+}
+
+const CommandBarContext = React.createContext<CommandBarContextValue | null>(null);
+
+function useCommandBarContext(): CommandBarContextValue {
+  const ctx = React.useContext(CommandBarContext);
+  if (!ctx) {
+    throw new Error('CommandBar components must be used within a <CommandBarProvider>.');
+  }
+  return ctx;
+}
+
+/**
+ * Read the open / toggle surface of the command bar. Throws when used
+ * outside a `CommandBarProvider` so misuse fails loudly.
+ */
+export function useCommandBar(): {
+  readonly open: boolean;
+  readonly setOpen: (open: boolean) => void;
+  readonly toggle: () => void;
+} {
+  const { open, setOpen, toggle } = useCommandBarContext();
+  return { open, setOpen, toggle };
+}
+
+/**
+ * Register a batch of actions for as long as the calling component is
+ * mounted. Actions are re-registered whenever the array's reference
+ * changes — wrap in `React.useMemo` with a stable dependency list if you
+ * need to avoid thrashing.
+ */
+export function useCommandBarActions(actions: ReadonlyArray<CommandAction>): void {
+  const { register } = useCommandBarContext();
+  React.useEffect(() => {
+    return register(actions);
+  }, [register, actions]);
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Provider
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export interface CommandBarProviderProps {
+  readonly children: React.ReactNode;
+  /**
+   * Controlled open state. Uncontrolled when omitted.
+   */
+  readonly open?: boolean;
+  readonly onOpenChange?: (open: boolean) => void;
+  /**
+   * Keyboard shortcut that toggles the bar. Defaults to `'k'` — fires on
+   * either `⌘K` (mac) or `Ctrl+K` (other). Set `null` to disable.
+   */
+  readonly shortcut?: string | null;
+}
+
+/**
+ * Root provider for the command-bar subsystem. Wrap the app (or a
+ * subtree) so descendants can register actions via
+ * `useCommandBarActions` and toggle the bar via `useCommandBar`.
+ */
+export function CommandBarProvider({
+  children,
+  open: openProp,
+  onOpenChange,
+  shortcut = 'k',
+}: CommandBarProviderProps) {
+  const [internalOpen, setInternalOpen] = React.useState(false);
+  const open = openProp ?? internalOpen;
+
+  const setOpen = React.useCallback(
+    (value: boolean) => {
+      if (openProp === undefined) {
+        setInternalOpen(value);
+      }
+      onOpenChange?.(value);
+    },
+    [openProp, onOpenChange],
+  );
+
+  const toggle = React.useCallback(() => setOpen(!open), [open, setOpen]);
+
+  // Registry: Map<bucketId, Action[]>. Each call to `register` occupies
+  // one bucket keyed by an auto-incrementing id; return value unregisters.
+  const bucketsRef = React.useRef(new Map<number, ReadonlyArray<CommandAction>>());
+  const nextBucketId = React.useRef(0);
+  const [actionsVersion, setActionsVersion] = React.useState(0);
+
+  const register = React.useCallback((actions: ReadonlyArray<CommandAction>) => {
+    const id = nextBucketId.current++;
+    bucketsRef.current.set(id, actions);
+    setActionsVersion((v) => v + 1);
+    return () => {
+      bucketsRef.current.delete(id);
+      setActionsVersion((v) => v + 1);
+    };
+  }, []);
+
+  const actions = React.useMemo<ReadonlyArray<CommandAction>>(() => {
+    const flat: CommandAction[] = [];
+    const seen = new Set<string>();
+    for (const bucket of bucketsRef.current.values()) {
+      for (const action of bucket) {
+        if (!seen.has(action.id)) {
+          seen.add(action.id);
+          flat.push(action);
+        }
+      }
+    }
+    return flat;
+    // actionsVersion intentionally included as dep — bucketsRef is mutable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [actionsVersion]);
+
+  // Keyboard shortcut.
+  React.useEffect(() => {
+    if (shortcut === null) return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === shortcut.toLowerCase() && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        toggle();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [shortcut, toggle]);
+
+  const value = React.useMemo<CommandBarContextValue>(
+    () => ({ open, setOpen, toggle, actions, register }),
+    [open, setOpen, toggle, actions, register],
+  );
+
+  return <CommandBarContext.Provider value={value}>{children}</CommandBarContext.Provider>;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Dialog
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export interface CommandBarProps {
+  /** Label announced to screen readers on the dialog. */
+  readonly title?: string;
+  /** Description for screen readers. */
+  readonly description?: string;
+  /** Placeholder for the search input. */
+  readonly placeholder?: string;
+  /** Content rendered when there are zero matches. */
+  readonly emptyState?: React.ReactNode;
+}
+
+/**
+ * The ⌘K palette. Renders nothing when closed; mounts inside a Radix
+ * portal via `CommandDialog` when open. Composes the registered actions,
+ * grouped by `action.group`, sorted by `action.priority`.
+ */
+export function CommandBar({
+  title = 'Command palette',
+  description = 'Search for an action or navigate.',
+  placeholder = 'Type a command or search…',
+  emptyState = 'No matching actions.',
+}: CommandBarProps = {}) {
+  const { open, setOpen, actions } = useCommandBarContext();
+
+  const grouped = React.useMemo(() => {
+    const byGroup = new Map<string, CommandAction[]>();
+    const NO_GROUP = '__ungrouped__';
+    for (const action of actions) {
+      const key = action.group ?? NO_GROUP;
+      const list = byGroup.get(key) ?? [];
+      list.push(action);
+      byGroup.set(key, list);
+    }
+    for (const list of byGroup.values()) {
+      list.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+    }
+    // Ungrouped first, then groups alphabetically.
+    const groups: Array<{ readonly name: string | null; readonly items: CommandAction[] }> = [];
+    if (byGroup.has(NO_GROUP)) {
+      groups.push({ name: null, items: byGroup.get(NO_GROUP)! });
+      byGroup.delete(NO_GROUP);
+    }
+    const sortedKeys = [...byGroup.keys()].sort();
+    for (const key of sortedKeys) {
+      groups.push({ name: key, items: byGroup.get(key)! });
+    }
+    return groups;
+  }, [actions]);
+
+  const onSelect = React.useCallback(
+    (action: CommandAction) => {
+      let preventClose = false;
+      const syntheticEvent = {
+        preventDefault: () => {
+          preventClose = true;
+        },
+      };
+      void action.perform(syntheticEvent);
+      if (!preventClose) {
+        setOpen(false);
+      }
+    },
+    [setOpen],
+  );
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen} title={title} description={description}>
+      <CommandInput placeholder={placeholder} />
+      <CommandList>
+        <CommandEmpty>{emptyState}</CommandEmpty>
+        {grouped.map((group, index) => (
+          <React.Fragment key={group.name ?? `__ungrouped__:${index}`}>
+            {index > 0 ? <CommandSeparator /> : null}
+            <CommandGroup heading={group.name ?? undefined}>
+              {group.items.map((action) => (
+                <CommandItem
+                  key={action.id}
+                  value={[action.label, ...(action.keywords ?? [])].join(' ')}
+                  disabled={action.disabled}
+                  onSelect={() => onSelect(action)}
+                >
+                  {action.icon}
+                  <span>{action.label}</span>
+                  {action.shortcut !== undefined ? (
+                    <CommandShortcut>{action.shortcut}</CommandShortcut>
+                  ) : null}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </React.Fragment>
+        ))}
+      </CommandList>
+    </CommandDialog>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Trigger
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export interface CommandBarTriggerProps extends Omit<
+  React.ComponentProps<typeof Button>,
+  'children' | 'onClick'
+> {
+  /**
+   * Display label. Defaults to `"Search…"`. Rendered alongside a search
+   * icon and the keyboard-shortcut hint.
+   */
+  readonly label?: string;
+  /** Override the shortcut hint text. Defaults to `"⌘K"`. */
+  readonly shortcut?: string;
+}
+
+/**
+ * Button-shaped trigger for the command bar — drop into a `TopBar`
+ * `center` slot. Opens the palette on click; the shortcut hint is
+ * display-only (the real shortcut is bound by `CommandBarProvider`).
+ */
+export function CommandBarTrigger({
+  label = 'Search…',
+  shortcut = '⌘K',
+  className,
+  variant = 'outline',
+  ...props
+}: CommandBarTriggerProps) {
+  const { toggle } = useCommandBarContext();
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      data-slot="command-bar-trigger"
+      className={cn(
+        'text-muted-foreground hover:text-foreground h-9 w-full max-w-sm justify-between gap-2 font-normal',
+        className,
+      )}
+      onClick={toggle}
+      {...props}
+    >
+      <span className="flex items-center gap-2">
+        <SearchIcon aria-hidden className="size-4" />
+        {label}
+      </span>
+      <kbd className="bg-muted text-muted-foreground pointer-events-none hidden rounded px-1.5 py-0.5 text-xs font-medium sm:inline-flex">
+        {shortcut}
+      </kbd>
+    </Button>
+  );
+}

--- a/packages/next-shell/src/layout/command-bar.tsx
+++ b/packages/next-shell/src/layout/command-bar.tsx
@@ -58,12 +58,14 @@ export interface CommandAction {
  * Context + registry
  * ──────────────────────────────────────────────────────────────────────── */
 
+type ActionGetter = () => ReadonlyArray<CommandAction>;
+
 interface CommandBarContextValue {
   readonly open: boolean;
   readonly setOpen: (open: boolean) => void;
   readonly toggle: () => void;
   readonly actions: ReadonlyArray<CommandAction>;
-  readonly register: (actions: ReadonlyArray<CommandAction>) => () => void;
+  readonly register: (getActions: ActionGetter) => () => void;
 }
 
 const CommandBarContext = React.createContext<CommandBarContextValue | null>(null);
@@ -91,15 +93,16 @@ export function useCommandBar(): {
 
 /**
  * Register a batch of actions for as long as the calling component is
- * mounted. Actions are re-registered whenever the array's reference
- * changes — wrap in `React.useMemo` with a stable dependency list if you
- * need to avoid thrashing.
+ * mounted. The action list is read via a ref so it stays current on every
+ * re-render without re-registering — the effect runs once per mount.
  */
 export function useCommandBarActions(actions: ReadonlyArray<CommandAction>): void {
   const { register } = useCommandBarContext();
+  const actionsRef = React.useRef(actions);
+  actionsRef.current = actions;
   React.useEffect(() => {
-    return register(actions);
-  }, [register, actions]);
+    return register(() => actionsRef.current);
+  }, [register]);
 }
 
 /* ────────────────────────────────────────────────────────────────────────
@@ -145,16 +148,23 @@ export function CommandBarProvider({
   );
 
   const toggle = React.useCallback(() => setOpen(!open), [open, setOpen]);
+  // Stable toggle for the keyboard listener — avoids re-registering the
+  // window event listener on every open/close cycle.
+  const toggleRef = React.useRef(toggle);
+  React.useLayoutEffect(() => {
+    toggleRef.current = toggle;
+  });
 
-  // Registry: Map<bucketId, Action[]>. Each call to `register` occupies
-  // one bucket keyed by an auto-incrementing id; return value unregisters.
-  const bucketsRef = React.useRef(new Map<number, ReadonlyArray<CommandAction>>());
+  // Registry: Map<bucketId, ActionGetter>. Storing getters (not snapshots)
+  // means the flattened list always reflects the caller's latest ref value
+  // without re-registering on every render.
+  const bucketsRef = React.useRef(new Map<number, ActionGetter>());
   const nextBucketId = React.useRef(0);
   const [actionsVersion, setActionsVersion] = React.useState(0);
 
-  const register = React.useCallback((actions: ReadonlyArray<CommandAction>) => {
+  const register = React.useCallback((getActions: ActionGetter) => {
     const id = nextBucketId.current++;
-    bucketsRef.current.set(id, actions);
+    bucketsRef.current.set(id, getActions);
     setActionsVersion((v) => v + 1);
     return () => {
       bucketsRef.current.delete(id);
@@ -165,8 +175,8 @@ export function CommandBarProvider({
   const actions = React.useMemo<ReadonlyArray<CommandAction>>(() => {
     const flat: CommandAction[] = [];
     const seen = new Set<string>();
-    for (const bucket of bucketsRef.current.values()) {
-      for (const action of bucket) {
+    for (const getActions of bucketsRef.current.values()) {
+      for (const action of getActions()) {
         if (!seen.has(action.id)) {
           seen.add(action.id);
           flat.push(action);
@@ -178,18 +188,19 @@ export function CommandBarProvider({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [actionsVersion]);
 
-  // Keyboard shortcut.
+  // Keyboard shortcut — depends only on `shortcut` so the listener is
+  // registered once and never re-added on open/close cycles.
   React.useEffect(() => {
     if (shortcut === null) return undefined;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key.toLowerCase() === shortcut.toLowerCase() && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
-        toggle();
+        toggleRef.current();
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [shortcut, toggle]);
+  }, [shortcut]);
 
   const value = React.useMemo<CommandBarContextValue>(
     () => ({ open, setOpen, toggle, actions, register }),

--- a/packages/next-shell/src/layout/index.ts
+++ b/packages/next-shell/src/layout/index.ts
@@ -27,6 +27,21 @@ export type { EmptyStateProps, ErrorStateProps, LoadingStateProps } from './stat
 export { TopBar } from './topbar.js';
 export type { TopBarProps } from './topbar.js';
 
+// Command palette (⌘K).
+export {
+  CommandBar,
+  CommandBarProvider,
+  CommandBarTrigger,
+  useCommandBar,
+  useCommandBarActions,
+} from './command-bar.js';
+export type {
+  CommandAction,
+  CommandBarProps,
+  CommandBarProviderProps,
+  CommandBarTriggerProps,
+} from './command-bar.js';
+
 // Interactive sidebar (client-only).
 export {
   Sidebar,

--- a/packages/next-shell/tests/command-bar.test.tsx
+++ b/packages/next-shell/tests/command-bar.test.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { act, render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  CommandBarProvider,
+  CommandBarTrigger,
+  useCommandBar,
+  useCommandBarActions,
+} from '../src/layout/command-bar.js';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <CommandBarProvider>{children}</CommandBarProvider>;
+}
+
+describe('CommandBarProvider + useCommandBar', () => {
+  it('throws when useCommandBar is called outside a provider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useCommandBar())).toThrow(
+      /CommandBar components must be used within a <CommandBarProvider>/,
+    );
+    spy.mockRestore();
+  });
+
+  it('exposes open/setOpen/toggle', () => {
+    const { result } = renderHook(() => useCommandBar(), { wrapper });
+    expect(result.current.open).toBe(false);
+    act(() => result.current.setOpen(true));
+    expect(result.current.open).toBe(true);
+    act(() => result.current.toggle());
+    expect(result.current.open).toBe(false);
+  });
+
+  it('respects controlled mode', () => {
+    function Probe() {
+      const { open } = useCommandBar();
+      return <span data-testid="state">{String(open)}</span>;
+    }
+    const { rerender } = render(
+      <CommandBarProvider open={true}>
+        <Probe />
+      </CommandBarProvider>,
+    );
+    expect(screen.getByTestId('state')).toHaveTextContent('true');
+    rerender(
+      <CommandBarProvider open={false}>
+        <Probe />
+      </CommandBarProvider>,
+    );
+    expect(screen.getByTestId('state')).toHaveTextContent('false');
+  });
+
+  it('fires the ⌘K shortcut to toggle open', async () => {
+    function Probe() {
+      const { open } = useCommandBar();
+      return <span data-testid="state">{String(open)}</span>;
+    }
+    render(
+      <CommandBarProvider>
+        <Probe />
+      </CommandBarProvider>,
+    );
+    expect(screen.getByTestId('state')).toHaveTextContent('false');
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
+    });
+    expect(screen.getByTestId('state')).toHaveTextContent('true');
+  });
+});
+
+describe('useCommandBarActions', () => {
+  it('registers actions without throwing', () => {
+    function Capture() {
+      useCommandBarActions([{ id: 'noop', label: 'Noop', perform: () => {} }]);
+      return <span data-testid="ok">ok</span>;
+    }
+    render(
+      <CommandBarProvider>
+        <Capture />
+      </CommandBarProvider>,
+    );
+    expect(screen.getByTestId('ok')).toBeInTheDocument();
+  });
+});
+
+describe('CommandBarTrigger', () => {
+  it('renders a button with data-slot + label + shortcut hint', () => {
+    render(
+      <CommandBarProvider>
+        <CommandBarTrigger data-testid="trigger" />
+      </CommandBarProvider>,
+    );
+    const btn = screen.getByTestId('trigger');
+    expect(btn).toHaveAttribute('data-slot', 'command-bar-trigger');
+    expect(btn).toHaveTextContent('Search…');
+    expect(btn).toHaveTextContent('⌘K');
+  });
+
+  it('clicking the trigger toggles open state', async () => {
+    const user = userEvent.setup();
+    function Probe() {
+      const { open } = useCommandBar();
+      return <span data-testid="state">{String(open)}</span>;
+    }
+    render(
+      <CommandBarProvider>
+        <CommandBarTrigger data-testid="trigger" />
+        <Probe />
+      </CommandBarProvider>,
+    );
+    expect(screen.getByTestId('state')).toHaveTextContent('false');
+    await user.click(screen.getByTestId('trigger'));
+    expect(screen.getByTestId('state')).toHaveTextContent('true');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4e. Original layout component (not vendored from shadcn) built on top of our Command primitive (cmdk) from #25. Implements the "⌘K palette with registerable action providers" requirement from #5.

Refs #5 · Refs #13.

## Exports

| Export | Kind | Purpose |
| ------ | ---- | ------- |
| `CommandBarProvider` | Component | Context root — manages open state + action registry + ⌘K keyboard shortcut |
| `CommandBar` | Component | The dialog — groups and renders registered actions via `CommandDialog` |
| `CommandBarTrigger` | Component | Button-shaped trigger for TopBar center slot (search icon + ⌘K hint) |
| `useCommandBar()` | Hook | Returns `{ open, setOpen, toggle }` |
| `useCommandBarActions(actions)` | Hook | Register actions from anywhere in the tree; auto-cleanup on unmount |
| `CommandAction` | Type | Per-action contract (`id`, `group`, `label`, `keywords`, `icon`, `shortcut`, `priority`, `disabled`, `perform`) |

## Action registration pattern

```tsx
const actions = useMemo(() => [
  { id: 'new-file', group: 'Files', label: 'New file',
    icon: <FilePlus />, shortcut: '⌘N',
    perform: () => router.push('/new') },
  { id: 'settings', group: 'Navigation', label: 'Settings',
    perform: () => router.push('/settings') },
], []);
useCommandBarActions(actions);
```

Actions from **any component** below `CommandBarProvider` are merged, deduplicated by `id`, grouped by `action.group`, and sorted by `priority`. `perform()` is called on select; the dialog closes unless `event.preventDefault()` is called (for multi-step flows).

## Design choices

- **Registry uses a bucket-map + version-counter pattern.** Each `register()` call gets a unique bucket id; the cleanup function removes it. A version counter forces re-memoization of the flat action list.
- **Uncontrolled + controlled modes.** Internal state by default; pass `open` / `onOpenChange` to control externally.
- **`shortcut='k'` by default; `shortcut={null}` disables** the global keyboard listener.
- **CommandBarTrigger composes our Button primitive** with `variant="outline"` and renders the ⌘K shortcut as a `<kbd>` element (hidden below `sm` breakpoint).
- **Token-driven styling** — `text-muted-foreground`, `bg-muted`, `hover:text-foreground`. No raw colors.

## Tests (+7 new)

- `useCommandBar`: throws outside provider, exposes open/setOpen/toggle
- Controlled mode: `open` prop overrides internal state
- ⌘K shortcut fires via window keydown event
- `useCommandBarActions`: registers without throwing
- `CommandBarTrigger`: `data-slot` + label + shortcut hint + click toggles open

Open-state dialog rendering (CommandBar with actions visible) deferred to Storybook + Playwright VR (Phase 9) — the JSDOM + Radix Dialog + cmdk portal stack exceeds the sandbox memory budget for unit tests.

## Verification

```
pnpm format     ok
pnpm lint       ok (0 warnings)
pnpm typecheck  ok
pnpm test       CI-validated (sandbox OOM on full 14-file suite)
pnpm build      CI-validated
```

## Checklist

- [x] No raw color literals
- [x] `data-slot="command-bar-trigger"` on the trigger
- [x] Keyboard shortcut (⌘K / Ctrl+K) bound and testable
- [x] `event.preventDefault()` escape hatch for multi-step flows
- [x] Controlled + uncontrolled modes
- [x] `shortcut={null}` disables listener

## Next up

- **4f** — `claude/phase-4-appshell` — AppShell root orchestrator (closes Phase 4)
- Then: close issue #5, update READMEs, and proceed to Phase 5 (auth)
