### PR TITLE
feat(phase-4): AppShell — root orchestrator closing Phase 4

### DIFF
--- a/packages/next-shell/src/layout/app-shell.tsx
+++ b/packages/next-shell/src/layout/app-shell.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/core/cn';
+
+import { CommandBarProvider } from './command-bar.js';
+import { SidebarInset, SidebarProvider } from './sidebar.js';
+import type { SidebarState } from './sidebar-state-cookie.js';
+
+export interface AppShellProps {
+  /**
+   * Page content. Rendered inside the main scrollable area between
+   * `topBar` and `footer`.
+   */
+  readonly children: React.ReactNode;
+  /**
+   * Sidebar nav tree. When omitted the sidebar rail and provider are not
+   * rendered and the content stretches to full width.
+   */
+  readonly sidebar?: React.ReactNode;
+  /**
+   * Top bar. Pass a `<TopBar … />` or any element — rendered as a sticky
+   * `<header>` inside `SidebarInset`.
+   */
+  readonly topBar?: React.ReactNode;
+  /**
+   * Footer. Rendered below the content area inside `SidebarInset`.
+   */
+  readonly footer?: React.ReactNode;
+  /**
+   * Mount a `CommandBarProvider` wrapping the whole shell. Consumers can
+   * then call `useCommandBarActions` anywhere in the tree.
+   */
+  readonly commandBar?: boolean;
+  /**
+   * Initial sidebar open/closed state read from the SSR cookie so the
+   * server render matches the first client paint without a flash.
+   */
+  readonly initialSidebarState?: SidebarState;
+  readonly className?: string;
+}
+
+/**
+ * Root orchestrator for the app shell. Composes `SidebarProvider`,
+ * optional `CommandBarProvider`, and the grid that houses the sidebar,
+ * top bar, content, and footer.
+ *
+ * Usage:
+ * ```tsx
+ * <AppShell
+ *   sidebar={<Nav />}
+ *   topBar={<TopBar left={<Brand />} right={<UserMenu />} />}
+ *   footer={<Footer />}
+ *   commandBar
+ *   initialSidebarState={cookieSidebarState}
+ * >
+ *   {children}
+ * </AppShell>
+ * ```
+ */
+export function AppShell({
+  children,
+  sidebar,
+  topBar,
+  footer,
+  commandBar = false,
+  initialSidebarState,
+  className,
+}: AppShellProps) {
+  const hasSidebar = Boolean(sidebar);
+  const defaultOpen = initialSidebarState !== 'closed';
+
+  const shell = hasSidebar ? (
+    <SidebarProvider defaultOpen={defaultOpen}>
+      {sidebar}
+      <SidebarInset className={cn('flex min-h-svh flex-col', className)}>
+        {topBar}
+        <main className="flex-1">{children}</main>
+        {footer}
+      </SidebarInset>
+    </SidebarProvider>
+  ) : (
+    <div className={cn('flex min-h-svh flex-col', className)}>
+      {topBar}
+      <main className="flex-1">{children}</main>
+      {footer}
+    </div>
+  );
+
+  return commandBar ? <CommandBarProvider>{shell}</CommandBarProvider> : shell;
+}

--- a/packages/next-shell/src/layout/index.ts
+++ b/packages/next-shell/src/layout/index.ts
@@ -13,6 +13,10 @@
  * instead — it has no client boundary.
  */
 
+// Root orchestrator — client component (depends on SidebarProvider + optional CommandBarProvider).
+export { AppShell } from './app-shell.js';
+export type { AppShellProps } from './app-shell.js';
+
 // Stateless content surfaces — also re-exported from `/layout/server`
 // for RSC consumers. Duplicated on both subpaths so the ergonomics are
 // straightforward regardless of the consumer's render context.

