### PR TITLE
feat(phase-8): hooks grab-bag + locale-aware formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,24 @@ Monorepo for [`@jonmatum/next-shell`](./packages/next-shell) — a reusable Next
 
 ## What's in the box today
 
-| Phase | Surface                                                                                                                                                                  | Status                               |
-| ----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
-|     0 | Monorepo scaffold + CI + publishing skeleton                                                                                                                             | ✅ Landed                            |
-|     1 | Semantic-token contract + Tailwind v4 preset + OKLCH color tokens                                                                                                        | ✅ Landed                            |
-|     2 | `ThemeProvider` · `useTheme` · `ThemeToggle` (cycle + dropdown) · SSR cookie helpers                                                                                     | ✅ Landed                            |
-|     3 | **42 shadcn/ui primitives** vendored from [`shadcn-ui/ui@84d1d476`](https://github.com/shadcn-ui/ui/commit/84d1d476b1d1c6a01c6eeadd95885ce109969b08), each token-audited | ✅ Landed                            |
-|     4 | `AppShell` · `Sidebar` (4 variants, mobile drawer) · `TopBar` · `CommandBar` (⌘K) · `ContentContainer` · `PageHeader` · `Footer` · status states · SSR sidebar cookie    | ✅ Landed                            |
-|     5 | Navigation system — `buildNav`, `SidebarNav`, `Breadcrumbs`, `CommandBarActions`; permission-gated nav via `requires`                                                    | ✅ Landed                            |
-|     6 | Providers composer — `AppProviders`, `QueryProvider` (TanStack Query v5), `ToastProvider` (Sonner), `ErrorBoundary`, `I18nProvider`                                      | ✅ Landed                            |
-|     7 | Auth adapter pattern — `AuthProvider`, `useSession`, `useUser`, `useHasPermission`, `useRequireAuth`, `SignedIn`, `SignedOut`, `RoleGate`, `requireSession` (server)     | ✅ Landed                            |
-|     8 | Hooks grab-bag (`useDebounce`, `useMedia`, …)                                                                                                                            | ⏳ Queued                            |
-|     9 | Utilities (`cn`, formatters, guards)                                                                                                                                     | ⏳ Queued (`cn` shipped in Phase 3a) |
-|    10 | Docs site + Storybook                                                                                                                                                    | ⏳ Queued                            |
-|    11 | Publishing + changeset release workflow                                                                                                                                  | ⏳ Queued                            |
-|    12 | Integration back into Smart Pad Rules                                                                                                                                    | ⏳ Queued                            |
+| Phase | Surface                                                                                                                                                                      | Status    |
+| ----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+|     0 | Monorepo scaffold + CI + publishing skeleton                                                                                                                                 | ✅ Landed |
+|     1 | Semantic-token contract + Tailwind v4 preset + OKLCH color tokens                                                                                                            | ✅ Landed |
+|     2 | `ThemeProvider` · `useTheme` · `ThemeToggle` (cycle + dropdown) · SSR cookie helpers                                                                                         | ✅ Landed |
+|     3 | **42 shadcn/ui primitives** vendored from [`shadcn-ui/ui@84d1d476`](https://github.com/shadcn-ui/ui/commit/84d1d476b1d1c6a01c6eeadd95885ce109969b08), each token-audited     | ✅ Landed |
+|     4 | `AppShell` · `Sidebar` (4 variants, mobile drawer) · `TopBar` · `CommandBar` (⌘K) · `ContentContainer` · `PageHeader` · `Footer` · status states · SSR sidebar cookie        | ✅ Landed |
+|     5 | Navigation system — `buildNav`, `SidebarNav`, `Breadcrumbs`, `CommandBarActions`; permission-gated nav via `requires`                                                        | ✅ Landed |
+|     6 | Providers composer — `AppProviders`, `QueryProvider` (TanStack Query v5), `ToastProvider` (Sonner), `ErrorBoundary`, `I18nProvider`                                          | ✅ Landed |
+|     7 | Auth adapter pattern — `AuthProvider`, `useSession`, `useUser`, `useHasPermission`, `useRequireAuth`, `SignedIn`, `SignedOut`, `RoleGate`, `requireSession` (server)         | ✅ Landed |
+|     8 | Hooks + formatters — `useDisclosure`, `useLocalStorage`, `useDebounced*`, `useHotkey`, `useBreakpoint`, `useCopyToClipboard` + `formatDate`, `formatCurrency`, `truncate`, … | ✅ Landed |
+|     9 | Docs site + Storybook                                                                                                                                                        | ⏳ Queued |
+|    10 | Publishing + changeset release workflow                                                                                                                                      | ⏳ Queued |
+|    11 | Integration back into Smart Pad Rules                                                                                                                                        | ⏳ Queued |
 
 **42 primitives** (Phase 3): Accordion, Alert, AlertDialog, AspectRatio, Avatar, Badge, Breadcrumb, Button, Calendar, Card, Carousel, Chart, Checkbox, Collapsible, Command, ContextMenu, Dialog, Drawer, DropdownMenu, Form, HoverCard, Input, InputOTP, Label, Menubar, NavigationMenu, Pagination, Popover, Progress, RadioGroup, Resizable, ScrollArea, Select, Separator, Sheet, Skeleton, Slider, Switch, Table, Tabs, Textarea, Toaster (Sonner), Toggle, ToggleGroup, Tooltip.
 
-**441 unit tests** across 19 test files cover render, interaction, SSR helpers, provider composition, auth adapter contracts, and export-surface completeness.
+**508 unit tests** across 21 test files cover render, interaction, SSR helpers, provider composition, auth adapter contracts, and export-surface completeness.
 
 Deliberately **not** vendored (composed patterns documented as consumer-side recipes): DatePicker (Popover + Calendar + Button), DataTable (Table + `@tanstack/react-table`), Typography (styling-guide h1/h2/p patterns).
 
@@ -58,7 +57,7 @@ nvm use              # Node version from .nvmrc
 pnpm install
 pnpm lint            # eslint --max-warnings=0
 pnpm typecheck
-pnpm test            # vitest run (441 tests)
+pnpm test            # vitest run (508 tests)
 pnpm build           # tsup + tailwind preset + DTS
 ```
 

--- a/packages/next-shell/README.md
+++ b/packages/next-shell/README.md
@@ -2,7 +2,7 @@
 
 Reusable Next.js app shell built on **shadcn/ui** primitives with a strict **semantic-token** design system.
 
-> **Status:** Phases 0–7 landed on `main` (tokens, theming, 42 primitives, full layout shell, nav system, providers, auth adapters). Follow the rollout in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
+> **Status:** Phases 0–8 landed on `main` (tokens, theming, 42 primitives, full layout shell, nav system, providers, auth adapters, hooks + formatters). Follow the rollout in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
 
 ## Install
 
@@ -89,24 +89,25 @@ Every primitive ships with `data-slot` attributes for custom-styling hooks, `ari
 
 ## Subpath entry points
 
-| Import                                   | Surface                                                                                                            | Status     |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------- |
-| `@jonmatum/next-shell`                   | Root barrel — `cn`, `packageVersion`, `tokenSchemaVersion`                                                         | ✅         |
-| `@jonmatum/next-shell/core`              | `cn`, `packageVersion`                                                                                             | ✅         |
-| `@jonmatum/next-shell/primitives`        | 42 shadcn/ui primitives (client)                                                                                   | ✅         |
-| `@jonmatum/next-shell/providers`         | `AppProviders`, `ThemeProvider`, `QueryProvider`, `ToastProvider`, `ErrorBoundary`, `I18nProvider` (client)        | ✅         |
-| `@jonmatum/next-shell/providers/server`  | SSR theme cookie helpers (server-safe)                                                                             | ✅         |
-| `@jonmatum/next-shell/layout`            | `AppShell`, `Sidebar`, `TopBar`, `CommandBar`, `ContentContainer`, `PageHeader`, `Footer`, nav + status helpers    | ✅         |
-| `@jonmatum/next-shell/layout/server`     | SSR sidebar-state cookie helpers (server-safe)                                                                     | ✅         |
-| `@jonmatum/next-shell/auth`              | `AuthProvider`, `useSession`, `useUser`, `useHasPermission`, `useRequireAuth`, `SignedIn`, `SignedOut`, `RoleGate` | ✅         |
-| `@jonmatum/next-shell/auth/server`       | `requireSession` — throws `AuthRequiredError` (401) for Route Handlers (server-safe)                               | ✅         |
-| `@jonmatum/next-shell/auth/nextauth`     | `createNextAuthAdapter` — Auth.js v5 wrapper (optional peer: `next-auth >= 5`)                                     | ✅         |
-| `@jonmatum/next-shell/auth/mock`         | `createMockAuthAdapter` — zero-dep adapter for tests and Storybook                                                 | ✅         |
-| `@jonmatum/next-shell/tokens`            | TS view of the semantic-token contract — literal unions, `cssVar`, brand overrides                                 | ✅         |
-| `@jonmatum/next-shell/tailwind-preset`   | Tailwind v4 preset (maps tokens → `@theme` keys)                                                                   | ✅         |
-| `@jonmatum/next-shell/styles/tokens.css` | Token CSS (custom properties for `:root` + `[data-theme="dark"]`)                                                  | ✅         |
-| `@jonmatum/next-shell/styles/preset.css` | Combined preset (tokens + `tw-animate-css` + Tailwind `@theme` mappings)                                           | ✅         |
-| `@jonmatum/next-shell/hooks`             | Cross-cutting hooks (`useDebounce`, `useMedia`, …)                                                                 | ⏳ Phase 8 |
+| Import                                   | Surface                                                                                                             | Status |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------ |
+| `@jonmatum/next-shell`                   | Root barrel — `cn`, `packageVersion`, `tokenSchemaVersion`                                                          | ✅     |
+| `@jonmatum/next-shell/core`              | `cn`, `packageVersion`                                                                                              | ✅     |
+| `@jonmatum/next-shell/primitives`        | 42 shadcn/ui primitives (client)                                                                                    | ✅     |
+| `@jonmatum/next-shell/providers`         | `AppProviders`, `ThemeProvider`, `QueryProvider`, `ToastProvider`, `ErrorBoundary`, `I18nProvider` (client)         | ✅     |
+| `@jonmatum/next-shell/providers/server`  | SSR theme cookie helpers (server-safe)                                                                              | ✅     |
+| `@jonmatum/next-shell/layout`            | `AppShell`, `Sidebar`, `TopBar`, `CommandBar`, `ContentContainer`, `PageHeader`, `Footer`, nav + status helpers     | ✅     |
+| `@jonmatum/next-shell/layout/server`     | SSR sidebar-state cookie helpers (server-safe)                                                                      | ✅     |
+| `@jonmatum/next-shell/auth`              | `AuthProvider`, `useSession`, `useUser`, `useHasPermission`, `useRequireAuth`, `SignedIn`, `SignedOut`, `RoleGate`  | ✅     |
+| `@jonmatum/next-shell/auth/server`       | `requireSession` — throws `AuthRequiredError` (401) for Route Handlers (server-safe)                                | ✅     |
+| `@jonmatum/next-shell/auth/nextauth`     | `createNextAuthAdapter` — Auth.js v5 wrapper (optional peer: `next-auth >= 5`)                                      | ✅     |
+| `@jonmatum/next-shell/auth/mock`         | `createMockAuthAdapter` — zero-dep adapter for tests and Storybook                                                  | ✅     |
+| `@jonmatum/next-shell/tokens`            | TS view of the semantic-token contract — literal unions, `cssVar`, brand overrides                                  | ✅     |
+| `@jonmatum/next-shell/tailwind-preset`   | Tailwind v4 preset (maps tokens → `@theme` keys)                                                                    | ✅     |
+| `@jonmatum/next-shell/styles/tokens.css` | Token CSS (custom properties for `:root` + `[data-theme="dark"]`)                                                   | ✅     |
+| `@jonmatum/next-shell/styles/preset.css` | Combined preset (tokens + `tw-animate-css` + Tailwind `@theme` mappings)                                            | ✅     |
+| `@jonmatum/next-shell/hooks`             | `useDisclosure`, `useLocalStorage`, `useBreakpoint`, `useHotkey`, `useDebouncedValue`, `useMounted`, `useLocale`, … | ✅     |
+| `@jonmatum/next-shell/formatters`        | `formatDate`, `formatRelativeTime`, `formatCurrency`, `formatFileSize`, `truncate`, `slugify`, …                    | ✅     |
 
 Subpath imports tree-shake cleanly — importing only `@jonmatum/next-shell/primitives` does not pull in providers, and vice versa.
 

--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -92,6 +92,11 @@
       "import": "./dist/hooks/index.js",
       "require": "./dist/hooks/index.cjs"
     },
+    "./formatters": {
+      "types": "./dist/formatters/index.d.ts",
+      "import": "./dist/formatters/index.js",
+      "require": "./dist/formatters/index.cjs"
+    },
     "./tokens": {
       "types": "./dist/tokens/index.d.ts",
       "import": "./dist/tokens/index.js",

--- a/packages/next-shell/src/formatters/date.ts
+++ b/packages/next-shell/src/formatters/date.ts
@@ -1,0 +1,92 @@
+/**
+ * Locale-aware date / time formatters built on the `Intl` platform APIs.
+ * All functions are pure — no React dependency — so they can be used in
+ * Server Components, Route Handlers, and test code without a provider.
+ *
+ * Pass a `locale` string to override; defaults to `'en'`.
+ */
+
+export interface FormatDateOptions extends Intl.DateTimeFormatOptions {
+  readonly locale?: string;
+}
+
+/**
+ * Format a date value (Date, timestamp, or ISO string) with
+ * `Intl.DateTimeFormat`. Defaults to a short date representation.
+ *
+ * ```ts
+ * formatDate(new Date()) // "4/16/2026"
+ * formatDate(new Date(), { dateStyle: 'long', locale: 'de' }) // "16. April 2026"
+ * ```
+ */
+export function formatDate(date: Date | number | string, options: FormatDateOptions = {}): string {
+  const { locale = 'en', ...intlOptions } = options;
+  const d = date instanceof Date ? date : new Date(date);
+  const opts: Intl.DateTimeFormatOptions =
+    Object.keys(intlOptions).length === 0 ? { dateStyle: 'short' } : intlOptions;
+  return new Intl.DateTimeFormat(locale, opts).format(d);
+}
+
+export interface FormatRelativeTimeOptions {
+  readonly locale?: string;
+  readonly style?: Intl.RelativeTimeFormatStyle;
+  /**
+   * Anchor date to measure from. Defaults to `Date.now()`.
+   * Passing a fixed anchor makes tests deterministic.
+   */
+  readonly now?: Date | number;
+}
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+const MONTH = 30 * DAY;
+const YEAR = 365 * DAY;
+
+/**
+ * Format a date as a relative time string (e.g. "3 days ago", "in 2 hours").
+ *
+ * ```ts
+ * formatRelativeTime(subDays(new Date(), 3)) // "3 days ago"
+ * ```
+ */
+export function formatRelativeTime(
+  date: Date | number | string,
+  options: FormatRelativeTimeOptions = {},
+): string {
+  const { locale = 'en', style = 'long', now } = options;
+  const d = date instanceof Date ? date.getTime() : new Date(date).getTime();
+  const anchor = now instanceof Date ? now.getTime() : (now ?? Date.now());
+  const diffMs = d - anchor;
+  const absMs = Math.abs(diffMs);
+
+  let value: number;
+  let unit: Intl.RelativeTimeFormatUnit;
+
+  if (absMs < MINUTE) {
+    value = Math.round(diffMs / SECOND);
+    unit = 'second';
+  } else if (absMs < HOUR) {
+    value = Math.round(diffMs / MINUTE);
+    unit = 'minute';
+  } else if (absMs < DAY) {
+    value = Math.round(diffMs / HOUR);
+    unit = 'hour';
+  } else if (absMs < WEEK) {
+    value = Math.round(diffMs / DAY);
+    unit = 'day';
+  } else if (absMs < MONTH) {
+    value = Math.round(diffMs / WEEK);
+    unit = 'week';
+  } else if (absMs < YEAR) {
+    value = Math.round(diffMs / MONTH);
+    unit = 'month';
+  } else {
+    value = Math.round(diffMs / YEAR);
+    unit = 'year';
+  }
+
+  return new Intl.RelativeTimeFormat(locale, { style, numeric: 'auto' }).format(value, unit);
+}

--- a/packages/next-shell/src/formatters/index.ts
+++ b/packages/next-shell/src/formatters/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Formatters subpath — locale-aware, pure functions, no React dependency.
+ *
+ * ```ts
+ * import { formatDate, formatCurrency, truncate } from '@jonmatum/next-shell/formatters';
+ * ```
+ *
+ * All formatters accept an optional `locale` string. For React components,
+ * compose with `useI18n()` or `useLocale()` from the hooks subpath to
+ * derive the locale from context.
+ */
+
+// ── Date / time ────────────────────────────────────────────────────────────
+export { formatDate, formatRelativeTime } from './date.js';
+export type { FormatDateOptions, FormatRelativeTimeOptions } from './date.js';
+
+// ── Numbers ────────────────────────────────────────────────────────────────
+export {
+  formatNumber,
+  formatCurrency,
+  formatPercent,
+  formatFileSize,
+  formatDuration,
+} from './number.js';
+export type {
+  FormatNumberOptions,
+  FormatFileSizeOptions,
+  FormatDurationOptions,
+} from './number.js';
+
+// ── Strings ───────────────────────────────────────────────────────────────
+export { truncate, pluralize, toTitleCase, toKebabCase, slugify } from './string.js';

--- a/packages/next-shell/src/formatters/number.ts
+++ b/packages/next-shell/src/formatters/number.ts
@@ -1,0 +1,110 @@
+/**
+ * Locale-aware number / currency / file-size formatters built on `Intl`.
+ * Pure functions — safe in Server Components, Route Handlers, and tests.
+ */
+
+export interface FormatNumberOptions extends Intl.NumberFormatOptions {
+  readonly locale?: string;
+}
+
+/**
+ * Format a number with `Intl.NumberFormat`.
+ *
+ * ```ts
+ * formatNumber(1234567.89) // "1,234,567.89"
+ * formatNumber(1234567.89, { locale: 'de' }) // "1.234.567,89"
+ * ```
+ */
+export function formatNumber(value: number, options: FormatNumberOptions = {}): string {
+  const { locale = 'en', ...intlOptions } = options;
+  return new Intl.NumberFormat(locale, intlOptions).format(value);
+}
+
+/**
+ * Format a number as currency.
+ *
+ * ```ts
+ * formatCurrency(9.99, 'USD') // "$9.99"
+ * formatCurrency(9.99, 'EUR', { locale: 'de' }) // "9,99 €"
+ * ```
+ */
+export function formatCurrency(
+  value: number,
+  currency: string,
+  options: FormatNumberOptions = {},
+): string {
+  const { locale = 'en', ...intlOptions } = options;
+  return new Intl.NumberFormat(locale, { style: 'currency', currency, ...intlOptions }).format(
+    value,
+  );
+}
+
+/**
+ * Format a number as a percentage (0–1 input, e.g. 0.75 → "75%").
+ *
+ * ```ts
+ * formatPercent(0.75) // "75%"
+ * formatPercent(0.123, { maximumFractionDigits: 1 }) // "12.3%"
+ * ```
+ */
+export function formatPercent(value: number, options: FormatNumberOptions = {}): string {
+  const { locale = 'en', ...intlOptions } = options;
+  return new Intl.NumberFormat(locale, { style: 'percent', ...intlOptions }).format(value);
+}
+
+const FILE_SIZE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const;
+
+export interface FormatFileSizeOptions {
+  readonly locale?: string;
+  /** Number of decimal places. Default: `1`. */
+  readonly decimals?: number;
+}
+
+/**
+ * Format a byte count as a human-readable file size string.
+ *
+ * ```ts
+ * formatFileSize(1536) // "1.5 KB"
+ * formatFileSize(1073741824) // "1.0 GB"
+ * ```
+ */
+export function formatFileSize(bytes: number, options: FormatFileSizeOptions = {}): string {
+  const { locale = 'en', decimals = 1 } = options;
+  if (bytes === 0) return '0 B';
+  const i = Math.min(
+    Math.floor(Math.log(Math.abs(bytes)) / Math.log(1024)),
+    FILE_SIZE_UNITS.length - 1,
+  );
+  const value = bytes / Math.pow(1024, i);
+  return `${new Intl.NumberFormat(locale, { maximumFractionDigits: decimals, minimumFractionDigits: decimals }).format(value)} ${FILE_SIZE_UNITS[i]}`;
+}
+
+export interface FormatDurationOptions {
+  readonly locale?: string;
+  /** How many parts to show. Default: `2` (e.g. "2 hr, 3 min"). */
+  readonly parts?: number;
+}
+
+/**
+ * Format a duration in milliseconds as a human-readable string.
+ *
+ * ```ts
+ * formatDuration(7383000) // "2 hr, 3 min"
+ * formatDuration(90000, { parts: 1 }) // "1 min"
+ * ```
+ */
+export function formatDuration(ms: number, options: FormatDurationOptions = {}): string {
+  const { parts = 2 } = options;
+  const abs = Math.abs(ms);
+  const segments: Array<[number, Intl.RelativeTimeFormatUnit]> = [
+    [Math.floor(abs / 3_600_000), 'hour'],
+    [Math.floor((abs % 3_600_000) / 60_000), 'minute'],
+    [Math.floor((abs % 60_000) / 1_000), 'second'],
+  ];
+  const active = segments.filter(([v]) => v > 0);
+  if (active.length === 0) return '0 sec';
+  return active
+    .slice(0, parts)
+    .map(([v, u]) => `${v} ${v === 1 ? u : `${u}s`}`)
+    .join(', ');
+}

--- a/packages/next-shell/src/formatters/string.ts
+++ b/packages/next-shell/src/formatters/string.ts
@@ -1,0 +1,77 @@
+/**
+ * String utilities. Pure functions, no dependencies.
+ */
+
+/**
+ * Truncate a string to `maxLength` characters, appending `suffix` when cut.
+ *
+ * ```ts
+ * truncate('Hello, world!', 8) // "Hello, …"
+ * truncate('Hi', 8) // "Hi"
+ * ```
+ */
+export function truncate(str: string, maxLength: number, suffix = '…'): string {
+  if (str.length <= maxLength) return str;
+  return str.slice(0, maxLength - suffix.length) + suffix;
+}
+
+/**
+ * Return `singular` when `count === 1`, otherwise `plural` (defaults to
+ * `singular + 's'`).
+ *
+ * ```ts
+ * pluralize(1, 'item') // "1 item"
+ * pluralize(3, 'item') // "3 items"
+ * pluralize(2, 'goose', 'geese') // "2 geese"
+ * ```
+ */
+export function pluralize(count: number, singular: string, plural?: string): string {
+  const word = count === 1 ? singular : (plural ?? `${singular}s`);
+  return `${count} ${word}`;
+}
+
+/**
+ * Convert a string to Title Case.
+ *
+ * ```ts
+ * toTitleCase('hello world') // "Hello World"
+ * ```
+ */
+export function toTitleCase(str: string): string {
+  return str.replace(
+    /\w\S*/g,
+    (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+  );
+}
+
+/**
+ * Convert a string to kebab-case.
+ *
+ * ```ts
+ * toKebabCase('HelloWorld') // "hello-world"
+ * toKebabCase('my string') // "my-string"
+ * ```
+ */
+export function toKebabCase(str: string): string {
+  return str
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
+}
+
+/**
+ * Slugify a string for use in URLs (lowercase, hyphens, ASCII only).
+ *
+ * ```ts
+ * slugify('Hello World!') // "hello-world"
+ * ```
+ */
+export function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/[\s-]+/g, '-');
+}

--- a/packages/next-shell/src/hooks/index.ts
+++ b/packages/next-shell/src/hooks/index.ts
@@ -1,12 +1,42 @@
+'use client';
+
 /**
- * Cross-cutting hooks.
+ * Hooks subpath — client-only surface.
  *
  * Subpath: `@jonmatum/next-shell/hooks`
- *
- * Currently exposes `useIsMobile` (populated in Phase 4d to back the
- * Sidebar's mobile-drawer mode). The broader Phase 8 surface
- * (`useBreakpoint`, `useDisclosure`, `useLocalStorage`, etc.) lands
- * separately.
  */
 
+// ── Layout / device ────────────────────────────────────────────────────────
 export { useIsMobile } from './use-mobile.js';
+export { useMediaQuery } from './use-media-query.js';
+export { useBreakpoint } from './use-breakpoint.js';
+export type { Breakpoint, UseBreakpointResult } from './use-breakpoint.js';
+
+// ── Lifecycle ──────────────────────────────────────────────────────────────
+export { useMounted } from './use-mounted.js';
+export { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect.js';
+
+// ── State primitives ───────────────────────────────────────────────────────
+export { useDisclosure } from './use-disclosure.js';
+export type { UseDisclosureResult } from './use-disclosure.js';
+
+export { useControllableState } from './use-controllable-state.js';
+export type { UseControllableStateOptions } from './use-controllable-state.js';
+
+// ── Storage ────────────────────────────────────────────────────────────────
+export { useLocalStorage } from './use-local-storage.js';
+export { useSessionStorage } from './use-session-storage.js';
+
+// ── Async / effects ────────────────────────────────────────────────────────
+export { useCopyToClipboard } from './use-copy-to-clipboard.js';
+export type { UseCopyToClipboardResult } from './use-copy-to-clipboard.js';
+
+export { useDebouncedValue } from './use-debounced-value.js';
+export { useDebouncedCallback } from './use-debounced-callback.js';
+
+// ── Keyboard ───────────────────────────────────────────────────────────────
+export { useHotkey } from './use-hotkey.js';
+export type { HotkeyOptions } from './use-hotkey.js';
+
+// ── i18n / locale ─────────────────────────────────────────────────────────
+export { useLocale } from './use-locale.js';

--- a/packages/next-shell/src/hooks/use-breakpoint.ts
+++ b/packages/next-shell/src/hooks/use-breakpoint.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useMediaQuery } from './use-media-query.js';
+
+/** Tailwind v4 default breakpoints. */
+const BREAKPOINTS = {
+  sm: '(min-width: 640px)',
+  md: '(min-width: 768px)',
+  lg: '(min-width: 1024px)',
+  xl: '(min-width: 1280px)',
+  '2xl': '(min-width: 1536px)',
+} as const;
+
+export type Breakpoint = keyof typeof BREAKPOINTS;
+
+export interface UseBreakpointResult {
+  /** Whether the viewport is ≥ 640 px. */
+  readonly isSm: boolean;
+  /** Whether the viewport is ≥ 768 px. */
+  readonly isMd: boolean;
+  /** Whether the viewport is ≥ 1024 px. */
+  readonly isLg: boolean;
+  /** Whether the viewport is ≥ 1280 px. */
+  readonly isXl: boolean;
+  /** Whether the viewport is ≥ 1536 px. */
+  readonly is2xl: boolean;
+  /**
+   * The largest active breakpoint, or `null` on SSR / below `sm`.
+   * Useful for switch-style logic.
+   */
+  readonly current: Breakpoint | null;
+}
+
+export function useBreakpoint(): UseBreakpointResult {
+  const isSm = useMediaQuery(BREAKPOINTS.sm);
+  const isMd = useMediaQuery(BREAKPOINTS.md);
+  const isLg = useMediaQuery(BREAKPOINTS.lg);
+  const isXl = useMediaQuery(BREAKPOINTS.xl);
+  const is2xl = useMediaQuery(BREAKPOINTS['2xl']);
+
+  let current: Breakpoint | null = null;
+  if (is2xl) current = '2xl';
+  else if (isXl) current = 'xl';
+  else if (isLg) current = 'lg';
+  else if (isMd) current = 'md';
+  else if (isSm) current = 'sm';
+
+  return { isSm, isMd, isLg, isXl, is2xl, current };
+}

--- a/packages/next-shell/src/hooks/use-controllable-state.ts
+++ b/packages/next-shell/src/hooks/use-controllable-state.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import * as React from 'react';
+
+import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect.js';
+
+type Updater<T> = T | ((prev: T | undefined) => T);
+
+export interface UseControllableStateOptions<T> {
+  /** The controlled value. When defined the component is controlled. */
+  readonly prop?: T;
+  /** Initial value for the uncontrolled case. */
+  readonly defaultProp?: T;
+  /** Called whenever the value changes (controlled or not). */
+  readonly onChange?: (value: T) => void;
+}
+
+/**
+ * Radix-style controlled/uncontrolled state primitive.
+ *
+ * ```tsx
+ * const [open, setOpen] = useControllableState({
+ *   prop: props.open,
+ *   defaultProp: props.defaultOpen,
+ *   onChange: props.onOpenChange,
+ * });
+ * ```
+ */
+export function useControllableState<T>({
+  prop,
+  defaultProp,
+  onChange,
+}: UseControllableStateOptions<T>): [T | undefined, (updater: Updater<T>) => void] {
+  const [uncontrolled, setUncontrolled] = React.useState<T | undefined>(defaultProp);
+  const isControlled = prop !== undefined;
+  const value = isControlled ? prop : uncontrolled;
+
+  const onChangeRef = React.useRef(onChange);
+  useIsomorphicLayoutEffect(() => {
+    onChangeRef.current = onChange;
+  });
+
+  const setValue = React.useCallback(
+    (updater: Updater<T>) => {
+      const next =
+        typeof updater === 'function' ? (updater as (p: T | undefined) => T)(value) : updater;
+      if (!isControlled) setUncontrolled(next);
+      onChangeRef.current?.(next);
+    },
+    [isControlled, value],
+  );
+
+  return [value, setValue];
+}

--- a/packages/next-shell/src/hooks/use-copy-to-clipboard.ts
+++ b/packages/next-shell/src/hooks/use-copy-to-clipboard.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import * as React from 'react';
+
+export interface UseCopyToClipboardResult {
+  /** The most recently copied value, or `null` before any copy. */
+  readonly copiedValue: string | null;
+  /** Whether the last copy happened within the reset window. */
+  readonly isCopied: boolean;
+  /** Copy `text` to the clipboard. Returns `true` on success. */
+  readonly copy: (text: string) => Promise<boolean>;
+}
+
+/**
+ * Copy text to the clipboard. `isCopied` is `true` for `resetMs`
+ * milliseconds after a successful copy (default 2000 ms).
+ *
+ * ```ts
+ * const { isCopied, copy } = useCopyToClipboard();
+ * <button onClick={() => copy(url)}>{isCopied ? 'Copied!' : 'Copy'}</button>
+ * ```
+ */
+export function useCopyToClipboard(resetMs = 2000): UseCopyToClipboardResult {
+  const [copiedValue, setCopiedValue] = React.useState<string | null>(null);
+  const [isCopied, setIsCopied] = React.useState(false);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const copy = React.useCallback(
+    async (text: string): Promise<boolean> => {
+      if (!navigator?.clipboard) return false;
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopiedValue(text);
+        setIsCopied(true);
+        clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setIsCopied(false), resetMs);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [resetMs],
+  );
+
+  React.useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  return { copiedValue, isCopied, copy };
+}

--- a/packages/next-shell/src/hooks/use-debounced-callback.ts
+++ b/packages/next-shell/src/hooks/use-debounced-callback.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * Returns a debounced version of `callback` that fires only after
+ * `delayMs` milliseconds have elapsed since the last invocation.
+ * The returned function is stable across renders.
+ *
+ * ```ts
+ * const saveDebounced = useDebouncedCallback(save, 500);
+ * ```
+ */
+export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
+  callback: T,
+  delayMs: number,
+): (...args: Parameters<T>) => void {
+  const callbackRef = React.useRef(callback);
+  React.useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  const timerRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const debounced = React.useCallback(
+    (...args: Parameters<T>) => {
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => callbackRef.current(...args), delayMs);
+    },
+    [delayMs],
+  );
+
+  React.useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  return debounced;
+}

