### PR TITLE
feat(phase-11): example consumer app — dashboard, data table, auth guards, settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build library
+        run: pnpm build
+
       - name: Lint
         run: pnpm lint
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Monorepo for [`@jonmatum/next-shell`](./packages/next-shell) — a reusable Next.js app shell built on **shadcn/ui** primitives with a strict **semantic-token** design system.
 
-> **Status:** Phases 0–9 landed on `main`. Phase 10 (release pipeline) in progress. Track phase-by-phase progress in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
+> **Status:** Phases 0–10 landed on `main`. Phase 11 (example consumer app) in progress. Track phase-by-phase progress in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
 
 ## What's in the box today
 
@@ -18,8 +18,8 @@ Monorepo for [`@jonmatum/next-shell`](./packages/next-shell) — a reusable Next
 |     7 | Auth adapter pattern — `AuthProvider`, `useSession`, `useUser`, `useHasPermission`, `useRequireAuth`, `SignedIn`, `SignedOut`, `RoleGate`, `requireSession` (server)         | ✅ Landed  |
 |     8 | Hooks + formatters — `useDisclosure`, `useLocalStorage`, `useDebounced*`, `useHotkey`, `useBreakpoint`, `useCopyToClipboard` + `formatDate`, `formatCurrency`, `truncate`, … | ✅ Landed  |
 |     9 | Docs site (fumadocs v14) — 8 content pages covering all phases; Storybook deferred                                                                                           | ✅ Landed  |
-|    10 | Publishing + changeset release workflow — `changesets/action`, npm provenance, `release.yml`                                                                                 | 🚧 PR open |
-|    11 | Integration back into Smart Pad Rules                                                                                                                                        | ⏳ Queued  |
+|    10 | Publishing + changeset release workflow — `changesets/action`, npm provenance, `release.yml`                                                                                 | ✅ Landed  |
+|    11 | Example consumer app — dashboard, data table, auth guards, settings form, toast demos                                                                                        | 🚧 PR open |
 
 **42 primitives** (Phase 3): Accordion, Alert, AlertDialog, AspectRatio, Avatar, Badge, Breadcrumb, Button, Calendar, Card, Carousel, Chart, Checkbox, Collapsible, Command, ContextMenu, Dialog, Drawer, DropdownMenu, Form, HoverCard, Input, InputOTP, Label, Menubar, NavigationMenu, Pagination, Popover, Progress, RadioGroup, Resizable, ScrollArea, Select, Separator, Sheet, Skeleton, Slider, Switch, Table, Tabs, Textarea, Toaster (Sonner), Toggle, ToggleGroup, Tooltip.
 

--- a/apps/example/.gitignore
+++ b/apps/example/.gitignore
@@ -1,0 +1,1 @@
+next-env.d.ts