--- a/packages/next-shell/tests/app-shell.test.tsx
+++ b/packages/next-shell/tests/app-shell.test.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { AppShell } from '../src/layout/app-shell.js';
+import { useCommandBar } from '../src/layout/command-bar.js';
+import { useSidebar } from '../src/layout/sidebar.js';
+
+describe('AppShell — no sidebar', () => {
+  it('renders children in a flex column without SidebarProvider', () => {
+    render(
+      <AppShell data-testid="shell">
+        <p data-testid="content">hello</p>
+      </AppShell>,
+    );
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+  });
+
+  it('renders topBar and footer slots', () => {
+    render(
+      <AppShell
+        topBar={<header data-testid="topbar">Top</header>}
+        footer={<footer data-testid="footer">Bottom</footer>}
+      >
+        <p>content</p>
+      </AppShell>,
+    );
+    expect(screen.getByTestId('topbar')).toBeInTheDocument();
+    expect(screen.getByTestId('footer')).toBeInTheDocument();
+  });
+
+  it('omits topBar / footer when not provided', () => {
+    const { container } = render(
+      <AppShell>
+        <p>x</p>
+      </AppShell>,
+    );
+    expect(container.querySelector('header')).toBeNull();
+    expect(container.querySelector('footer')).toBeNull();
+  });
+});
+
+describe('AppShell — with sidebar', () => {
+  it('renders SidebarProvider when sidebar prop is provided', () => {
+    function SidebarProbe() {
+      useSidebar(); // throws when outside SidebarProvider
+      return <nav data-testid="nav">Nav</nav>;
+    }
+    render(
+      <AppShell sidebar={<SidebarProbe />}>
+        <p data-testid="content">content</p>
+      </AppShell>,
+    );
+    expect(screen.getByTestId('nav')).toBeInTheDocument();
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+  });
+
+  it('defaults sidebar to open when initialSidebarState is "open"', () => {
+    function StateProbe() {
+      const { open } = useSidebar();
+      return <span data-testid="state">{String(open)}</span>;
+    }
+    render(
+      <AppShell sidebar={<StateProbe />} initialSidebarState="open">
+        <p>c</p>
+      </AppShell>,
+    );
+    expect(screen.getByTestId('state')).toHaveTextContent('true');
+  });
+
+  it('defaults sidebar to closed when initialSidebarState is "closed"', () => {
+    function StateProbe() {
+      const { open } = useSidebar();
+      return <span data-testid="state">{String(open)}</span>;
+    }
+    render(
+      <AppShell sidebar={<StateProbe />} initialSidebarState="closed">
+        <p>c</p>
+      </AppShell>,
+    );
+    expect(screen.getByTestId('state')).toHaveTextContent('false');
+  });
+});
+
+describe('AppShell — commandBar', () => {
+  it('does NOT mount CommandBarProvider when commandBar is false', () => {
+    function Probe() {
+      // useCommandBar throws when outside CommandBarProvider
+      try {
+        useCommandBar();
+        return <span data-testid="inside">inside</span>;
+      } catch {
+        return <span data-testid="outside">outside</span>;
+      }
+    }
+    render(
+      <AppShell>
+        <Probe />
+      </AppShell>,
+    );
+    expect(screen.getByTestId('outside')).toBeInTheDocument();
+  });
+
+  it('mounts CommandBarProvider when commandBar is true', () => {
+    function Probe() {
+      const { open } = useCommandBar();
+      return <span data-testid="cb-open">{String(open)}</span>;
+    }
+    render(
+      <AppShell commandBar>
+        <Probe />
+      </AppShell>,
+    );
+    expect(screen.getByTestId('cb-open')).toHaveTextContent('false');
+  });
+
+  it('works with commandBar + sidebar together', () => {
+    function SidebarProbe() {
+      useSidebar();
+      return <nav data-testid="nav">Nav</nav>;
+    }
+    function CBProbe() {
+      const { open } = useCommandBar();
+      return <span data-testid="cb">{String(open)}</span>;
+    }
+    render(
+      <AppShell commandBar sidebar={<SidebarProbe />}>
+        <CBProbe />
+      </AppShell>,
+    );
+    expect(screen.getByTestId('nav')).toBeInTheDocument();
+    expect(screen.getByTestId('cb')).toHaveTextContent('false');
+  });
+});


### PR DESCRIPTION
Closes #5 · Refs #13

## Summary

Phase 4f — the final piece. `AppShell` is the single entry point that wires all Phase 4 primitives together into a complete responsive shell.

## What's in the box

```tsx
<AppShell
  sidebar={<Nav />}            // optional — omit for full-width layout
  topBar={<TopBar … />}        // optional sticky header slot
  footer={<Footer />}          // optional footer slot
  commandBar                   // boolean: mount CommandBarProvider
  initialSidebarState={…}      // from SSR cookie → no layout flash
>
  {children}
</AppShell>
```

| Export | Kind | Notes |
|--------|------|-------|
| `AppShell` | Component | Root orchestrator (`'use client'`) |
| `AppShellProps` | Type | Public prop contract |

**Layout modes:**
- **With sidebar**: wraps children in `SidebarProvider` → `Sidebar` + `SidebarInset` (main + topBar + footer)
- **Without sidebar**: plain `<div>` flex column — topBar + main + footer
- **`commandBar={true}`**: wraps the whole shell in `CommandBarProvider` so any descendant can call `useCommandBarActions`

**SSR-safe**: `initialSidebarState` (read from the sidebar-state cookie in the server component) maps directly to `SidebarProvider`'s `defaultOpen` so the server-rendered HTML matches first paint.

## What is intentionally NOT in this PR

- No `ThemeProvider` wrapping — consumers wire that in their own root layout (it requires `suppressHydrationWarning` on `<html>`)
- No density or spacing props — deferred to Phase 6 (providers composer)
- No nested shell variants — flat composition is sufficient for Phase 4

## Verification

```
pnpm format     ✓ ok
pnpm lint       ✓ ok (0 warnings)
pnpm typecheck  ✓ ok
pnpm test       ✓ 385 passed (15 files) — includes 9 new AppShell tests
pnpm build      ✓ ESM + CJS + DTS success
```

## Checklist

- [x] No raw color literals
- [x] `'use client'` at top (depends on `SidebarProvider` + `CommandBarProvider`)
- [x] SSR-safe via `initialSidebarState` cookie prop
- [x] Tests cover: no-sidebar, with-sidebar, open/closed initial state, commandBar on/off, combined

🤖 Generated with [Claude Code](https://claude.com/claude-code)