--- a/packages/next-shell/src/hooks/use-debounced-value.ts
+++ b/packages/next-shell/src/hooks/use-debounced-value.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delayMs`
+ * milliseconds of inactivity.
+ *
+ * ```ts
+ * const [search, setSearch] = React.useState('');
+ * const debouncedSearch = useDebouncedValue(search, 300);
+ * ```
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debouncedValue;
+}

--- a/packages/next-shell/src/hooks/use-disclosure.ts
+++ b/packages/next-shell/src/hooks/use-disclosure.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import * as React from 'react';
+
+export interface UseDisclosureResult {
+  readonly isOpen: boolean;
+  readonly open: () => void;
+  readonly close: () => void;
+  readonly toggle: () => void;
+  /** Pass directly to controlled components: `<Dialog open={...} onOpenChange={...}>` */
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Open / close / toggle primitive. Works as a controlled or uncontrolled
+ * state holder for dialogs, drawers, popovers, etc.
+ *
+ * ```ts
+ * const { isOpen, open, close, toggle, onOpenChange } = useDisclosure();
+ * ```
+ */
+export function useDisclosure(initialOpen = false): UseDisclosureResult {
+  const [isOpen, setIsOpen] = React.useState(initialOpen);
+
+  const open = React.useCallback(() => setIsOpen(true), []);
+  const close = React.useCallback(() => setIsOpen(false), []);
+  const toggle = React.useCallback(() => setIsOpen((v) => !v), []);
+
+  return { isOpen, open, close, toggle, onOpenChange: setIsOpen };
+}

--- a/packages/next-shell/src/hooks/use-hotkey.ts
+++ b/packages/next-shell/src/hooks/use-hotkey.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import * as React from 'react';
+
+export interface HotkeyOptions {
+  /** Require the Meta (⌘ / Windows) key. */
+  readonly meta?: boolean;
+  /** Require the Ctrl key. */
+  readonly ctrl?: boolean;
+  /** Require the Shift key. */
+  readonly shift?: boolean;
+  /** Require the Alt / Option key. */
+  readonly alt?: boolean;
+  /** Call `event.preventDefault()` when the hotkey fires. Default: `true`. */
+  readonly preventDefault?: boolean;
+  /** Element to attach the listener to. Defaults to `window`. */
+  readonly target?: EventTarget | null;
+  /** When `false` the listener is not attached. Useful for conditional hotkeys. */
+  readonly enabled?: boolean;
+}
+
+/**
+ * Register a keyboard shortcut. The handler is stable (wrapped in a ref)
+ * so it does not cause the listener to be re-registered on every render.
+ *
+ * ```ts
+ * useHotkey('k', openCommandBar, { meta: true });
+ * ```
+ */
+export function useHotkey(
+  key: string,
+  handler: (event: KeyboardEvent) => void,
+  options: HotkeyOptions = {},
+): void {
+  const {
+    meta = false,
+    ctrl = false,
+    shift = false,
+    alt = false,
+    preventDefault = true,
+    target,
+    enabled = true,
+  } = options;
+
+  const handlerRef = React.useRef(handler);
+  React.useLayoutEffect(() => {
+    handlerRef.current = handler;
+  });
+
+  React.useEffect(() => {
+    if (!enabled) return undefined;
+    const el: EventTarget = target ?? window;
+
+    const onKeyDown = (e: Event) => {
+      const event = e as KeyboardEvent;
+      if (event.key.toLowerCase() !== key.toLowerCase()) return;
+      if (meta && !event.metaKey) return;
+      if (ctrl && !event.ctrlKey) return;
+      if (shift && !event.shiftKey) return;
+      if (alt && !event.altKey) return;
+      if (preventDefault) event.preventDefault();
+      handlerRef.current(event);
+    };
+
+    el.addEventListener('keydown', onKeyDown);
+    return () => el.removeEventListener('keydown', onKeyDown);
+  }, [key, meta, ctrl, shift, alt, preventDefault, target, enabled]);
+}

--- a/packages/next-shell/src/hooks/use-isomorphic-layout-effect.ts
+++ b/packages/next-shell/src/hooks/use-isomorphic-layout-effect.ts
@@ -1,0 +1,10 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * `useLayoutEffect` on the client, `useEffect` on the server.
+ * Avoids the SSR warning while keeping layout-timing semantics where it matters.
+ */
+export const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;

--- a/packages/next-shell/src/hooks/use-local-storage.ts
+++ b/packages/next-shell/src/hooks/use-local-storage.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import * as React from 'react';
+
+type SetValue<T> = (value: T | ((prev: T) => T)) => void;
+
+/**
+ * SSR-safe `localStorage` hook. Returns `[storedValue, setValue, removeValue]`.
+ * On the server and on first render the `initialValue` is used to avoid
+ * hydration mismatches.
+ *
+ * ```ts
+ * const [theme, setTheme, removeTheme] = useLocalStorage('theme', 'system');
+ * ```
+ */
+export function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T>, () => void] {
+  const [storedValue, setStoredValue] = React.useState<T>(() => {
+    if (typeof window === 'undefined') return initialValue;
+    try {
+      const item = window.localStorage.getItem(key);
+      return item !== null ? (JSON.parse(item) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  const setValue: SetValue<T> = React.useCallback(
+    (value) => {
+      setStoredValue((prev) => {
+        const resolved = typeof value === 'function' ? (value as (p: T) => T)(prev) : value;
+        try {
+          window.localStorage.setItem(key, JSON.stringify(resolved));
+        } catch {
+          // Quota exceeded or private-mode restriction — silently ignore.
+        }
+        return resolved;
+      });
+    },
+    [key],
+  );
+
+  const removeValue = React.useCallback(() => {
+    setStoredValue(initialValue);
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      // ignore
+    }
+  }, [key, initialValue]);
+
+  return [storedValue, setValue, removeValue];
+}

--- a/packages/next-shell/src/hooks/use-locale.ts
+++ b/packages/next-shell/src/hooks/use-locale.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useI18n } from '../providers/i18n/i18n-provider.js';
+
+/**
+ * Returns the current locale string. Reads from `I18nProvider` if the
+ * adapter exposes a `locale` property, otherwise falls back to
+ * `navigator.language` on the client or `'en'` on the server.
+ *
+ * Use this to pass a consistent locale to the pure formatter functions:
+ *
+ * ```ts
+ * const locale = useLocale();
+ * const formatted = formatCurrency(price, 'USD', { locale });
+ * ```
+ */
+export function useLocale(): string {
+  const i18n = useI18n();
+  // If the adapter exposes a locale, use it.
+  if (i18n && 'locale' in i18n && typeof (i18n as { locale?: unknown }).locale === 'string') {
+    return (i18n as { locale: string }).locale;
+  }
+  if (typeof navigator !== 'undefined' && navigator.language) {
+    return navigator.language;
+  }
+  return 'en';
+}

--- a/packages/next-shell/src/hooks/use-media-query.ts
+++ b/packages/next-shell/src/hooks/use-media-query.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * Returns whether a CSS media query matches. SSR-safe: returns `false`
+ * on the server and on first render to avoid hydration mismatches.
+ *
+ * ```ts
+ * const isLarge = useMediaQuery('(min-width: 1024px)');
+ * ```
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = React.useState(false);
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+
+    const onChange = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/packages/next-shell/src/hooks/use-mounted.ts
+++ b/packages/next-shell/src/hooks/use-mounted.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * Returns `true` after the component first mounts (client-only). Safe to
+ * use for conditional rendering that must be skipped during SSR.
+ */
+export function useMounted(): boolean {
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  return mounted;
+}

--- a/packages/next-shell/src/hooks/use-session-storage.ts
+++ b/packages/next-shell/src/hooks/use-session-storage.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import * as React from 'react';
+
+type SetValue<T> = (value: T | ((prev: T) => T)) => void;
+
+/**
+ * SSR-safe `sessionStorage` hook. Same API as `useLocalStorage` but backed
+ * by `sessionStorage` (cleared when the tab closes).
+ */
+export function useSessionStorage<T>(key: string, initialValue: T): [T, SetValue<T>, () => void] {
+  const [storedValue, setStoredValue] = React.useState<T>(() => {
+    if (typeof window === 'undefined') return initialValue;
+    try {
+      const item = window.sessionStorage.getItem(key);
+      return item !== null ? (JSON.parse(item) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  const setValue: SetValue<T> = React.useCallback(
+    (value) => {
+      setStoredValue((prev) => {
+        const resolved = typeof value === 'function' ? (value as (p: T) => T)(prev) : value;
+        try {
+          window.sessionStorage.setItem(key, JSON.stringify(resolved));
+        } catch {
+          // ignore
+        }
+        return resolved;
+      });
+    },
+    [key],
+  );
+
+  const removeValue = React.useCallback(() => {
+    setStoredValue(initialValue);
+    try {
+      window.sessionStorage.removeItem(key);
+    } catch {
+      // ignore
+    }
+  }, [key, initialValue]);
+
+  return [storedValue, setValue, removeValue];
+}

--- a/packages/next-shell/tests/formatters.test.ts
+++ b/packages/next-shell/tests/formatters.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDate, formatRelativeTime } from '../src/formatters/date.js';
+import {
+  formatNumber,
+  formatCurrency,
+  formatPercent,
+  formatFileSize,
+  formatDuration,
+} from '../src/formatters/number.js';
+import {
+  truncate,
+  pluralize,
+  toTitleCase,
+  toKebabCase,
+  slugify,
+} from '../src/formatters/string.js';
+
+/* ── formatDate ──────────────────────────────────────────────────────────── */
+
+describe('formatDate', () => {
+  const d = new Date('2026-04-16T12:00:00Z');
+
+  it('returns a string', () => {
+    expect(typeof formatDate(d, { locale: 'en-US' })).toBe('string');
+  });
+
+  it('accepts a timestamp', () => {
+    expect(typeof formatDate(d.getTime(), { locale: 'en-US' })).toBe('string');
+  });
+
+  it('accepts an ISO string', () => {
+    expect(typeof formatDate('2026-04-16', { locale: 'en-US' })).toBe('string');
+  });
+
+  it('respects dateStyle option', () => {
+    const short = formatDate(d, { dateStyle: 'short', locale: 'en-US' });
+    const long = formatDate(d, { dateStyle: 'long', locale: 'en-US' });
+    expect(short.length).toBeLessThan(long.length);
+  });
+});
+
+/* ── formatRelativeTime ──────────────────────────────────────────────────── */
+
+describe('formatRelativeTime', () => {
+  const now = new Date('2026-04-16T12:00:00Z');
+
+  it('returns "now" / "0 seconds ago" for same time', () => {
+    const result = formatRelativeTime(now, { now, locale: 'en' });
+    expect(result).toBeTruthy();
+  });
+
+  it('returns past for earlier date', () => {
+    const past = new Date(now.getTime() - 3 * 24 * 3600 * 1000);
+    const result = formatRelativeTime(past, { now, locale: 'en' });
+    expect(result).toMatch(/3 days ago/i);
+  });
+
+  it('returns future for later date', () => {
+    const future = new Date(now.getTime() + 2 * 3600 * 1000);
+    const result = formatRelativeTime(future, { now, locale: 'en' });
+    expect(result).toMatch(/in 2 hours/i);
+  });
+
+  it('handles years', () => {
+    const past = new Date(now.getTime() - 2 * 365 * 24 * 3600 * 1000);
+    const result = formatRelativeTime(past, { now, locale: 'en' });
+    expect(result).toMatch(/2 years ago/i);
+  });
+});
+
+/* ── formatNumber ────────────────────────────────────────────────────────── */
+
+describe('formatNumber', () => {
+  it('formats with grouping by default', () => {
+    const result = formatNumber(1234567, { locale: 'en-US' });
+    expect(result).toContain(',');
+  });
+
+  it('formats zero', () => {
+    expect(formatNumber(0, { locale: 'en-US' })).toBe('0');
+  });
+
+  it('respects maximumFractionDigits', () => {
+    const result = formatNumber(1.23456, { maximumFractionDigits: 2, locale: 'en-US' });
+    expect(result).toBe('1.23');
+  });
+});
+
+/* ── formatCurrency ──────────────────────────────────────────────────────── */
+
+describe('formatCurrency', () => {
+  it('includes currency symbol', () => {
+    const result = formatCurrency(9.99, 'USD', { locale: 'en-US' });
+    expect(result).toContain('$');
+    expect(result).toContain('9.99');
+  });
+});
+
+/* ── formatPercent ───────────────────────────────────────────────────────── */
+
+describe('formatPercent', () => {
+  it('formats 0.75 as 75%', () => {
+    const result = formatPercent(0.75, { locale: 'en-US' });
+    expect(result).toContain('75');
+    expect(result).toContain('%');
+  });
+
+  it('formats 1 as 100%', () => {
+    const result = formatPercent(1, { locale: 'en-US' });
+    expect(result).toContain('100');
+  });
+});
+
+/* ── formatFileSize ──────────────────────────────────────────────────────── */
+
+describe('formatFileSize', () => {
+  it('formats 0 as "0 B"', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+  });
+
+  it('formats bytes', () => {
+    expect(formatFileSize(512)).toContain('B');
+  });
+
+  it('formats kilobytes', () => {
+    const result = formatFileSize(1536);
+    expect(result).toContain('KB');
+  });
+
+  it('formats megabytes', () => {
+    const result = formatFileSize(1_048_576);
+    expect(result).toContain('MB');
+  });
+
+  it('formats gigabytes', () => {
+    const result = formatFileSize(1_073_741_824);
+    expect(result).toContain('GB');
+  });
+});
+
+/* ── formatDuration ──────────────────────────────────────────────────────── */
+
+describe('formatDuration', () => {
+  it('formats milliseconds to 0 sec', () => {
+    expect(formatDuration(0)).toBe('0 sec');
+  });
+
+  it('formats seconds', () => {
+    expect(formatDuration(45_000)).toBe('45 seconds');
+  });
+
+  it('formats hours and minutes', () => {
+    const result = formatDuration(7_383_000);
+    expect(result).toMatch(/2 hours/i);
+    expect(result).toMatch(/3 minutes/i);
+  });
+
+  it('respects parts=1', () => {
+    const result = formatDuration(7_383_000, { parts: 1 });
+    expect(result).toMatch(/2 hours/i);
+    expect(result).not.toContain(',');
+  });
+});
+
+/* ── truncate ────────────────────────────────────────────────────────────── */
+
+describe('truncate', () => {
+  it('returns string as-is when short enough', () => {
+    expect(truncate('Hi', 10)).toBe('Hi');
+  });
+
+  it('truncates and appends suffix', () => {
+    expect(truncate('Hello, world!', 8)).toBe('Hello, …');
+  });
+
+  it('supports custom suffix', () => {
+    expect(truncate('Hello, world!', 10, '...')).toBe('Hello, ...');
+  });
+});
+
+/* ── pluralize ───────────────────────────────────────────────────────────── */
+
+describe('pluralize', () => {
+  it('uses singular for count=1', () => {
+    expect(pluralize(1, 'item')).toBe('1 item');
+  });
+
+  it('uses plural for count≠1', () => {
+    expect(pluralize(3, 'item')).toBe('3 items');
+  });
+
+  it('uses explicit plural', () => {
+    expect(pluralize(2, 'goose', 'geese')).toBe('2 geese');
+  });
+
+  it('handles zero', () => {
+    expect(pluralize(0, 'item')).toBe('0 items');
+  });
+});
+
+/* ── toTitleCase ─────────────────────────────────────────────────────────── */
+
+describe('toTitleCase', () => {
+  it('capitalises each word', () => {
+    expect(toTitleCase('hello world')).toBe('Hello World');
+  });
+
+  it('lowercases rest of word', () => {
+    expect(toTitleCase('hELLO wORLD')).toBe('Hello World');
+  });
+});
+
+/* ── toKebabCase ─────────────────────────────────────────────────────────── */
+
+describe('toKebabCase', () => {
+  it('converts camelCase', () => {
+    expect(toKebabCase('HelloWorld')).toBe('hello-world');
+  });
+
+  it('converts spaces', () => {
+    expect(toKebabCase('my string')).toBe('my-string');
+  });
+});
+
+/* ── slugify ─────────────────────────────────────────────────────────────── */
+
+describe('slugify', () => {
+  it('lowercases and replaces spaces with hyphens', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  it('removes special characters', () => {
+    expect(slugify('Hello, World!')).toBe('hello-world');
+  });
+
+  it('strips accents', () => {
+    expect(slugify('café')).toBe('cafe');
+  });
+
+  it('collapses multiple hyphens', () => {
+    expect(slugify('a  b')).toBe('a-b');
+  });
+});

--- a/packages/next-shell/tests/hooks.test.tsx
+++ b/packages/next-shell/tests/hooks.test.tsx
@@ -1,0 +1,292 @@
+import * as React from 'react';
+import { act, render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDisclosure } from '../src/hooks/use-disclosure.js';
+import { useDebouncedValue } from '../src/hooks/use-debounced-value.js';
+import { useDebouncedCallback } from '../src/hooks/use-debounced-callback.js';
+import { useMounted } from '../src/hooks/use-mounted.js';
+import { useLocalStorage } from '../src/hooks/use-local-storage.js';
+import { useSessionStorage } from '../src/hooks/use-session-storage.js';
+import { useControllableState } from '../src/hooks/use-controllable-state.js';
+import { useHotkey } from '../src/hooks/use-hotkey.js';
+import { useCopyToClipboard } from '../src/hooks/use-copy-to-clipboard.js';
+
+/* ── useDisclosure ─────────────────────────────────────────────────────── */
+
+describe('useDisclosure', () => {
+  it('defaults to closed', () => {
+    const { result } = renderHook(() => useDisclosure());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('opens with initialOpen=true', () => {
+    const { result } = renderHook(() => useDisclosure(true));
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('open() sets isOpen to true', () => {
+    const { result } = renderHook(() => useDisclosure());
+    act(() => result.current.open());
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('close() sets isOpen to false', () => {
+    const { result } = renderHook(() => useDisclosure(true));
+    act(() => result.current.close());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('toggle() flips isOpen', () => {
+    const { result } = renderHook(() => useDisclosure());
+    act(() => result.current.toggle());
+    expect(result.current.isOpen).toBe(true);
+    act(() => result.current.toggle());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('onOpenChange sets value directly', () => {
+    const { result } = renderHook(() => useDisclosure());
+    act(() => result.current.onOpenChange(true));
+    expect(result.current.isOpen).toBe(true);
+  });
+});
+
+/* ── useDebouncedValue ─────────────────────────────────────────────────── */
+
+describe('useDebouncedValue', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('returns initial value immediately', () => {
+    const { result } = renderHook(() => useDebouncedValue('hello', 300));
+    expect(result.current).toBe('hello');
+  });
+
+  it('updates after delay', () => {
+    const { result, rerender } = renderHook(({ val }) => useDebouncedValue(val, 300), {
+      initialProps: { val: 'a' },
+    });
+    rerender({ val: 'b' });
+    expect(result.current).toBe('a');
+    act(() => vi.advanceTimersByTime(300));
+    expect(result.current).toBe('b');
+  });
+
+  it('resets timer on rapid changes', () => {
+    const { result, rerender } = renderHook(({ val }) => useDebouncedValue(val, 300), {
+      initialProps: { val: 'a' },
+    });
+    rerender({ val: 'b' });
+    act(() => vi.advanceTimersByTime(100));
+    rerender({ val: 'c' });
+    act(() => vi.advanceTimersByTime(200));
+    expect(result.current).toBe('a');
+    act(() => vi.advanceTimersByTime(100));
+    expect(result.current).toBe('c');
+  });
+});
+
+/* ── useDebouncedCallback ──────────────────────────────────────────────── */
+
+describe('useDebouncedCallback', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('does not call immediately', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(fn, 200));
+    act(() => result.current('x'));
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('calls after delay', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(fn, 200));
+    act(() => result.current('x'));
+    act(() => vi.advanceTimersByTime(200));
+    expect(fn).toHaveBeenCalledWith('x');
+  });
+
+  it('only calls once for rapid invocations', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(fn, 200));
+    act(() => {
+      result.current('a');
+      result.current('b');
+      result.current('c');
+    });
+    act(() => vi.advanceTimersByTime(200));
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('c');
+  });
+});
+
+/* ── useMounted ───────────────────────────────────────────────────────── */
+
+describe('useMounted', () => {
+  it('returns true after mounting', () => {
+    function Probe() {
+      const mounted = useMounted();
+      return <span data-testid="val">{mounted ? 'yes' : 'no'}</span>;
+    }
+    render(<Probe />);
+    expect(screen.getByTestId('val')).toHaveTextContent('yes');
+  });
+});
+
+/* ── useLocalStorage ──────────────────────────────────────────────────── */
+
+describe('useLocalStorage', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('returns initialValue when key is absent', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 42));
+    expect(result.current[0]).toBe(42);
+  });
+
+  it('persists value to localStorage', () => {
+    const { result } = renderHook(() => useLocalStorage('theme', 'light'));
+    act(() => result.current[1]('dark'));
+    expect(localStorage.getItem('theme')).toBe('"dark"');
+    expect(result.current[0]).toBe('dark');
+  });
+
+  it('supports functional updater', () => {
+    const { result } = renderHook(() => useLocalStorage('count', 0));
+    act(() => result.current[1]((prev) => prev + 1));
+    expect(result.current[0]).toBe(1);
+  });
+
+  it('removeValue resets to initial', () => {
+    const { result } = renderHook(() => useLocalStorage('x', 'init'));
+    act(() => result.current[1]('changed'));
+    act(() => result.current[2]());
+    expect(result.current[0]).toBe('init');
+    expect(localStorage.getItem('x')).toBeNull();
+  });
+});
+
+/* ── useSessionStorage ────────────────────────────────────────────────── */
+
+describe('useSessionStorage', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('returns initialValue when key is absent', () => {
+    const { result } = renderHook(() => useSessionStorage('key', 'default'));
+    expect(result.current[0]).toBe('default');
+  });
+
+  it('persists value to sessionStorage', () => {
+    const { result } = renderHook(() => useSessionStorage('sid', 'abc'));
+    act(() => result.current[1]('xyz'));
+    expect(sessionStorage.getItem('sid')).toBe('"xyz"');
+  });
+});
+
+/* ── useControllableState ─────────────────────────────────────────────── */
+
+describe('useControllableState', () => {
+  it('uses defaultProp as initial uncontrolled value', () => {
+    const { result } = renderHook(() => useControllableState({ defaultProp: 'hello' }));
+    expect(result.current[0]).toBe('hello');
+  });
+
+  it('updates uncontrolled value', () => {
+    const { result } = renderHook(() => useControllableState({ defaultProp: 0 }));
+    act(() => result.current[1](5));
+    expect(result.current[0]).toBe(5);
+  });
+
+  it('uses prop as controlled value', () => {
+    const { result } = renderHook(() => useControllableState({ prop: 'controlled' }));
+    expect(result.current[0]).toBe('controlled');
+  });
+
+  it('calls onChange when value changes', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useControllableState({ defaultProp: 0, onChange }));
+    act(() => result.current[1](99));
+    expect(onChange).toHaveBeenCalledWith(99);
+  });
+
+  it('supports functional updater', () => {
+    const { result } = renderHook(() => useControllableState({ defaultProp: 10 }));
+    act(() => result.current[1]((prev) => (prev ?? 0) + 1));
+    expect(result.current[0]).toBe(11);
+  });
+});
+
+/* ── useHotkey ────────────────────────────────────────────────────────── */
+
+describe('useHotkey', () => {
+  it('calls handler when key matches', async () => {
+    const user = userEvent.setup();
+    const handler = vi.fn();
+    function Probe() {
+      useHotkey('k', handler, { preventDefault: false });
+      return <div />;
+    }
+    render(<Probe />);
+    await user.keyboard('k');
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call handler for wrong key', async () => {
+    const user = userEvent.setup();
+    const handler = vi.fn();
+    function Probe() {
+      useHotkey('k', handler, { preventDefault: false });
+      return <div />;
+    }
+    render(<Probe />);
+    await user.keyboard('j');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not attach when enabled=false', async () => {
+    const user = userEvent.setup();
+    const handler = vi.fn();
+    function Probe() {
+      useHotkey('k', handler, { enabled: false, preventDefault: false });
+      return <div />;
+    }
+    render(<Probe />);
+    await user.keyboard('k');
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+/* ── useCopyToClipboard ───────────────────────────────────────────────── */
+
+describe('useCopyToClipboard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('copies text and sets isCopied', async () => {
+    const { result } = renderHook(() => useCopyToClipboard(1000));
+    await act(async () => {
+      await result.current.copy('hello');
+    });
+    expect(result.current.isCopied).toBe(true);
+    expect(result.current.copiedValue).toBe('hello');
+  });
+
+  it('resets isCopied after resetMs', async () => {
+    const { result } = renderHook(() => useCopyToClipboard(500));
+    await act(async () => {
+      await result.current.copy('test');
+    });
+    expect(result.current.isCopied).toBe(true);
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current.isCopied).toBe(false);
+  });
+});

--- a/packages/next-shell/tsup.config.ts
+++ b/packages/next-shell/tsup.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
     'auth/adapters/nextauth': 'src/auth/adapters/nextauth.ts',
     'auth/adapters/mock': 'src/auth/adapters/mock.ts',
     'hooks/index': 'src/hooks/index.ts',
+    'formatters/index': 'src/formatters/index.ts',
     'tokens/index': 'src/tokens/index.ts',
     'tailwind-preset/index': 'src/tailwind-preset/index.ts',
   },


### PR DESCRIPTION
Closes #9 · Refs #13

## What's in the box

**`@jonmatum/next-shell/hooks`** — 12 new hooks (+`useIsMobile` already present):

| Hook | Purpose |
|------|---------|
| `useIsomorphicLayoutEffect` | `useLayoutEffect` on client, `useEffect` on server |
| `useMounted()` | `true` after first mount — SSR-safe conditional render |
| `useMediaQuery(query)` | SSR-safe, event-driven media query |
| `useBreakpoint()` | `isSm/isMd/isLg/isXl/is2xl` + `current` Tailwind breakpoint |
| `useDisclosure(initialOpen?)` | `open/close/toggle/onOpenChange` — dialog/drawer primitive |
| `useLocalStorage(key, init)` | JSON-serialised, SSR-safe, functional updater, `removeValue` |
| `useSessionStorage(key, init)` | Same as above but `sessionStorage` |
| `useCopyToClipboard(resetMs)` | `isCopied` auto-resets; `copiedValue` preserved |
| `useDebouncedValue(val, ms)` | Debounced state value |
| `useDebouncedCallback(fn, ms)` | Stable ref-wrapped debounced function |
| `useControllableState(opts)` | Radix-style controlled/uncontrolled with `onChange` |
| `useHotkey(key, handler, opts)` | `meta/ctrl/shift/alt`, `enabled` flag, custom `target` |
| `useLocale()` | Reads `I18nAdapter.locale` or `navigator.language` |

**`@jonmatum/next-shell/formatters`** — pure functions, no React, server-safe:

- **Date:** `formatDate`, `formatRelativeTime` (Intl-based, `now` param for deterministic tests)
- **Number:** `formatNumber`, `formatCurrency`, `formatPercent`, `formatFileSize`, `formatDuration`
- **String:** `truncate`, `pluralize`, `toTitleCase`, `toKebabCase`, `slugify`

All formatters accept optional `locale` string — compose with `useLocale()` for context-aware rendering.

## What is intentionally NOT in this PR

- Data-fetching hooks (`useSWR`-style) — TanStack Query covers this via the providers layer
- `useForm` wrappers — `react-hook-form` is a direct dep; consumers use it directly
- Animation hooks — `tw-animate-css` utilities cover the token-driven animation needs

## Verification

```
pnpm format    ✓
pnpm lint      ✓  (0 errors, 0 warnings)
pnpm typecheck ✓
pnpm test      ✓  508 tests, 21 files (3.51s)
pnpm build     ✓  all DTS + ESM + CJS emitted incl. formatters/index
```

## Checklist

- [x] No raw color literals
- [x] All hook files have `'use client'` directive; `formatters/` has none (server-safe)
- [x] `hooks/index` already in `CLIENT_ENTRIES`; `formatters/index` is server-safe (no directive needed)
- [x] `./formatters` added to `package.json#exports` + `tsup.config.ts` entry
- [x] 67 new tests across `hooks.test.tsx` and `formatters.test.ts`
- [x] Both READMEs updated (Phase 8 ✅, test count 441→508, new subpath rows)
- [x] Commit is GPG-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)