### PR TITLE
feat(phase-5): navigation system — NavConfig, buildNav, SidebarNav, Breadcrumbs, CommandBarActions

### DIFF
--- a/packages/next-shell/src/layout/breadcrumbs.tsx
+++ b/packages/next-shell/src/layout/breadcrumbs.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/primitives/breadcrumb';
+
+import type { NavConfig } from './nav-config.js';
+import { buildNav } from './nav-config.js';
+import type { ResolvedNavItem } from './nav-config.js';
+
+export interface BreadcrumbsProps extends Omit<
+  React.ComponentProps<typeof Breadcrumb>,
+  'children'
+> {
+  /**
+   * Nav config to derive the trail from. Pass the same config used by
+   * `<SidebarNav>` so breadcrumbs stay in sync automatically.
+   */
+  readonly config: NavConfig;
+  /**
+   * Current pathname. Must match the format used in `NavItem.href` values.
+   */
+  readonly pathname: string;
+  /**
+   * Permission keys the current user holds — must match what was passed to
+   * `buildNav` so permission-gated items are excluded from the trail.
+   */
+  readonly permissions?: ReadonlyArray<string>;
+  /**
+   * Render a link for each ancestor item. Defaults to a plain `<a>` tag;
+   * pass a Next.js `<Link>` component via `asChild` or override this to
+   * render custom link elements.
+   */
+  readonly renderLink?: (item: ResolvedNavItem, children: React.ReactNode) => React.ReactNode;
+}
+
+/**
+ * Derives a breadcrumb trail from a `NavConfig` + current pathname.
+ * No state required — re-derive on every render (fast, pure).
+ *
+ * ```tsx
+ * <Breadcrumbs config={NAV} pathname={pathname} />
+ * ```
+ */
+export function Breadcrumbs({
+  config,
+  pathname,
+  permissions = [],
+  renderLink,
+  ...props
+}: BreadcrumbsProps) {
+  const { breadcrumbs } = buildNav({ config, pathname, permissions });
+
+  if (breadcrumbs.length === 0) return null;
+
+  return (
+    <Breadcrumb {...props}>
+      <BreadcrumbList>
+        {breadcrumbs.map((crumb, index) => {
+          const isLast = index === breadcrumbs.length - 1;
+          return (
+            <React.Fragment key={crumb.id}>
+              <BreadcrumbItem>
+                {isLast ? (
+                  <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink asChild={Boolean(renderLink || crumb.href)}>
+                    {renderLink ? (
+                      renderLink(crumb, crumb.label)
+                    ) : crumb.href ? (
+                      <a href={crumb.href}>{crumb.label}</a>
+                    ) : (
+                      <span>{crumb.label}</span>
+                    )}
+                  </BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+              {!isLast && <BreadcrumbSeparator />}
+            </React.Fragment>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/packages/next-shell/src/layout/command-bar-actions.tsx
+++ b/packages/next-shell/src/layout/command-bar-actions.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import * as React from 'react';
+
+import { useCommandBarActions } from './command-bar.js';
+import type { NavConfig, ResolvedNavItem } from './nav-config.js';
+import { buildNav } from './nav-config.js';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Helpers
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function collectLeaves(
+  items: ReadonlyArray<ResolvedNavItem>,
+  groupLabel: string | null = null,
+): Array<{ item: ResolvedNavItem; group: string | null }> {
+  const leaves: Array<{ item: ResolvedNavItem; group: string | null }> = [];
+  for (const item of items) {
+    if (item.children?.length) {
+      // Use this item's label as the group heading for its children.
+      leaves.push(...collectLeaves(item.children, item.label));
+    } else if (item.href) {
+      leaves.push({ item, group: groupLabel });
+    }
+  }
+  return leaves;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Component
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export interface CommandBarActionsProps {
+  /**
+   * Nav config to surface as command-bar actions. Pass the same config
+   * used by `<SidebarNav>` so the palette stays in sync.
+   */
+  readonly config: NavConfig;
+  /**
+   * Current pathname — active items can be styled differently in the bar
+   * (currently forwarded as metadata only; visual treatment is up to the
+   * theme).
+   */
+  readonly pathname?: string;
+  /**
+   * Permission keys. Items requiring permissions the user doesn't have are
+   * excluded from the palette.
+   */
+  readonly permissions?: ReadonlyArray<string>;
+  /**
+   * Called when a nav action is selected in the command bar. Receives the
+   * resolved `NavItem`. Default: navigate to `item.href` via `window.location`.
+   */
+  readonly onNavigate?: (item: ResolvedNavItem) => void;
+}
+
+/**
+ * Registers nav items from a `NavConfig` as command-bar actions. Mount
+ * inside a `CommandBarProvider` (e.g. via `<AppShell commandBar>`).
+ *
+ * Renders nothing — side-effect only.
+ *
+ * ```tsx
+ * <AppShell commandBar>
+ *   <CommandBarActions config={NAV} pathname={pathname} />
+ *   {children}
+ * </AppShell>
+ * ```
+ */
+export function CommandBarActions({
+  config,
+  pathname = '/',
+  permissions = [],
+  onNavigate,
+}: CommandBarActionsProps) {
+  const { items } = buildNav({ config, pathname, permissions });
+  const leaves = collectLeaves(items);
+
+  const actions = React.useMemo(
+    () =>
+      leaves.map(({ item, group }) => ({
+        id: `nav:${item.id}`,
+        label: item.label,
+        group: group ?? 'Navigation',
+        icon: item.icon,
+        keywords: item.keywords ? [...item.keywords] : undefined,
+        disabled: item.disabled,
+        perform: () => {
+          if (onNavigate) {
+            onNavigate(item);
+          } else if (item.href) {
+            window.location.href = item.href;
+          }
+        },
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [leaves.length, pathname, permissions.join(',')],
+  );
+
+  useCommandBarActions(actions);
+
+  return null;
+}

--- a/packages/next-shell/src/layout/index.ts
+++ b/packages/next-shell/src/layout/index.ts
@@ -17,6 +17,23 @@
 export { AppShell } from './app-shell.js';
 export type { AppShellProps } from './app-shell.js';
 
+// Navigation system — config-driven sidebar, breadcrumbs, and command-bar actions.
+export { buildNav } from './nav-config.js';
+export type {
+  NavConfig,
+  NavItem,
+  NavMatcher,
+  ResolvedNavItem,
+  BuildNavResult,
+  BuildNavOptions,
+} from './nav-config.js';
+export { SidebarNav } from './sidebar-nav.js';
+export type { SidebarNavProps } from './sidebar-nav.js';
+export { Breadcrumbs } from './breadcrumbs.js';
+export type { BreadcrumbsProps } from './breadcrumbs.js';
+export { CommandBarActions } from './command-bar-actions.js';
+export type { CommandBarActionsProps } from './command-bar-actions.js';
+
 // Stateless content surfaces — also re-exported from `/layout/server`
 // for RSC consumers. Duplicated on both subpaths so the ergonomics are
 // straightforward regardless of the consumer's render context.

--- a/packages/next-shell/src/layout/nav-config.ts
+++ b/packages/next-shell/src/layout/nav-config.ts
@@ -1,0 +1,187 @@
+/**
+ * NavConfig — the single source of truth that drives sidebar, breadcrumbs,
+ * and command-bar entries.
+ *
+ * Usage:
+ * ```ts
+ * const nav: NavConfig = [
+ *   { id: 'dashboard', label: 'Dashboard', href: '/', icon: <HomeIcon /> },
+ *   { id: 'settings', label: 'Settings', href: '/settings',
+ *     requires: 'admin', children: [
+ *       { id: 'profile', label: 'Profile', href: '/settings/profile' },
+ *     ],
+ *   },
+ * ];
+ * const { items } = buildNav({ config: nav, pathname: '/settings/profile' });
+ * ```
+ */
+
+import type * as React from 'react';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Types
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Active-state matching strategy for a nav item.
+ * - `"exact"` — href must equal pathname exactly.
+ * - `"prefix"` — pathname must start with href.
+ * - `RegExp` — applied against pathname.
+ *
+ * Defaults to `"prefix"` so nested pages remain highlighted.
+ */
+export type NavMatcher = 'exact' | 'prefix' | RegExp;
+
+/**
+ * A single node in the navigation tree. Supports arbitrary nesting; the
+ * sidebar collapses sub-trees at the first level, breadcrumbs trace the
+ * path from root to the active leaf, and CommandBar surfaces leaf nodes
+ * as searchable palette actions.
+ */
+export interface NavItem {
+  /** Stable identifier — used as React key and CommandBar action id. */
+  readonly id: string;
+  /** Display label. */
+  readonly label: string;
+  /** Navigation target. Omit for group headings that have no own href. */
+  readonly href?: string;
+  /** Leading icon — rendered in sidebars and command bar. */
+  readonly icon?: React.ReactNode;
+  /** Badge text or count rendered in the sidebar menu button. */
+  readonly badge?: string | number;
+  /** Child items. Rendered as a collapsible sub-menu in the sidebar. */
+  readonly children?: NavItem[];
+  /**
+   * Permission key(s) required to show this item. Omitted from the tree
+   * when the consumer's `permissions` array does not include all keys.
+   */
+  readonly requires?: string | ReadonlyArray<string>;
+  /**
+   * How pathname matching is performed to determine active state.
+   * Defaults to `"prefix"`.
+   */
+  readonly matcher?: NavMatcher;
+  /** Additional keywords surfaced during command-bar fuzzy search. */
+  readonly keywords?: ReadonlyArray<string>;
+  /** Render the item in a disabled (non-clickable) state. */
+  readonly disabled?: boolean;
+}
+
+/** Top-level config — an ordered list of root nav items. */
+export type NavConfig = ReadonlyArray<NavItem>;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Resolved types (output of buildNav)
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export interface ResolvedNavItem extends NavItem {
+  /** Whether this item (or any descendant) matches the current pathname. */
+  readonly active: boolean;
+  /** Recursively resolved children (permission-filtered + active-marked). */
+  readonly children?: ResolvedNavItem[];
+}
+
+export interface BuildNavResult {
+  /** Fully resolved nav tree (permission-filtered, active-marked). */
+  readonly items: ResolvedNavItem[];
+  /**
+   * The path from root → … → current active leaf, in order.
+   * Empty when nothing is active. Used by `<Breadcrumbs>`.
+   */
+  readonly breadcrumbs: ResolvedNavItem[];
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Active matching
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function isActive(item: NavItem, pathname: string): boolean {
+  if (!item.href) return false;
+  const matcher = item.matcher ?? 'prefix';
+  if (matcher === 'exact') return item.href === pathname;
+  if (matcher === 'prefix') return pathname === item.href || pathname.startsWith(item.href + '/');
+  return matcher.test(pathname);
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Permission gating
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function hasPermission(item: NavItem, permissions: ReadonlyArray<string>): boolean {
+  if (!item.requires) return true;
+  const required = Array.isArray(item.requires) ? item.requires : [item.requires];
+  return (required as string[]).every((p) => permissions.includes(p));
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Core builder
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function resolveItem(
+  item: NavItem,
+  pathname: string,
+  permissions: ReadonlyArray<string>,
+): ResolvedNavItem | null {
+  if (!hasPermission(item, permissions)) return null;
+
+  const resolvedChildren = item.children
+    ? (item.children
+        .map((child) => resolveItem(child, pathname, permissions))
+        .filter(Boolean) as ResolvedNavItem[])
+    : undefined;
+
+  const selfActive = isActive(item, pathname);
+  const childActive = resolvedChildren?.some((c) => c.active) ?? false;
+
+  return {
+    ...item,
+    active: selfActive || childActive,
+    children: resolvedChildren?.length ? resolvedChildren : undefined,
+  };
+}
+
+function collectBreadcrumbs(
+  items: ResolvedNavItem[],
+  path: ResolvedNavItem[] = [],
+): ResolvedNavItem[] {
+  for (const item of items) {
+    if (item.active) {
+      const trail = [...path, item];
+      if (item.children) {
+        const deeper = collectBreadcrumbs(item.children, trail);
+        if (deeper.length > trail.length) return deeper;
+      }
+      return trail;
+    }
+  }
+  return [];
+}
+
+export interface BuildNavOptions {
+  readonly config: NavConfig;
+  /** Current route pathname. Defaults to `"/"`. */
+  readonly pathname?: string;
+  /**
+   * Permission keys the current user holds. Items with a `requires` field
+   * are filtered out when any required key is missing.
+   */
+  readonly permissions?: ReadonlyArray<string>;
+}
+
+/**
+ * Resolve a `NavConfig` into an active-marked, permission-filtered tree
+ * plus a breadcrumb trail for the current pathname.
+ */
+export function buildNav({
+  config,
+  pathname = '/',
+  permissions = [],
+}: BuildNavOptions): BuildNavResult {
+  const items = config
+    .map((item) => resolveItem(item, pathname, permissions))
+    .filter(Boolean) as ResolvedNavItem[];
+
+  const breadcrumbs = collectBreadcrumbs(items);
+
+  return { items, breadcrumbs };
+}

--- a/packages/next-shell/src/layout/sidebar-nav.tsx
+++ b/packages/next-shell/src/layout/sidebar-nav.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import * as React from 'react';
+import { ChevronRightIcon } from 'lucide-react';
+
+import { cn } from '@/core/cn';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/primitives/collapsible';
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+} from './sidebar.js';
+import type { ResolvedNavItem } from './nav-config.js';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Sub-item (one nesting level)
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function NavSubItem({
+  item,
+  onNavigate,
+}: {
+  item: ResolvedNavItem;
+  onNavigate?: (item: ResolvedNavItem) => void;
+}) {
+  return (
+    <SidebarMenuSubItem>
+      <SidebarMenuSubButton
+        asChild={Boolean(item.href && !onNavigate)}
+        isActive={item.active}
+        aria-disabled={item.disabled}
+        data-slot="nav-sub-item"
+        data-nav-id={item.id}
+        onClick={onNavigate ? () => onNavigate(item) : undefined}
+      >
+        {item.href && !onNavigate ? (
+          <a href={item.href}>
+            {item.icon}
+            <span>{item.label}</span>
+          </a>
+        ) : (
+          <>
+            {item.icon}
+            <span>{item.label}</span>
+          </>
+        )}
+      </SidebarMenuSubButton>
+    </SidebarMenuSubItem>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Top-level item (collapsible when it has children)
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function NavTopItem({
+  item,
+  onNavigate,
+}: {
+  item: ResolvedNavItem;
+  onNavigate?: (item: ResolvedNavItem) => void;
+}) {
+  const hasChildren = Boolean(item.children?.length);
+
+  if (hasChildren) {
+    return (
+      <Collapsible asChild defaultOpen={item.active} className="group/collapsible">
+        <SidebarMenuItem>
+          <CollapsibleTrigger asChild>
+            <SidebarMenuButton
+              tooltip={item.label}
+              isActive={item.active}
+              disabled={item.disabled}
+              data-slot="nav-item"
+              data-nav-id={item.id}
+            >
+              {item.icon}
+              <span>{item.label}</span>
+              {item.badge !== undefined && <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>}
+              <ChevronRightIcon
+                className={cn(
+                  'ml-auto size-4 transition-transform duration-200',
+                  'group-data-[state=open]/collapsible:rotate-90',
+                )}
+                aria-hidden
+              />
+            </SidebarMenuButton>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <SidebarMenuSub>
+              {item.children!.map((child) => (
+                <NavSubItem key={child.id} item={child} onNavigate={onNavigate} />
+              ))}
+            </SidebarMenuSub>
+          </CollapsibleContent>
+        </SidebarMenuItem>
+      </Collapsible>
+    );
+  }
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        asChild={Boolean(item.href && !onNavigate)}
+        tooltip={item.label}
+        isActive={item.active}
+        disabled={item.disabled}
+        data-slot="nav-item"
+        data-nav-id={item.id}
+        onClick={onNavigate ? () => onNavigate(item) : undefined}
+      >
+        {item.href && !onNavigate ? (
+          <a href={item.href}>
+            {item.icon}
+            <span>{item.label}</span>
+            {item.badge !== undefined && <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>}
+          </a>
+        ) : (
+          <>
+            {item.icon}
+            <span>{item.label}</span>
+            {item.badge !== undefined && <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>}
+          </>
+        )}
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Public component
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export interface SidebarNavProps {
+  /**
+   * Resolved nav items from `buildNav()`. Pass the full tree — the component
+   * handles nested collapsible groups.
+   */
+  readonly items: ReadonlyArray<ResolvedNavItem>;
+  /**
+   * Optional label rendered as a `SidebarGroupLabel` above the menu.
+   * Omit for an unlabelled group.
+   */
+  readonly label?: string;
+  /**
+   * Override the default anchor-tag navigation. Useful with client-side
+   * routers (e.g. `router.push` in Next.js App Router).
+   */
+  readonly onNavigate?: (item: ResolvedNavItem) => void;
+  readonly className?: string;
+}
+
+/**
+ * Renders a resolved `NavConfig` tree as a collapsible sidebar menu.
+ * Compose inside a shadcn `<Sidebar>` element.
+ *
+ * ```tsx
+ * const { items } = buildNav({ config: NAV, pathname });
+ * <Sidebar>
+ *   <SidebarContent>
+ *     <SidebarNav items={items} label="Main" />
+ *   </SidebarContent>
+ * </Sidebar>
+ * ```
+ */
+export function SidebarNav({ items, label, onNavigate, className }: SidebarNavProps) {
+  return (
+    <SidebarGroup className={className}>
+      {label ? <SidebarGroupLabel>{label}</SidebarGroupLabel> : null}
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {items.map((item) => (
+            <NavTopItem key={item.id} item={item} onNavigate={onNavigate} />
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}

--- a/packages/next-shell/tests/nav-config.test.ts
+++ b/packages/next-shell/tests/nav-config.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildNav } from '../src/layout/nav-config.js';
+import type { NavConfig } from '../src/layout/nav-config.js';
+
+const NAV: NavConfig = [
+  { id: 'home', label: 'Home', href: '/', matcher: 'exact' },
+  {
+    id: 'settings',
+    label: 'Settings',
+    href: '/settings',
+    children: [
+      { id: 'profile', label: 'Profile', href: '/settings/profile' },
+      { id: 'security', label: 'Security', href: '/settings/security', requires: 'admin' },
+    ],
+  },
+  { id: 'admin', label: 'Admin', href: '/admin', requires: 'admin' },
+];
+
+describe('buildNav — active matching', () => {
+  it('marks exact matcher item active only when pathname matches exactly', () => {
+    const { items } = buildNav({ config: NAV, pathname: '/' });
+    expect(items.find((i) => i.id === 'home')?.active).toBe(true);
+    const { items: items2 } = buildNav({ config: NAV, pathname: '/other' });
+    expect(items2.find((i) => i.id === 'home')?.active).toBe(false);
+  });
+
+  it('marks prefix item active when pathname starts with href', () => {
+    const { items } = buildNav({ config: NAV, pathname: '/settings/profile' });
+    const settings = items.find((i) => i.id === 'settings');
+    expect(settings?.active).toBe(true);
+  });
+
+  it('marks child item active', () => {
+    const { items } = buildNav({ config: NAV, pathname: '/settings/profile' });
+    const settings = items.find((i) => i.id === 'settings');
+    const profile = settings?.children?.find((c) => c.id === 'profile');
+    expect(profile?.active).toBe(true);
+  });
+
+  it('returns empty breadcrumbs when nothing is active', () => {
+    const { breadcrumbs } = buildNav({ config: NAV, pathname: '/unknown' });
+    expect(breadcrumbs).toHaveLength(0);
+  });
+
+  it('derives breadcrumb trail for a nested active item', () => {
+    const { breadcrumbs } = buildNav({ config: NAV, pathname: '/settings/profile' });
+    expect(breadcrumbs.map((b) => b.id)).toEqual(['settings', 'profile']);
+  });
+
+  it('derives breadcrumb trail for a root active item', () => {
+    const { breadcrumbs } = buildNav({ config: NAV, pathname: '/' });
+    expect(breadcrumbs.map((b) => b.id)).toEqual(['home']);
+  });
+});
+
+describe('buildNav — permission filtering', () => {
+  it('excludes items that require a permission the user lacks', () => {
+    const { items } = buildNav({ config: NAV, pathname: '/', permissions: [] });
+    expect(items.find((i) => i.id === 'admin')).toBeUndefined();
+  });
+
+  it('includes items when the user has the required permission', () => {
+    const { items } = buildNav({ config: NAV, pathname: '/', permissions: ['admin'] });
+    expect(items.find((i) => i.id === 'admin')).toBeDefined();
+  });
+
+  it('excludes gated children but keeps the parent group', () => {
+    const { items } = buildNav({ config: NAV, pathname: '/', permissions: [] });
+    const settings = items.find((i) => i.id === 'settings');
+    expect(settings?.children?.find((c) => c.id === 'security')).toBeUndefined();
+    expect(settings?.children?.find((c) => c.id === 'profile')).toBeDefined();
+  });
+});
+
+describe('buildNav — regex matcher', () => {
+  it('supports RegExp matcher', () => {
+    const regexNav: NavConfig = [
+      { id: 'docs', label: 'Docs', href: '/docs', matcher: /^\/docs(\/.*)?$/ },
+    ];
+    const { items } = buildNav({ config: regexNav, pathname: '/docs/getting-started' });
+    expect(items[0]?.active).toBe(true);
+  });
+});

--- a/packages/next-shell/tests/sidebar-nav.test.tsx
+++ b/packages/next-shell/tests/sidebar-nav.test.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { buildNav } from '../src/layout/nav-config.js';
+import { SidebarNav } from '../src/layout/sidebar-nav.js';
+import { SidebarProvider } from '../src/layout/sidebar.js';
+
+const NAV = [
+  { id: 'home', label: 'Home', href: '/' },
+  {
+    id: 'settings',
+    label: 'Settings',
+    href: '/settings',
+    children: [{ id: 'profile', label: 'Profile', href: '/settings/profile' }],
+  },
+];
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <SidebarProvider>{children}</SidebarProvider>;
+}
+
+describe('SidebarNav', () => {
+  it('renders top-level nav items', () => {
+    const { items } = buildNav({ config: NAV, pathname: '/' });
+    render(<SidebarNav items={items} />, { wrapper: Wrapper });
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  it('renders optional group label', () => {
+    const { items } = buildNav({ config: NAV, pathname: '/' });
+    render(<SidebarNav items={items} label="Main Navigation" />, { wrapper: Wrapper });
+    expect(screen.getByText('Main Navigation')).toBeInTheDocument();
+  });
+
+  it('renders child items inside collapsible', () => {
+    const { items } = buildNav({ config: NAV, pathname: '/settings/profile' });
+    render(<SidebarNav items={items} />, { wrapper: Wrapper });
+    expect(screen.getByText('Profile')).toBeInTheDocument();
+  });
+
+  it('marks active items with data-active attribute', () => {
+    const { items } = buildNav({ config: NAV, pathname: '/' });
+    render(<SidebarNav items={items} />, { wrapper: Wrapper });
+    const homeBtn = screen.getByText('Home').closest('[data-nav-id="home"]');
+    expect(homeBtn).toHaveAttribute('data-active');
+  });
+});


### PR DESCRIPTION
Closes #6 · Refs #13

## Summary

Config-driven navigation system. One `NavConfig` object drives sidebar, breadcrumbs, and command-bar entries consistently.

## What's in the box

### Types + helpers (`nav-config.ts`) — server-safe

| Export | Kind | Purpose |
|--------|------|---------|
| `NavItem` | Type | Node in the nav tree — id, label, href, icon, badge, children, requires, matcher, keywords |
| `NavConfig` | Type | `ReadonlyArray<NavItem>` |
| `NavMatcher` | Type | `'exact' \| 'prefix' \| RegExp` |
| `ResolvedNavItem` | Type | `NavItem` + `active: boolean` |
| `buildNav(opts)` | Function | Permission-filter + active-mark + breadcrumb-trail derivation |

### Components

| Export | Kind | Client? | Purpose |
|--------|------|---------|---------|
| `SidebarNav` | Component | ✓ | Collapsible sidebar menu from resolved items |
| `Breadcrumbs` | Component | — | Auto-derived trail from config + pathname |
| `CommandBarActions` | Component | ✓ | Registers nav leaves as ⌘K palette actions |

### Active matching

```ts
{ id: 'home', href: '/', matcher: 'exact' }          // active only on '/'
{ id: 'docs', href: '/docs' }                         // active on '/docs' + '/docs/*'
{ id: 'blog', href: '/blog', matcher: /^\/blog/ }     // regex
```

### Permission gating

```ts
{ id: 'admin', href: '/admin', requires: 'admin' }    // hidden when 'admin' not in permissions
{ id: 'reports', requires: ['admin', 'reports'] }     // AND semantics
```

## Usage

```tsx
const NAV: NavConfig = [
  { id: 'home', label: 'Home', href: '/', icon: <HomeIcon />, matcher: 'exact' },
  { id: 'settings', label: 'Settings', href: '/settings', children: [
    { id: 'profile', label: 'Profile', href: '/settings/profile' },
    { id: 'security', label: 'Security', href: '/settings/security', requires: 'admin' },
  ]},
];

// Server component / layout
const { items, breadcrumbs } = buildNav({ config: NAV, pathname, permissions });

// Shell
<AppShell
  commandBar
  sidebar={
    <Sidebar>
      <SidebarContent>
        <SidebarNav items={items} label="Main" onNavigate={(i) => router.push(i.href!)} />
      </SidebarContent>
    </Sidebar>
  }
  topBar={<TopBar left={<Breadcrumbs config={NAV} pathname={pathname} />} />}
>
  <CommandBarActions config={NAV} pathname={pathname} onNavigate={(i) => router.push(i.href!)} />
  {children}
</AppShell>
```

## What is intentionally NOT in this PR

- No fuzzy-search library integration — command-bar search uses cmdk's built-in filtering (already works via `keywords` field)
- No mobile drawer nav — deferred to Phase 4f followup or consumer
- No multi-level nesting (>2 deep) in `SidebarNav` — one level of sub-items covers 95% of use cases; deeper nesting deferred

## Verification

```
pnpm format     ✓ ok
pnpm lint       ✓ ok (0 warnings)
pnpm typecheck  ✓ ok
pnpm test       ✓ 399 passed (17 files) — 14 new tests
pnpm build      ✓ ESM + CJS + DTS success
```

## Checklist

- [x] No raw color literals
- [x] `nav-config.ts` is server-safe (no React client imports — `import type` only)
- [x] Permission gating: AND semantics, requires all listed keys
- [x] All 3 matchers work: exact, prefix, RegExp
- [x] `buildNav` breadcrumbs trace root → active leaf correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)