### PR TITLE
feat(phase-7): auth adapter pattern — AuthProvider, hooks, guards, server helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,29 @@
 
 Monorepo for [`@jonmatum/next-shell`](./packages/next-shell) — a reusable Next.js app shell built on **shadcn/ui** primitives with a strict **semantic-token** design system.
 
-> **Status:** Phases 0–3 landed on `main`; Phase 4 (app-shell layout) is in progress. Track phase-by-phase progress in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
+> **Status:** Phases 0–7 landed on `main`. Track phase-by-phase progress in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
 
 ## What's in the box today
 
-| Phase | Surface                                                                                                                                                                                | Status                               |
-| ----: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-|     0 | Monorepo scaffold + CI + publishing skeleton                                                                                                                                           | ✅ Landed                            |
-|     1 | Semantic-token contract + Tailwind v4 preset + OKLCH color tokens                                                                                                                      | ✅ Landed                            |
-|     2 | `ThemeProvider` · `useTheme` · `ThemeToggle` (cycle + dropdown) · SSR cookie helpers                                                                                                   | ✅ Landed                            |
-|     3 | **42 shadcn/ui primitives** vendored from [`shadcn-ui/ui@84d1d476`](https://github.com/shadcn-ui/ui/commit/84d1d476b1d1c6a01c6eeadd95885ce109969b08), each token-audited               | ✅ Landed                            |
-|     4 | Layout primitives: `ContentContainer`, `PageHeader`, `Footer`, `EmptyState`/`ErrorState`/`LoadingState` · SSR sidebar-state cookies · AppShell / Sidebar / TopBar / CommandBar pending | 🟡 In progress                       |
-|     5 | Auth adapters                                                                                                                                                                          | ⏳ Queued                            |
-|     6 | Providers composer                                                                                                                                                                     | ⏳ Queued                            |
-|     7 | Cross-cutting hooks                                                                                                                                                                    | ⏳ Queued                            |
-|     8 | Utilities (`cn`, formatters, guards)                                                                                                                                                   | ⏳ Queued (`cn` shipped in Phase 3a) |
-|     9 | Docs site + Storybook                                                                                                                                                                  | ⏳ Queued                            |
-|    10 | Publishing + changeset release workflow                                                                                                                                                | ⏳ Queued                            |
-|    11 | Integration back into Smart Pad Rules                                                                                                                                                  | ⏳ Queued                            |
+| Phase | Surface                                                                                                                                                                  | Status                               |
+| ----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
+|     0 | Monorepo scaffold + CI + publishing skeleton                                                                                                                             | ✅ Landed                            |
+|     1 | Semantic-token contract + Tailwind v4 preset + OKLCH color tokens                                                                                                        | ✅ Landed                            |
+|     2 | `ThemeProvider` · `useTheme` · `ThemeToggle` (cycle + dropdown) · SSR cookie helpers                                                                                     | ✅ Landed                            |
+|     3 | **42 shadcn/ui primitives** vendored from [`shadcn-ui/ui@84d1d476`](https://github.com/shadcn-ui/ui/commit/84d1d476b1d1c6a01c6eeadd95885ce109969b08), each token-audited | ✅ Landed                            |
+|     4 | `AppShell` · `Sidebar` (4 variants, mobile drawer) · `TopBar` · `CommandBar` (⌘K) · `ContentContainer` · `PageHeader` · `Footer` · status states · SSR sidebar cookie    | ✅ Landed                            |
+|     5 | Navigation system — `buildNav`, `SidebarNav`, `Breadcrumbs`, `CommandBarActions`; permission-gated nav via `requires`                                                    | ✅ Landed                            |
+|     6 | Providers composer — `AppProviders`, `QueryProvider` (TanStack Query v5), `ToastProvider` (Sonner), `ErrorBoundary`, `I18nProvider`                                      | ✅ Landed                            |
+|     7 | Auth adapter pattern — `AuthProvider`, `useSession`, `useUser`, `useHasPermission`, `useRequireAuth`, `SignedIn`, `SignedOut`, `RoleGate`, `requireSession` (server)     | ✅ Landed                            |
+|     8 | Hooks grab-bag (`useDebounce`, `useMedia`, …)                                                                                                                            | ⏳ Queued                            |
+|     9 | Utilities (`cn`, formatters, guards)                                                                                                                                     | ⏳ Queued (`cn` shipped in Phase 3a) |
+|    10 | Docs site + Storybook                                                                                                                                                    | ⏳ Queued                            |
+|    11 | Publishing + changeset release workflow                                                                                                                                  | ⏳ Queued                            |
+|    12 | Integration back into Smart Pad Rules                                                                                                                                    | ⏳ Queued                            |
 
-**42 primitives shipping today** (#20–#27): Accordion, Alert, AlertDialog, AspectRatio, Avatar, Badge, Breadcrumb, Button, Calendar, Card, Carousel, Chart, Checkbox, Collapsible, Command, ContextMenu, Dialog, Drawer, DropdownMenu, Form, HoverCard, Input, InputOTP, Label, Menubar, NavigationMenu, Pagination, Popover, Progress, RadioGroup, Resizable, ScrollArea, Select, Separator, Sheet, Skeleton, Slider, Switch, Table, Tabs, Textarea, Toaster (Sonner), Toggle, ToggleGroup, Tooltip. **328+ unit tests** cover render + interaction + export-surface completeness.
+**42 primitives** (Phase 3): Accordion, Alert, AlertDialog, AspectRatio, Avatar, Badge, Breadcrumb, Button, Calendar, Card, Carousel, Chart, Checkbox, Collapsible, Command, ContextMenu, Dialog, Drawer, DropdownMenu, Form, HoverCard, Input, InputOTP, Label, Menubar, NavigationMenu, Pagination, Popover, Progress, RadioGroup, Resizable, ScrollArea, Select, Separator, Sheet, Skeleton, Slider, Switch, Table, Tabs, Textarea, Toaster (Sonner), Toggle, ToggleGroup, Tooltip.
+
+**441 unit tests** across 19 test files cover render, interaction, SSR helpers, provider composition, auth adapter contracts, and export-surface completeness.
 
 Deliberately **not** vendored (composed patterns documented as consumer-side recipes): DatePicker (Popover + Calendar + Button), DataTable (Table + `@tanstack/react-table`), Typography (styling-guide h1/h2/p patterns).
 
@@ -55,7 +58,7 @@ nvm use              # Node version from .nvmrc
 pnpm install
 pnpm lint            # eslint --max-warnings=0
 pnpm typecheck
-pnpm test            # vitest run (328 tests)
+pnpm test            # vitest run (441 tests)
 pnpm build           # tsup + tailwind preset + DTS
 ```
 

--- a/packages/next-shell/README.md
+++ b/packages/next-shell/README.md
@@ -2,7 +2,7 @@
 
 Reusable Next.js app shell built on **shadcn/ui** primitives with a strict **semantic-token** design system.
 
-> **Status:** Phases 1–3 usable today (tokens, theming, 42 primitives). Phase 4 (app-shell layout) in progress. Follow the rollout in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
+> **Status:** Phases 0–7 landed on `main` (tokens, theming, 42 primitives, full layout shell, nav system, providers, auth adapters). Follow the rollout in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
 
 ## Install
 
@@ -89,23 +89,86 @@ Every primitive ships with `data-slot` attributes for custom-styling hooks, `ari
 
 ## Subpath entry points
 
-| Import                                   | Surface                                                                            | Status     |
-| ---------------------------------------- | ---------------------------------------------------------------------------------- | ---------- |
-| `@jonmatum/next-shell`                   | Root barrel — `cn`, `packageVersion`, `tokenSchemaVersion`                         | ✅         |
-| `@jonmatum/next-shell/core`              | `cn`, `packageVersion`                                                             | ✅         |
-| `@jonmatum/next-shell/primitives`        | 42 shadcn/ui primitives (client)                                                   | ✅         |
-| `@jonmatum/next-shell/providers`         | `ThemeProvider`, `ThemeToggle`, `ThemeToggleDropdown`, `useTheme` (client)         | ✅         |
-| `@jonmatum/next-shell/providers/server`  | SSR theme cookie helpers (server-safe)                                             | ✅         |
-| `@jonmatum/next-shell/layout`            | `ContentContainer`, `PageHeader`, `Footer`, status states + sidebar state types    | 🟡 partial |
-| `@jonmatum/next-shell/layout/server`     | SSR sidebar-state cookie helpers (server-safe)                                     | ✅         |
-| `@jonmatum/next-shell/tokens`            | TS view of the semantic-token contract — literal unions, `cssVar`, brand overrides | ✅         |
-| `@jonmatum/next-shell/tailwind-preset`   | Tailwind v4 preset (maps tokens → `@theme` keys)                                   | ✅         |
-| `@jonmatum/next-shell/styles/tokens.css` | Token CSS (custom properties for `:root` + `[data-theme="dark"]`)                  | ✅         |
-| `@jonmatum/next-shell/styles/preset.css` | Combined preset (tokens + `tw-animate-css` + Tailwind `@theme` mappings)           | ✅         |
-| `@jonmatum/next-shell/auth`              | Auth adapter interface                                                             | ⏳ Phase 5 |
-| `@jonmatum/next-shell/hooks`             | Cross-cutting hooks                                                                | ⏳ Phase 7 |
+| Import                                   | Surface                                                                                                            | Status     |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------- |
+| `@jonmatum/next-shell`                   | Root barrel — `cn`, `packageVersion`, `tokenSchemaVersion`                                                         | ✅         |
+| `@jonmatum/next-shell/core`              | `cn`, `packageVersion`                                                                                             | ✅         |
+| `@jonmatum/next-shell/primitives`        | 42 shadcn/ui primitives (client)                                                                                   | ✅         |
+| `@jonmatum/next-shell/providers`         | `AppProviders`, `ThemeProvider`, `QueryProvider`, `ToastProvider`, `ErrorBoundary`, `I18nProvider` (client)        | ✅         |
+| `@jonmatum/next-shell/providers/server`  | SSR theme cookie helpers (server-safe)                                                                             | ✅         |
+| `@jonmatum/next-shell/layout`            | `AppShell`, `Sidebar`, `TopBar`, `CommandBar`, `ContentContainer`, `PageHeader`, `Footer`, nav + status helpers    | ✅         |
+| `@jonmatum/next-shell/layout/server`     | SSR sidebar-state cookie helpers (server-safe)                                                                     | ✅         |
+| `@jonmatum/next-shell/auth`              | `AuthProvider`, `useSession`, `useUser`, `useHasPermission`, `useRequireAuth`, `SignedIn`, `SignedOut`, `RoleGate` | ✅         |
+| `@jonmatum/next-shell/auth/server`       | `requireSession` — throws `AuthRequiredError` (401) for Route Handlers (server-safe)                               | ✅         |
+| `@jonmatum/next-shell/auth/nextauth`     | `createNextAuthAdapter` — Auth.js v5 wrapper (optional peer: `next-auth >= 5`)                                     | ✅         |
+| `@jonmatum/next-shell/auth/mock`         | `createMockAuthAdapter` — zero-dep adapter for tests and Storybook                                                 | ✅         |
+| `@jonmatum/next-shell/tokens`            | TS view of the semantic-token contract — literal unions, `cssVar`, brand overrides                                 | ✅         |
+| `@jonmatum/next-shell/tailwind-preset`   | Tailwind v4 preset (maps tokens → `@theme` keys)                                                                   | ✅         |
+| `@jonmatum/next-shell/styles/tokens.css` | Token CSS (custom properties for `:root` + `[data-theme="dark"]`)                                                  | ✅         |
+| `@jonmatum/next-shell/styles/preset.css` | Combined preset (tokens + `tw-animate-css` + Tailwind `@theme` mappings)                                           | ✅         |
+| `@jonmatum/next-shell/hooks`             | Cross-cutting hooks (`useDebounce`, `useMedia`, …)                                                                 | ⏳ Phase 8 |
 
 Subpath imports tree-shake cleanly — importing only `@jonmatum/next-shell/primitives` does not pull in providers, and vice versa.
+
+## Auth adapter pattern
+
+Wire in Auth.js v5 (or any backend) in three lines:
+
+```tsx
+// app/layout.tsx
+import { createNextAuthAdapter } from '@jonmatum/next-shell/auth/nextauth';
+import { auth } from '@/auth'; // your Auth.js handler
+import { AuthProvider } from '@jonmatum/next-shell/auth';
+
+<AuthProvider adapter={createNextAuthAdapter({ getServerSession: auth })}>{children}</AuthProvider>;
+```
+
+Guard routes and UI with the built-in hooks and components:
+
+```tsx
+import { SignedIn, SignedOut, RoleGate, useUser } from '@jonmatum/next-shell/auth';
+
+function Nav() {
+  const user = useUser();
+  return (
+    <>
+      <SignedIn>
+        <span>Hello, {user?.name}</span>
+      </SignedIn>
+      <SignedOut>
+        <a href="/login">Sign in</a>
+      </SignedOut>
+      <RoleGate role="admin">
+        <a href="/admin">Admin</a>
+      </RoleGate>
+    </>
+  );
+}
+```
+
+Protect Route Handlers server-side:
+
+```ts
+import { requireSession } from '@jonmatum/next-shell/auth/server';
+import { auth } from '@/auth';
+
+export async function GET() {
+  const session = await requireSession(auth); // throws 401 if unauthenticated
+  return Response.json({ user: session.user });
+}
+```
+
+Swap to the mock adapter for tests — no config changes needed in components:
+
+```tsx
+import { createMockAuthAdapter } from '@jonmatum/next-shell/auth/mock';
+
+render(
+  <AuthProvider adapter={createMockAuthAdapter({ user: { id: '1', roles: ['admin'] } })}>
+    <MyComponent />
+  </AuthProvider>,
+);
+```
 
 ## Semantic tokens
 

--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -72,6 +72,21 @@
       "import": "./dist/auth/index.js",
       "require": "./dist/auth/index.cjs"
     },
+    "./auth/server": {
+      "types": "./dist/auth/server/index.d.ts",
+      "import": "./dist/auth/server/index.js",
+      "require": "./dist/auth/server/index.cjs"
+    },
+    "./auth/nextauth": {
+      "types": "./dist/auth/adapters/nextauth.d.ts",
+      "import": "./dist/auth/adapters/nextauth.js",
+      "require": "./dist/auth/adapters/nextauth.cjs"
+    },
+    "./auth/mock": {
+      "types": "./dist/auth/adapters/mock.d.ts",
+      "import": "./dist/auth/adapters/mock.js",
+      "require": "./dist/auth/adapters/mock.cjs"
+    },
     "./hooks": {
       "types": "./dist/hooks/index.d.ts",
       "import": "./dist/hooks/index.js",
@@ -105,12 +120,16 @@
   },
   "peerDependencies": {
     "next": "^15.0.0",
+    "next-auth": ">=5.0.0-beta.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {
+      "optional": true
+    },
+    "next-auth": {
       "optional": true
     }
   },

--- a/packages/next-shell/src/auth/adapters/mock.ts
+++ b/packages/next-shell/src/auth/adapters/mock.ts
@@ -1,0 +1,73 @@
+/**
+ * Mock auth adapter — deterministic, zero-dependency, no React required.
+ *
+ * Designed for unit / integration tests and Storybook. Swap in place of
+ * `createNextAuthAdapter` without touching consumer component code.
+ *
+ * ```tsx
+ * import { createMockAuthAdapter } from '@jonmatum/next-shell/auth/mock';
+ * import { AuthProvider } from '@jonmatum/next-shell/auth';
+ *
+ * render(
+ *   <AuthProvider adapter={createMockAuthAdapter({ user: { id: '1', roles: ['admin'] } })}>
+ *     <MyComponent />
+ *   </AuthProvider>,
+ * );
+ * ```
+ */
+
+import type { AuthAdapter, AuthSession, AuthUser } from '../auth-types.js';
+
+export interface MockAuthOptions {
+  /**
+   * Pre-seeded user. Omit to simulate an unauthenticated session.
+   * Pass `null` explicitly to simulate a signed-out state.
+   */
+  readonly user?: AuthUser | null;
+  /**
+   * Override the session expiry (ISO-8601). Defaults to a date far in
+   * the future so tests don't have to care about it.
+   */
+  readonly expires?: string;
+  /** Simulate the loading state. Defaults to `false`. */
+  readonly loading?: boolean;
+  /** Spy on sign-in calls in tests. */
+  readonly onSignIn?: (options?: Record<string, unknown>) => void;
+  /** Spy on sign-out calls in tests. */
+  readonly onSignOut?: (options?: Record<string, unknown>) => void;
+}
+
+export function createMockAuthAdapter(options?: MockAuthOptions): AuthAdapter {
+  const {
+    user = null,
+    expires = '2099-12-31T23:59:59.000Z',
+    loading = false,
+    onSignIn,
+    onSignOut,
+  } = options ?? {};
+
+  const session: AuthSession | null = user != null ? { user, expires } : null;
+
+  return {
+    useSession() {
+      if (loading) return { data: null, status: 'loading' };
+      return {
+        data: session,
+        status: session ? 'authenticated' : 'unauthenticated',
+      };
+    },
+
+    async signIn(opts) {
+      onSignIn?.(opts);
+    },
+
+    async signOut(opts) {
+      onSignOut?.(opts);
+    },
+
+    async getServerSession() {
+      if (loading) return null;
+      return session;
+    },
+  };
+}

--- a/packages/next-shell/src/auth/adapters/next-auth-react.d.ts
+++ b/packages/next-shell/src/auth/adapters/next-auth-react.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Minimal ambient declarations for `next-auth/react`.
+ * next-auth is an optional peer dependency — these declarations keep
+ * TypeScript happy without installing the package. Consumers who import
+ * `@jonmatum/next-shell/auth/nextauth` must install `next-auth >= 5`.
+ */
+declare module 'next-auth/react' {
+  export function useSession(): {
+    data: unknown;
+    status: 'loading' | 'authenticated' | 'unauthenticated';
+  };
+  export function signIn(provider?: string, options?: Record<string, unknown>): Promise<unknown>;
+  export function signOut(options?: Record<string, unknown>): Promise<unknown>;
+}

--- a/packages/next-shell/src/auth/adapters/nextauth.ts
+++ b/packages/next-shell/src/auth/adapters/nextauth.ts
@@ -1,0 +1,65 @@
+'use client';
+
+/**
+ * Auth.js v5 (next-auth@5) adapter for `<AuthProvider>`.
+ *
+ * Peer dependency: `next-auth >= 5.0.0-beta.0` (optional — only
+ * needed when this adapter is used).
+ *
+ * ```tsx
+ * // app/layout.tsx
+ * import { createNextAuthAdapter } from '@jonmatum/next-shell/auth/nextauth';
+ * import { auth } from '@/auth';     // your Auth.js handler
+ * import { AuthProvider } from '@jonmatum/next-shell/auth';
+ *
+ * export default function RootLayout({ children }) {
+ *   return (
+ *     <AuthProvider adapter={createNextAuthAdapter({ getServerSession: auth })}>
+ *       {children}
+ *     </AuthProvider>
+ *   );
+ * }
+ * ```
+ */
+
+// next-auth is an optional peer dependency — consumers must install it.
+// Types are declared in `./next-auth-react.d.ts` so TypeScript resolves
+// without the package being installed locally.
+import {
+  useSession as useNextAuthSession,
+  signIn as nextAuthSignIn,
+  signOut as nextAuthSignOut,
+} from 'next-auth/react';
+
+import type { AuthAdapter, AuthSession } from '../auth-types.js';
+
+export interface CreateNextAuthAdapterOptions {
+  /**
+   * Server-side session getter — pass your Auth.js `auth` export here.
+   * Used by `requireSession()` in Route Handlers and Server Components.
+   */
+  readonly getServerSession?: () => Promise<AuthSession | null>;
+}
+
+export function createNextAuthAdapter(options?: CreateNextAuthAdapterOptions): AuthAdapter {
+  return {
+    useSession() {
+      const { data, status } = useNextAuthSession();
+      return {
+        data: data as AuthSession | null,
+        status,
+      };
+    },
+
+    async signIn(opts) {
+      const { provider, ...rest } = (opts ?? {}) as { provider?: string } & Record<string, unknown>;
+      await nextAuthSignIn(provider, rest);
+    },
+
+    async signOut(opts) {
+      await nextAuthSignOut(opts);
+    },
+
+    getServerSession: options?.getServerSession,
+  };
+}

--- a/packages/next-shell/src/auth/auth-provider.tsx
+++ b/packages/next-shell/src/auth/auth-provider.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import * as React from 'react';
+
+import type { AuthAdapter } from './auth-types.js';
+
+export type { AuthAdapter };
+
+const AuthContext = React.createContext<AuthAdapter | null>(null);
+
+export interface AuthProviderProps {
+  readonly children: React.ReactNode;
+  readonly adapter: AuthAdapter;
+}
+
+export function AuthProvider({ children, adapter }: AuthProviderProps) {
+  return <AuthContext.Provider value={adapter}>{children}</AuthContext.Provider>;
+}
+
+export function useAuthAdapter(): AuthAdapter {
+  const ctx = React.useContext(AuthContext);
+  if (!ctx) {
+    throw new Error(
+      '[next-shell] useAuthAdapter must be called inside <AuthProvider>. ' +
+        'Wrap your app with <AuthProvider adapter={...}>.',
+    );
+  }
+  return ctx;
+}

--- a/packages/next-shell/src/auth/auth-types.ts
+++ b/packages/next-shell/src/auth/auth-types.ts
@@ -1,0 +1,47 @@
+/**
+ * Core auth types — shared between client surface, server helpers,
+ * and all adapters. No runtime code; safe to import anywhere.
+ */
+
+export interface AuthUser {
+  readonly id: string;
+  readonly email?: string | null;
+  readonly name?: string | null;
+  readonly image?: string | null;
+  /** Role or permission keys — matched against nav `requires` fields. */
+  readonly roles?: ReadonlyArray<string>;
+  /** OAuth / custom scopes. */
+  readonly scopes?: ReadonlyArray<string>;
+}
+
+export interface AuthSession {
+  readonly user: AuthUser;
+  /** ISO-8601 expiry timestamp. */
+  readonly expires: string;
+}
+
+export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+
+export interface SessionResult {
+  readonly data: AuthSession | null;
+  readonly status: AuthStatus;
+}
+
+/**
+ * Minimal adapter contract. Plug in Auth.js, Clerk, Supabase Auth, etc.
+ * by implementing this interface and passing the instance to `<AuthProvider>`.
+ *
+ * `useSession` is intentionally a hook signature — it will be called inside
+ * React render. Adapters that wrap third-party hooks (e.g. `next-auth/react`)
+ * should forward to those hooks here.
+ */
+export interface AuthAdapter {
+  useSession(): SessionResult;
+  signIn(options?: Record<string, unknown>): Promise<void>;
+  signOut(options?: Record<string, unknown>): Promise<void>;
+  /**
+   * Optional server-side session getter for Route Handlers and Server
+   * Components. Returns `null` when no session is active.
+   */
+  getServerSession?(): Promise<AuthSession | null>;
+}

--- a/packages/next-shell/src/auth/components.tsx
+++ b/packages/next-shell/src/auth/components.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import * as React from 'react';
+
+import { useHasPermission, useSession } from './hooks.js';
+
+export interface SignedInProps {
+  readonly children: React.ReactNode;
+  /** Content to render while the session status is `'loading'`. */
+  readonly fallback?: React.ReactNode;
+}
+
+/** Renders `children` only when the user is authenticated. */
+export function SignedIn({ children, fallback = null }: SignedInProps): React.ReactNode {
+  const { status } = useSession();
+  if (status === 'loading') return fallback;
+  if (status !== 'authenticated') return null;
+  return <>{children}</>;
+}
+
+export interface SignedOutProps {
+  readonly children: React.ReactNode;
+  readonly fallback?: React.ReactNode;
+}
+
+/** Renders `children` only when the user is NOT authenticated. */
+export function SignedOut({ children, fallback = null }: SignedOutProps): React.ReactNode {
+  const { status } = useSession();
+  if (status === 'loading') return fallback;
+  if (status !== 'unauthenticated') return null;
+  return <>{children}</>;
+}
+
+export interface RoleGateProps {
+  /**
+   * Role(s) or scope(s) the current user must hold (AND semantics —
+   * every listed value must be present). Mirrors the nav `requires` field.
+   */
+  readonly role: string | ReadonlyArray<string>;
+  readonly children: React.ReactNode;
+  /** Rendered when the permission check fails. Defaults to `null`. */
+  readonly fallback?: React.ReactNode;
+}
+
+/** Renders `children` only when the user holds all required roles/scopes. */
+export function RoleGate({ role, children, fallback = null }: RoleGateProps): React.ReactNode {
+  const allowed = useHasPermission(role);
+  if (!allowed) return fallback;
+  return <>{children}</>;
+}

--- a/packages/next-shell/src/auth/hooks.ts
+++ b/packages/next-shell/src/auth/hooks.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import type { AuthSession, AuthStatus, AuthUser, SessionResult } from './auth-types.js';
+import { useAuthAdapter } from './auth-provider.js';
+
+export type { AuthSession, AuthStatus, AuthUser, SessionResult };
+
+/** Returns the raw session result (data + status) from the active adapter. */
+export function useSession(): SessionResult {
+  return useAuthAdapter().useSession();
+}
+
+/** Returns the current user or `null` when unauthenticated / loading. */
+export function useUser(): AuthUser | null {
+  const { data } = useSession();
+  return data?.user ?? null;
+}
+
+/**
+ * Returns the current user and throws a Suspense promise while the
+ * session is loading, or a redirect-friendly `AuthRequiredError` when
+ * unauthenticated. Pair with `React.Suspense` and an error boundary.
+ */
+export function useRequireAuth(): AuthUser {
+  const { data, status } = useSession();
+  if (status === 'loading') {
+    // Suspend until the session resolves. Throwing a Promise is the
+    // React Suspense contract — not a real error throw.
+    throw new Promise<void>(() => {});
+  }
+  if (status !== 'authenticated' || !data?.user) {
+    throw new AuthRequiredError();
+  }
+  return data.user;
+}
+
+/**
+ * Returns `true` when the current user holds ALL of the given roles or
+ * scopes. Checks both `user.roles` and `user.scopes`, so a single
+ * `requires` value can refer to either.
+ */
+export function useHasPermission(roleOrScope: string | ReadonlyArray<string>): boolean {
+  const user = useUser();
+  if (!user) return false;
+  const required = Array.isArray(roleOrScope) ? roleOrScope : [roleOrScope];
+  const granted = [...(user.roles ?? []), ...(user.scopes ?? [])];
+  return required.every((r) => granted.includes(r));
+}
+
+export class AuthRequiredError extends Error {
+  constructor() {
+    super('Authentication required');
+    this.name = 'AuthRequiredError';
+  }
+}

--- a/packages/next-shell/src/auth/index.ts
+++ b/packages/next-shell/src/auth/index.ts
@@ -1,9 +1,32 @@
+'use client';
+
 /**
- * Auth adapter pattern — pluggable auth for any backend (Auth.js v5 adapter
- * shipped first-party).
+ * Auth subpath — client surface.
  *
- * See the Phase 7 issue for the full specification.
- * This module is scaffolded during Phase 0 and populated in Phase 7.
+ * ```tsx
+ * import { AuthProvider, useSession, SignedIn, RoleGate } from '@jonmatum/next-shell/auth';
+ * ```
+ *
+ * Plug in an adapter (nextauth, mock, or custom) via `<AuthProvider adapter={...}>`.
+ * Server helpers live at `@jonmatum/next-shell/auth/server`.
+ * The Auth.js v5 adapter lives at `@jonmatum/next-shell/auth/nextauth`.
+ * The mock adapter for tests lives at `@jonmatum/next-shell/auth/mock`.
  */
 
-export {};
+// ── Context + adapter contract ─────────────────────────────────────────────
+export { AuthProvider } from './auth-provider.js';
+export type { AuthProviderProps, AuthAdapter } from './auth-provider.js';
+
+// ── Hooks ──────────────────────────────────────────────────────────────────
+export {
+  useSession,
+  useUser,
+  useRequireAuth,
+  useHasPermission,
+  AuthRequiredError,
+} from './hooks.js';
+export type { AuthSession, AuthUser, AuthStatus, SessionResult } from './hooks.js';
+
+// ── Components ────────────────────────────────────────────────────────────
+export { SignedIn, SignedOut, RoleGate } from './components.js';
+export type { SignedInProps, SignedOutProps, RoleGateProps } from './components.js';

--- a/packages/next-shell/src/auth/server/index.ts
+++ b/packages/next-shell/src/auth/server/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Auth server helpers — safe to import from Server Components and
+ * Route Handlers. No `'use client'` directive; no React imports.
+ *
+ * ```ts
+ * import { requireSession } from '@jonmatum/next-shell/auth/server';
+ * ```
+ */
+
+export type { AuthSession, AuthUser, AuthStatus, SessionResult } from '../auth-types.js';
+
+export class AuthRequiredError extends Error {
+  readonly statusCode = 401;
+
+  constructor(message = 'Authentication required') {
+    super(message);
+    this.name = 'AuthRequiredError';
+  }
+}
+
+/**
+ * Asserts that a session exists, throwing `AuthRequiredError` (HTTP 401)
+ * when not. Use inside Route Handlers and async Server Components.
+ *
+ * ```ts
+ * // app/api/protected/route.ts
+ * import { requireSession } from '@jonmatum/next-shell/auth/server';
+ * import { auth } from '@/auth';  // your Auth.js handler
+ *
+ * export async function GET() {
+ *   const session = await requireSession(auth);
+ *   return Response.json({ user: session.user });
+ * }
+ * ```
+ */
+export async function requireSession<T extends { user: unknown; expires: string }>(
+  getSession: () => Promise<T | null>,
+): Promise<T> {
+  const session = await getSession();
+  if (!session) throw new AuthRequiredError();
+  return session;
+}

--- a/packages/next-shell/tests/auth.test.tsx
+++ b/packages/next-shell/tests/auth.test.tsx
@@ -1,0 +1,276 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  AuthProvider,
+  useSession,
+  useUser,
+  useHasPermission,
+  SignedIn,
+  SignedOut,
+  RoleGate,
+  AuthRequiredError,
+} from '../src/auth/index.js';
+import { createMockAuthAdapter } from '../src/auth/adapters/mock.js';
+import {
+  requireSession,
+  AuthRequiredError as ServerAuthRequiredError,
+} from '../src/auth/server/index.js';
+
+/* ── helpers ──────────────────────────────────────────────────────────────── */
+
+function renderWithAuth(ui: React.ReactElement, adapter = createMockAuthAdapter()) {
+  return render(<AuthProvider adapter={adapter}>{ui}</AuthProvider>);
+}
+
+/* ── createMockAuthAdapter ────────────────────────────────────────────────── */
+
+describe('createMockAuthAdapter', () => {
+  it('returns unauthenticated status when no user provided', () => {
+    const adapter = createMockAuthAdapter();
+    expect(adapter.useSession()).toEqual({ data: null, status: 'unauthenticated' });
+  });
+
+  it('returns authenticated status when user is provided', () => {
+    const adapter = createMockAuthAdapter({ user: { id: '1', name: 'Alice' } });
+    const { data, status } = adapter.useSession();
+    expect(status).toBe('authenticated');
+    expect(data?.user.name).toBe('Alice');
+  });
+
+  it('returns loading status when loading=true', () => {
+    const adapter = createMockAuthAdapter({ loading: true });
+    expect(adapter.useSession().status).toBe('loading');
+  });
+
+  it('calls onSignIn spy', async () => {
+    const onSignIn = vi.fn();
+    const adapter = createMockAuthAdapter({ onSignIn });
+    await adapter.signIn({ provider: 'github' });
+    expect(onSignIn).toHaveBeenCalledWith({ provider: 'github' });
+  });
+
+  it('calls onSignOut spy', async () => {
+    const onSignOut = vi.fn();
+    const adapter = createMockAuthAdapter({ onSignOut });
+    await adapter.signOut();
+    expect(onSignOut).toHaveBeenCalled();
+  });
+
+  it('getServerSession returns session when user is set', async () => {
+    const adapter = createMockAuthAdapter({ user: { id: '42' } });
+    const session = await adapter.getServerSession!();
+    expect(session?.user.id).toBe('42');
+  });
+
+  it('getServerSession returns null when no user', async () => {
+    const adapter = createMockAuthAdapter();
+    expect(await adapter.getServerSession!()).toBeNull();
+  });
+});
+
+/* ── useSession / useUser ─────────────────────────────────────────────────── */
+
+describe('useSession', () => {
+  it('exposes status from adapter', () => {
+    function Probe() {
+      const { status } = useSession();
+      return <span data-testid="status">{status}</span>;
+    }
+    renderWithAuth(<Probe />, createMockAuthAdapter({ user: { id: '1' } }));
+    expect(screen.getByTestId('status')).toHaveTextContent('authenticated');
+  });
+});
+
+describe('useUser', () => {
+  it('returns null when unauthenticated', () => {
+    function Probe() {
+      const user = useUser();
+      return <span data-testid="val">{user === null ? 'null' : user.id}</span>;
+    }
+    renderWithAuth(<Probe />);
+    expect(screen.getByTestId('val')).toHaveTextContent('null');
+  });
+
+  it('returns user when authenticated', () => {
+    function Probe() {
+      const user = useUser();
+      return <span data-testid="val">{user?.name ?? 'none'}</span>;
+    }
+    renderWithAuth(<Probe />, createMockAuthAdapter({ user: { id: '1', name: 'Bob' } }));
+    expect(screen.getByTestId('val')).toHaveTextContent('Bob');
+  });
+});
+
+/* ── useHasPermission ─────────────────────────────────────────────────────── */
+
+describe('useHasPermission', () => {
+  it('returns false when unauthenticated', () => {
+    function Probe() {
+      const ok = useHasPermission('admin');
+      return <span data-testid="val">{ok ? 'yes' : 'no'}</span>;
+    }
+    renderWithAuth(<Probe />);
+    expect(screen.getByTestId('val')).toHaveTextContent('no');
+  });
+
+  it('returns true when user has the role', () => {
+    function Probe() {
+      const ok = useHasPermission('admin');
+      return <span data-testid="val">{ok ? 'yes' : 'no'}</span>;
+    }
+    renderWithAuth(
+      <Probe />,
+      createMockAuthAdapter({ user: { id: '1', roles: ['admin', 'editor'] } }),
+    );
+    expect(screen.getByTestId('val')).toHaveTextContent('yes');
+  });
+
+  it('returns true when user has the scope', () => {
+    function Probe() {
+      const ok = useHasPermission('read:posts');
+      return <span data-testid="val">{ok ? 'yes' : 'no'}</span>;
+    }
+    renderWithAuth(<Probe />, createMockAuthAdapter({ user: { id: '1', scopes: ['read:posts'] } }));
+    expect(screen.getByTestId('val')).toHaveTextContent('yes');
+  });
+
+  it('returns false when user lacks role', () => {
+    function Probe() {
+      const ok = useHasPermission('superadmin');
+      return <span data-testid="val">{ok ? 'yes' : 'no'}</span>;
+    }
+    renderWithAuth(<Probe />, createMockAuthAdapter({ user: { id: '1', roles: ['editor'] } }));
+    expect(screen.getByTestId('val')).toHaveTextContent('no');
+  });
+
+  it('AND semantics — all roles must be present', () => {
+    function Probe() {
+      const ok = useHasPermission(['admin', 'editor']);
+      return <span data-testid="val">{ok ? 'yes' : 'no'}</span>;
+    }
+    renderWithAuth(<Probe />, createMockAuthAdapter({ user: { id: '1', roles: ['admin'] } }));
+    expect(screen.getByTestId('val')).toHaveTextContent('no');
+  });
+});
+
+/* ── SignedIn / SignedOut ─────────────────────────────────────────────────── */
+
+describe('SignedIn', () => {
+  it('renders children when authenticated', () => {
+    renderWithAuth(
+      <SignedIn>
+        <span data-testid="content">secret</span>
+      </SignedIn>,
+      createMockAuthAdapter({ user: { id: '1' } }),
+    );
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+  });
+
+  it('hides children when unauthenticated', () => {
+    renderWithAuth(
+      <SignedIn>
+        <span data-testid="content">secret</span>
+      </SignedIn>,
+    );
+    expect(screen.queryByTestId('content')).not.toBeInTheDocument();
+  });
+
+  it('renders fallback while loading', () => {
+    renderWithAuth(
+      <SignedIn fallback={<span data-testid="loading">…</span>}>
+        <span data-testid="content">secret</span>
+      </SignedIn>,
+      createMockAuthAdapter({ loading: true }),
+    );
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('content')).not.toBeInTheDocument();
+  });
+});
+
+describe('SignedOut', () => {
+  it('renders children when unauthenticated', () => {
+    renderWithAuth(
+      <SignedOut>
+        <span data-testid="login">login</span>
+      </SignedOut>,
+    );
+    expect(screen.getByTestId('login')).toBeInTheDocument();
+  });
+
+  it('hides children when authenticated', () => {
+    renderWithAuth(
+      <SignedOut>
+        <span data-testid="login">login</span>
+      </SignedOut>,
+      createMockAuthAdapter({ user: { id: '1' } }),
+    );
+    expect(screen.queryByTestId('login')).not.toBeInTheDocument();
+  });
+});
+
+/* ── RoleGate ─────────────────────────────────────────────────────────────── */
+
+describe('RoleGate', () => {
+  it('renders children when user has role', () => {
+    renderWithAuth(
+      <RoleGate role="admin">
+        <span data-testid="content">admin panel</span>
+      </RoleGate>,
+      createMockAuthAdapter({ user: { id: '1', roles: ['admin'] } }),
+    );
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+  });
+
+  it('hides children when user lacks role', () => {
+    renderWithAuth(
+      <RoleGate role="admin">
+        <span data-testid="content">admin panel</span>
+      </RoleGate>,
+      createMockAuthAdapter({ user: { id: '1', roles: ['editor'] } }),
+    );
+    expect(screen.queryByTestId('content')).not.toBeInTheDocument();
+  });
+
+  it('renders fallback when user lacks role', () => {
+    renderWithAuth(
+      <RoleGate role="admin" fallback={<span data-testid="denied">denied</span>}>
+        <span data-testid="content">admin panel</span>
+      </RoleGate>,
+      createMockAuthAdapter({ user: { id: '1' } }),
+    );
+    expect(screen.getByTestId('denied')).toBeInTheDocument();
+  });
+});
+
+/* ── AuthRequiredError ───────────────────────────────────────────────────── */
+
+describe('AuthRequiredError', () => {
+  it('is an Error instance with correct name', () => {
+    const err = new AuthRequiredError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('AuthRequiredError');
+    expect(err.message).toBe('Authentication required');
+  });
+});
+
+/* ── requireSession (server) ─────────────────────────────────────────────── */
+
+describe('requireSession', () => {
+  it('returns the session when one exists', async () => {
+    const fakeSession = { user: { id: '7' }, expires: '2099-01-01' };
+    const getSession = async () => fakeSession;
+    const result = await requireSession(getSession);
+    expect(result).toBe(fakeSession);
+  });
+
+  it('throws ServerAuthRequiredError when session is null', async () => {
+    await expect(requireSession(async () => null)).rejects.toBeInstanceOf(ServerAuthRequiredError);
+  });
+
+  it('ServerAuthRequiredError has statusCode 401', () => {
+    const err = new ServerAuthRequiredError();
+    expect(err.statusCode).toBe(401);
+  });
+});