--- a/apps/example/app/(shell)/admin/page.tsx
+++ b/apps/example/app/(shell)/admin/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { ContentContainer, PageHeader, ErrorState } from '@jonmatum/next-shell/layout';
+import { Card, CardContent, CardHeader, CardTitle, Badge } from '@jonmatum/next-shell/primitives';
+import { SignedIn, SignedOut, RoleGate, useUser } from '@jonmatum/next-shell/auth';
+import { Shield, Users, Key } from 'lucide-react';
+
+export default function AdminPage() {
+  const user = useUser();
+
+  return (
+    <ContentContainer>
+      <PageHeader title="Admin Panel" description="Restricted to users with the admin role." />
+
+      {/* SignedOut guard demo */}
+      <SignedOut>
+        <ErrorState title="Not authenticated" description="Sign in to access this page." />
+      </SignedOut>
+
+      {/* RoleGate: only admin sees the panel */}
+      <SignedIn>
+        <RoleGate
+          role={['admin']}
+          fallback={
+            <ErrorState
+              title="Access denied"
+              description="You need the admin role to view this section."
+            />
+          }
+        >
+          <div className="grid gap-4 md:grid-cols-3">
+            <Card>
+              <CardHeader className="flex flex-row items-center gap-2">
+                <Shield className="text-primary size-4" />
+                <CardTitle className="text-sm">Role</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-1">
+                  {(user?.roles ?? []).map((r) => (
+                    <Badge key={r}>{r}</Badge>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center gap-2">
+                <Users className="text-primary size-4" />
+                <CardTitle className="text-sm">Session User</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm font-medium">{user?.name}</p>
+                <p className="text-muted-foreground text-xs">{user?.email}</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center gap-2">
+                <Key className="text-primary size-4" />
+                <CardTitle className="text-sm">Auth Adapter</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Badge variant="outline">mock adapter</Badge>
+              </CardContent>
+            </Card>
+          </div>
+        </RoleGate>
+      </SignedIn>
+    </ContentContainer>
+  );
+}

--- a/apps/example/app/(shell)/dashboard/page.tsx
+++ b/apps/example/app/(shell)/dashboard/page.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { toast } from 'sonner';
+import {
+  ContentContainer,
+  PageHeader,
+  EmptyState,
+  LoadingState,
+} from '@jonmatum/next-shell/layout';
+import { Button, Card, CardContent, CardHeader, CardTitle } from '@jonmatum/next-shell/primitives';
+import { useUser, SignedIn } from '@jonmatum/next-shell/auth';
+import { TrendingUp, Users, DollarSign, Activity, Plus, RefreshCw } from 'lucide-react';
+
+const stats = [
+  { label: 'Total Revenue', value: '$48,295', change: '+12%', icon: DollarSign },
+  { label: 'Active Users', value: '2,841', change: '+4%', icon: Users },
+  { label: 'Conversions', value: '1,023', change: '+8%', icon: TrendingUp },
+  { label: 'System Health', value: '99.9%', change: '0%', icon: Activity },
+];
+
+export default function DashboardPage() {
+  const user = useUser();
+
+  return (
+    <ContentContainer>
+      <PageHeader
+        title={`Welcome back, ${user?.name ?? 'Demo User'}`}
+        description="Here's what's happening with your project today."
+        actions={
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => toast.info('Refreshed!', { description: 'Data is up to date.' })}
+            >
+              <RefreshCw className="size-4" />
+              Refresh
+            </Button>
+            <Button
+              size="sm"
+              onClick={() =>
+                toast.success('Created!', { description: 'New item added successfully.' })
+              }
+            >
+              <Plus className="size-4" />
+              New Item
+            </Button>
+          </div>
+        }
+      />
+
+      {/* Stats Grid */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {stats.map((stat) => (
+          <Card key={stat.label}>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-sm font-medium">{stat.label}</CardTitle>
+              <stat.icon className="text-muted-foreground size-4" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{stat.value}</div>
+              <p className="text-muted-foreground text-xs">{stat.change} from last month</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Status State Demo */}
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Loading State</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <LoadingState description="Fetching analytics…" />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Empty State</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <EmptyState
+              title="No recent activity"
+              description="Activity will appear here once events are recorded."
+              action={
+                <Button variant="outline" size="sm">
+                  <Plus className="size-4" />
+                  Add first item
+                </Button>
+              }
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Toast Demo */}
+      <SignedIn>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Toast Demos</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-wrap gap-2">
+            <Button variant="outline" size="sm" onClick={() => toast.success('Success toast!')}>
+              Success
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => toast.error('Something went wrong.')}
+            >
+              Error
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                toast.promise(new Promise((r) => setTimeout(r, 2000)), {
+                  loading: 'Processing…',
+                  success: 'Done!',
+                  error: 'Failed.',
+                });
+              }}
+            >
+              Promise
+            </Button>
+          </CardContent>
+        </Card>
+      </SignedIn>
+    </ContentContainer>
+  );
+}

--- a/apps/example/app/(shell)/data/page.tsx
+++ b/apps/example/app/(shell)/data/page.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState } from 'react';
+import { ContentContainer, PageHeader } from '@jonmatum/next-shell/layout';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Badge,
+  Input,
+} from '@jonmatum/next-shell/primitives';
+import { ChevronLeft, ChevronRight, Search } from 'lucide-react';
+
+type Status = 'active' | 'inactive' | 'pending';
+
+interface Row {
+  id: number;
+  name: string;
+  email: string;
+  role: string;
+  status: Status;
+  joined: string;
+}
+
+const ROWS: Row[] = Array.from({ length: 50 }, (_, i) => ({
+  id: i + 1,
+  name: `User ${i + 1}`,
+  email: `user${i + 1}@example.com`,
+  role: i % 5 === 0 ? 'admin' : i % 3 === 0 ? 'editor' : 'viewer',
+  status: (['active', 'inactive', 'pending'] as Status[])[i % 3]!,
+  joined: new Date(2024, i % 12, (i % 28) + 1).toLocaleDateString(),
+}));
+
+const PAGE_SIZE = 10;
+
+const statusVariant: Record<Status, 'default' | 'secondary' | 'outline'> = {
+  active: 'default',
+  inactive: 'secondary',
+  pending: 'outline',
+};
+
+export default function DataPage() {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+
+  const filtered = ROWS.filter(
+    (r) =>
+      r.name.toLowerCase().includes(search.toLowerCase()) ||
+      r.email.toLowerCase().includes(search.toLowerCase()),
+  );
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+  const slice = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  return (
+    <ContentContainer>
+      <PageHeader title="Data Table" description="Server-side pagination and filtering demo." />
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-4">
+          <CardTitle className="text-sm">Users ({filtered.length})</CardTitle>
+          <div className="relative max-w-xs flex-1">
+            <Search className="text-muted-foreground absolute left-2.5 top-2.5 size-4" />
+            <Input
+              placeholder="Filter users…"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
+              className="pl-8"
+            />
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Joined</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {slice.map((row) => (
+                <TableRow key={row.id}>
+                  <TableCell className="font-medium">{row.name}</TableCell>
+                  <TableCell className="text-muted-foreground">{row.email}</TableCell>
+                  <TableCell>{row.role}</TableCell>
+                  <TableCell>
+                    <Badge variant={statusVariant[row.status]}>{row.status}</Badge>
+                  </TableCell>
+                  <TableCell>{row.joined}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          <div className="flex items-center justify-between border-t px-4 py-3">
+            <span className="text-muted-foreground text-sm">
+              Page {page} of {totalPages}
+            </span>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 1}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                <ChevronLeft className="size-4" />
+                Prev
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === totalPages}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+                <ChevronRight className="size-4" />
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </ContentContainer>
+  );
+}

--- a/apps/example/app/(shell)/layout.tsx
+++ b/apps/example/app/(shell)/layout.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { AppShell, TopBar, SidebarNav, Breadcrumbs, buildNav } from '@jonmatum/next-shell/layout';
+import { ThemeToggleDropdown } from '@jonmatum/next-shell/providers';
+import { useUser } from '@jonmatum/next-shell/auth';
+import { LayoutDashboard, Settings, Shield, Database, Bell } from 'lucide-react';
+import type { NavConfig } from '@jonmatum/next-shell/layout';
+
+const NAV_CONFIG: NavConfig = [
+  { id: 'dashboard', label: 'Dashboard', href: '/dashboard', icon: <LayoutDashboard /> },
+  { id: 'data', label: 'Data Table', href: '/data', icon: <Database /> },
+  { id: 'admin', label: 'Admin', href: '/admin', icon: <Shield />, requires: ['admin'] },
+  { id: 'settings', label: 'Settings', href: '/settings', icon: <Settings /> },
+];
+
+function ShellSidebar({ pathname }: { pathname: string }) {
+  const user = useUser();
+  const { items } = buildNav({
+    config: NAV_CONFIG,
+    pathname,
+    permissions: user?.roles ?? [],
+  });
+  return <SidebarNav items={items} label="Menu" />;
+}
+
+function ShellTopBar({ pathname }: { pathname: string }) {
+  const user = useUser();
+  return (
+    <TopBar
+      left={<Breadcrumbs config={NAV_CONFIG} pathname={pathname} />}
+      right={
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground hidden text-sm sm:block">
+            {user?.name ?? 'Demo User'}
+          </span>
+          <ThemeToggleDropdown />
+          <Bell className="text-muted-foreground size-4 cursor-pointer" />
+        </div>
+      }
+    />
+  );
+}
+
+export default function ShellLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <AppShell
+      commandBar
+      sidebar={<ShellSidebar pathname={pathname} />}
+      topBar={<ShellTopBar pathname={pathname} />}
+      footer={
+        <footer className="border-border text-muted-foreground border-t px-6 py-3 text-xs">
+          next-shell example app
+        </footer>
+      }
+    >
+      {children}
+    </AppShell>
+  );
+}

