### PR TITLE
fix(docs): add tailwindcss as explicit dependency

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,7 +15,8 @@
     "fumadocs-ui": "^14.5.6",
     "next": "^15.1.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,7 +16,8 @@
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwindcss": "^4.2.2"
+    "tailwindcss": "^4.2.2",
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",

--- a/apps/example/app/layout.tsx
+++ b/apps/example/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
-import { AppProviders } from '@jonmatum/next-shell/providers';
-import { AuthProvider } from '@jonmatum/next-shell/auth';
-import { createMockAuthAdapter } from '@jonmatum/next-shell/auth/mock';
+import { Providers } from './providers';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -10,17 +8,11 @@ export const metadata: Metadata = {
   description: 'Living reference implementation for @jonmatum/next-shell',
 };
 
-const authAdapter = createMockAuthAdapter({
-  user: { id: '1', name: 'Demo User', email: 'demo@example.com', roles: ['admin'] },
-});
-
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
-        <AppProviders themeProps={{ defaultTheme: 'system', enableSystem: true }}>
-          <AuthProvider adapter={authAdapter}>{children}</AuthProvider>
-        </AppProviders>
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/apps/example/app/providers.tsx
+++ b/apps/example/app/providers.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { AppProviders } from '@jonmatum/next-shell/providers';
+import { AuthProvider } from '@jonmatum/next-shell/auth';
+import { createMockAuthAdapter } from '@jonmatum/next-shell/auth/mock';
+
+const authAdapter = createMockAuthAdapter({
+  user: { id: '1', name: 'Demo User', email: 'demo@example.com', roles: ['admin'] },
+});
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <AppProviders themeProps={{ defaultTheme: 'system', enableSystem: true }}>
+      <AuthProvider adapter={authAdapter}>{children}</AuthProvider>
+    </AppProviders>
+  );
+}

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.72.1",
     "sonner": "^2.0.7",
+    "tailwindcss": "^4.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -17,6 +17,7 @@
     "react-hook-form": "^7.72.1",
     "sonner": "^2.0.7",
     "tailwindcss": "^4.2.2",
+    "tw-animate-css": "^1.4.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -128,10 +128,14 @@
     "next-auth": ">=5.0.0-beta.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwindcss": "^4.0.0"
+    "tailwindcss": "^4.0.0",
+    "tw-animate-css": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {
+      "optional": true
+    },
+    "tw-animate-css": {
       "optional": true
     },
     "next-auth": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.2.2
       zod:
         specifier: ^3.24.0
         version: 3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 11.10.1(fumadocs-core@14.7.7(@types/react@19.2.14)(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@6.4.2(@types/node@22.19.17)(yaml@2.8.3))
       fumadocs-ui:
         specifier: ^14.5.6
-        version: 14.7.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@14.7.7(@types/react@19.2.14)(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 14.7.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@14.7.7(@types/react@19.2.14)(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.2)
       next:
         specifier: ^15.1.0
         version: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -86,6 +86,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.2.2
     devDependencies:
       '@types/node':
         specifier: ^22.10.1
@@ -7135,7 +7138,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@14.7.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@14.7.7(@types/react@19.2.14)(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  fumadocs-ui@14.7.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@14.7.7(@types/react@19.2.14)(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.2):
     dependencies:
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -7157,6 +7160,8 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-medium-image-zoom: 5.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwind-merge: 2.6.1
+    optionalDependencies:
+      tailwindcss: 4.2.2
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
     devDependencies:
       '@types/node':
         specifier: ^22.10.1
@@ -129,6 +132,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
       zod:
         specifier: ^3.24.0
         version: 3.25.76


### PR DESCRIPTION
Fixes 'Module not found: tailwindcss' when running `pnpm dev` in apps/docs. tailwindcss is not hoisted from next-shell so it must be declared directly.