--- a/packages/next-shell/tsup.config.ts
+++ b/packages/next-shell/tsup.config.ts
@@ -11,6 +11,8 @@ import { existsSync } from 'node:fs';
  * the build completes.
  */
 const CLIENT_ENTRIES = [
+  'auth/index',
+  'auth/adapters/nextauth',
   'providers/index',
   'primitives/index',
   'layout/index',
@@ -34,6 +36,9 @@ export default defineConfig({
     'providers/index': 'src/providers/index.ts',
     'providers/server/index': 'src/providers/server/index.ts',
     'auth/index': 'src/auth/index.ts',
+    'auth/server/index': 'src/auth/server/index.ts',
+    'auth/adapters/nextauth': 'src/auth/adapters/nextauth.ts',
+    'auth/adapters/mock': 'src/auth/adapters/mock.ts',
     'hooks/index': 'src/hooks/index.ts',
     'tokens/index': 'src/tokens/index.ts',
     'tailwind-preset/index': 'src/tailwind-preset/index.ts',
@@ -45,7 +50,7 @@ export default defineConfig({
   splitting: false,
   treeshake: true,
   target: 'es2022',
-  external: ['react', 'react-dom', 'next', 'tailwindcss'],
+  external: ['react', 'react-dom', 'next', 'next-auth', 'next-auth/react', 'tailwindcss'],
   async onSuccess() {
     // Copy static CSS assets into dist/styles/.
     if (existsSync('src/styles')) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       lucide-react:
         specifier: ^0.544.0
         version: 0.544.0(react@19.2.5)
+      next-auth:
+        specifier: '>=5.0.0-beta.0'
+        version: 5.0.0-beta.31(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -179,6 +182,20 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@auth/core@0.41.2':
+    resolution: {integrity: sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^7.0.7
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -671,6 +688,9 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2540,6 +2560,9 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -2685,6 +2708,22 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-auth@5.0.0-beta.31:
+    resolution: {integrity: sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
+      nodemailer: ^7.0.7
+      react: ^18.2.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -2722,6 +2761,9 @@ packages:
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  oauth4webapi@3.8.5:
+    resolution: {integrity: sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2855,6 +2897,14 @@ packages:
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3622,6 +3672,14 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
+  '@auth/core@0.41.2':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.2.2
+      oauth4webapi: 3.8.5
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -3947,6 +4005,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
+
+  '@panva/hkdf@1.2.1': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -5956,6 +6016,8 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jose@6.2.2: {}
+
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
@@ -6122,6 +6184,12 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-auth@5.0.0-beta.31(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@auth/core': 0.41.2
+      next: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+
   next-themes@0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -6162,6 +6230,8 @@ snapshots:
       path-key: 4.0.0
 
   nwsapi@2.2.23: {}
+
+  oauth4webapi@3.8.5: {}
 
   object-assign@4.1.1: {}
 
@@ -6286,6 +6356,12 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
Closes #8 · Refs #13

## What's in the box

**`@jonmatum/next-shell/auth`** (client)
- `AuthAdapter` interface — `useSession()`, `signIn()`, `signOut()`, optional `getServerSession()`
- `AuthProvider` — React context; accepts any adapter as a prop
- `useSession()` / `useUser()` — raw session and typed user accessors
- `useRequireAuth()` — Suspense-compatible; throws while loading, `AuthRequiredError` when unauthenticated
- `useHasPermission(role | scope | string[])` — AND-semantics; directly mirrors nav `requires` field
- `<SignedIn fallback?>` / `<SignedOut fallback?>` — conditional render based on auth status
- `<RoleGate role="..." fallback?>` — role/scope gate; composes with nav permission keys

**`@jonmatum/next-shell/auth/server`**
- `requireSession(getSession)` — throws `AuthRequiredError` (statusCode 401) for Route Handlers + Server Components

**`@jonmatum/next-shell/auth/nextauth`** (Auth.js v5 adapter)
- `createNextAuthAdapter({ getServerSession? })` — wraps `next-auth/react` hooks
- `next-auth >= 5.0.0-beta.0` declared as optional peer dep; `.d.ts` shim avoids requiring the package locally

**`@jonmatum/next-shell/auth/mock`** (test / Storybook adapter)
- `createMockAuthAdapter({ user?, loading?, expires?, onSignIn?, onSignOut? })` — zero-dep, deterministic

3-line wiring example:
```tsx
import { createNextAuthAdapter } from '@jonmatum/next-shell/auth/nextauth';
import { auth } from '@/auth';
<AuthProvider adapter={createNextAuthAdapter({ getServerSession: auth })}>
```

## What is intentionally NOT in this PR

- Session refresh / token rotation logic — left to the adapter impl
- Clerk / Supabase Auth first-party adapters — clear extension points documented
- Route-level middleware guards — out of scope for the library layer
- Auth UI components (login form, user menu) — Phase 9 / Storybook

## Verification

```
pnpm format    ✓
pnpm lint      ✓  (0 errors, 0 warnings)
pnpm typecheck ✓
pnpm test      ✓  441 tests, 19 files (3.57s)
pnpm build     ✓  all DTS + ESM + CJS emitted
```

## Checklist

- [x] No raw color literals
- [x] `'use client'` on all client entries; `auth/server` and `auth/mock` are server-safe
- [x] `auth/index` and `auth/adapters/nextauth` added to `CLIENT_ENTRIES` in tsup.config.ts
- [x] `next-auth` added to `external` in tsup (not bundled)
- [x] `next-auth` as optional peer dep with `peerDependenciesMeta`
- [x] All new exports wired in `package.json#exports`
- [x] 27 new tests covering all hooks, components, mock adapter, and server helper
- [x] Commit is GPG-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)