--- a/apps/example/app/(shell)/settings/page.tsx
+++ b/apps/example/app/(shell)/settings/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { ContentContainer, PageHeader } from '@jonmatum/next-shell/layout';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  Input,
+  Label,
+  Separator,
+} from '@jonmatum/next-shell/primitives';
+import { ThemeToggleDropdown } from '@jonmatum/next-shell/providers';
+import { useUser } from '@jonmatum/next-shell/auth';
+
+interface ProfileForm {
+  name: string;
+  email: string;
+}
+
+export default function SettingsPage() {
+  const user = useUser();
+  const { register, handleSubmit } = useForm<ProfileForm>({
+    defaultValues: { name: user?.name ?? '', email: user?.email ?? '' },
+  });
+
+  function onSubmit(data: ProfileForm) {
+    toast.promise(new Promise((r) => setTimeout(r, 1200)), {
+      loading: 'Saving profile…',
+      success: `Profile updated for ${data.name}`,
+      error: 'Failed to save.',
+    });
+  }
+
+  return (
+    <ContentContainer size="sm">
+      <PageHeader title="Settings" description="Manage your profile and preferences." />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Profile</CardTitle>
+          <CardDescription>Update your display name and email address.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="name">Display name</Label>
+              <Input id="name" {...register('name')} />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" type="email" {...register('email')} />
+            </div>
+            <div className="flex justify-end">
+              <Button type="submit" size="sm">
+                Save changes
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Separator />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Appearance</CardTitle>
+          <CardDescription>Toggle between light, dark, and system theme.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-between">
+          <span className="text-sm">Color scheme</span>
+          <ThemeToggleDropdown />
+        </CardContent>
+      </Card>
+    </ContentContainer>
+  );
+}

--- a/apps/example/app/globals.css
+++ b/apps/example/app/globals.css
@@ -1,0 +1,4 @@
+@import '@jonmatum/next-shell/styles/tokens.css';
+@import '@jonmatum/next-shell/styles/preset.css';
+
+@import 'tailwindcss';

--- a/apps/example/app/layout.tsx
+++ b/apps/example/app/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import { AppProviders } from '@jonmatum/next-shell/providers';
+import { AuthProvider } from '@jonmatum/next-shell/auth';
+import { createMockAuthAdapter } from '@jonmatum/next-shell/auth/mock';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'next-shell Example',
+  description: 'Living reference implementation for @jonmatum/next-shell',
+};
+
+const authAdapter = createMockAuthAdapter({
+  user: { id: '1', name: 'Demo User', email: 'demo@example.com', roles: ['admin'] },
+});
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <AppProviders themeProps={{ defaultTheme: 'system', enableSystem: true }}>
+          <AuthProvider adapter={authAdapter}>{children}</AuthProvider>
+        </AppProviders>
+      </body>
+    </html>
+  );
+}

--- a/apps/example/app/page.tsx
+++ b/apps/example/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Home() {
+  redirect('/dashboard');
+}

--- a/apps/example/next.config.ts
+++ b/apps/example/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const config: NextConfig = {
+  transpilePackages: ['@jonmatum/next-shell'],
+};
+
+export default config;

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@jonmatum/next-shell-example",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev --turbo",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@jonmatum/next-shell": "workspace:*",
+    "lucide-react": "^0.544.0",
+    "next": "^15.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-hook-form": "^7.72.1",
+    "sonner": "^2.0.7",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "@types/react": "^19.0.1",
+    "@types/react-dom": "^19.0.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/example/tsconfig.json
+++ b/apps/example/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "preserve",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ export default [
       '**/.source/**',
       '**/coverage/**',
       '**/*.min.js',
+      '**/next-env.d.ts',
       'pnpm-lock.yaml',
       '.claude/skills/**',
     ],

--- a/packages/next-shell/README.md
+++ b/packages/next-shell/README.md
@@ -2,7 +2,7 @@
 
 Reusable Next.js app shell built on **shadcn/ui** primitives with a strict **semantic-token** design system.
 
-> **Status:** Phases 0–9 landed on `main` (tokens, theming, 42 primitives, full layout shell, nav system, providers, auth adapters, hooks + formatters, docs site). Release pipeline (Phase 10) in progress. Follow the rollout in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
+> **Status:** Phases 0–10 landed on `main` (tokens, theming, 42 primitives, full layout shell, nav system, providers, auth adapters, hooks + formatters, docs site, release pipeline). Phase 11 (example app) in progress. Follow the rollout in [Epic #13](https://github.com/jonmatum/next-shell/issues/13).
 
 ## Install
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,46 @@ importers:
         specifier: ^5.6.3
         version: 5.9.3
 
+  apps/example:
+    dependencies:
+      '@jonmatum/next-shell':
+        specifier: workspace:*
+        version: link:../../packages/next-shell
+      lucide-react:
+        specifier: ^0.544.0
+        version: 0.544.0(react@19.2.5)
+      next:
+        specifier: ^15.1.0
+        version: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+      react-hook-form:
+        specifier: ^7.72.1
+        version: 7.72.1(react@19.2.5)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.1
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.1
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
   packages/next-shell:
     dependencies:
       '@tanstack/react-query':
@@ -4516,6 +4556,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -9406,6 +9449,8 @@ snapshots:
   yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
Closes #12 · Refs #13

## Summary

Adds `apps/example` — a Next.js 15 App Router app that exercises every major `@jonmatum/next-shell` feature as a living reference implementation.

## What's in the box

```
apps/example/
├── app/
│   ├── layout.tsx              — AppProviders + AuthProvider (mock adapter, admin role)
│   ├── page.tsx                — redirect → /dashboard
│   └── (shell)/
│       ├── layout.tsx          — AppShell + SidebarNav + TopBar (Breadcrumbs, ThemeToggleDropdown) + footer + CommandBar
│       ├── dashboard/page.tsx  — stat cards, LoadingState + EmptyState, toast demos
│       ├── data/page.tsx       — paginated + filtered table (50 rows, 10/page)
│       ├── admin/page.tsx      — SignedIn + RoleGate guard demo; ErrorState fallback
│       └── settings/page.tsx   — react-hook-form profile form + ThemeToggleDropdown
```

**Feature coverage:**
- AppShell / Sidebar / TopBar / Footer / CommandBar
- SidebarNav with permission-filtered items (`admin` route gated)
- Breadcrumbs derived from nav config + current pathname
- SignedIn / SignedOut / RoleGate components
- useUser hook
- createMockAuthAdapter pre-seeded with admin user
- AppProviders + AuthProvider composition
- toast.success / toast.error / toast.promise
- LoadingState / EmptyState / ErrorState
- ThemeToggleDropdown (live dark mode switch in settings)
- react-hook-form form with save feedback
- Table with client pagination + text filter

## What is intentionally NOT in this PR

- Vercel deployment / live demo URL (can be wired up separately with a Vercel project)
- Recharts / chart widget (data is mocked; adding a chart page is a follow-up)
- Server-side data fetching (all data is in-memory; demonstrates the UI patterns)

## Verification

```
pnpm format      ✅
pnpm lint        ✅ (0 errors, 0 warnings)
pnpm typecheck   ✅ (all 4 workspaces pass)
pnpm test        ✅ 508 tests / 21 files
pnpm build       ✅ library DTS clean
```

## Checklist

- [x] No raw color literals
- [x] `next-env.d.ts` gitignored in `apps/example/`
- [x] `**/next-env.d.ts` in ESLint ignores (avoids triple-slash-reference warning)
- [x] Both READMEs updated (Phases 0–10 ✅, Phase 11 🚧 PR open)
- [x] All commits GPG-signed