### PR TITLE
fix(qa): resolve tw-animate-css, React runtime error, and CSS import order

### DIFF
--- a/apps/example/app/globals.css
+++ b/apps/example/app/globals.css
@@ -1,4 +1,2 @@
-@import '@jonmatum/next-shell/styles/tokens.css';
-@import '@jonmatum/next-shell/styles/preset.css';
-
 @import 'tailwindcss';
+@import '@jonmatum/next-shell/styles/preset.css';

--- a/packages/next-shell/src/styles/preset.css
+++ b/packages/next-shell/src/styles/preset.css
@@ -18,6 +18,10 @@
 
 @import './tokens.css';
 
+/* Tell Tailwind v4 to scan this package's bundled output for used class names
+   so tree-shaking doesn't strip utilities that only appear in library code. */
+@source "../**/*.{js,cjs}";
+
 /* Animation utilities — `animate-in`, `fade-in-0`, `zoom-in-95`,
    `slide-in-from-*`, etc. Required by every shadcn/ui overlay primitive
    (Tooltip, Dialog, Popover, DropdownMenu, Sheet, Drawer, …).

--- a/packages/next-shell/tsup.config.ts
+++ b/packages/next-shell/tsup.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'tsup';
 import { cp, readFile, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import path from 'node:path';
 
 /**
  * Entry paths whose bundled output must be client-only (RSC `'use client'`
@@ -56,6 +57,21 @@ export default defineConfig({
     // Copy static CSS assets into dist/styles/.
     if (existsSync('src/styles')) {
       await cp('src/styles', 'dist/styles', { recursive: true });
+    }
+
+    // Inline tw-animate-css into dist/styles/preset.css so the distributed
+    // file has no external CSS @import dependencies. Consuming apps don't need
+    // tw-animate-css in their own node_modules for CSS processing to work.
+    const presetPath = 'dist/styles/preset.css';
+    if (existsSync(presetPath)) {
+      const twAnimatePath = path.join(
+        process.cwd(),
+        'node_modules/tw-animate-css/dist/tw-animate.css',
+      );
+      const twAnimateContent = await readFile(twAnimatePath, 'utf8');
+      const preset = await readFile(presetPath, 'utf8');
+      const inlined = preset.replace("@import 'tw-animate-css';", twAnimateContent);
+      await writeFile(presetPath, inlined, 'utf8');
     }
 
     // Re-apply `'use client'` to bundled client entries so Next.js RSC

--- a/packages/next-shell/tsup.config.ts
+++ b/packages/next-shell/tsup.config.ts
@@ -52,6 +52,9 @@ export default defineConfig({
   splitting: false,
   treeshake: true,
   target: 'es2022',
+  esbuildOptions(options) {
+    options.jsx = 'automatic';
+  },
   external: ['react', 'react-dom', 'next', 'next-auth', 'next-auth/react', 'tailwindcss'],
   async onSuccess() {
     // Copy static CSS assets into dist/styles/.


### PR DESCRIPTION
## Summary

- **`dist/styles/preset.css` self-contained**: inlines `tw-animate-css` at build time so `@import 'tw-animate-css'` is never resolved at CSS-processing time in the consuming app — fixes `Module not found: tw-animate-css` in pnpm workspaces with strict non-hoisting
- **`React is not defined` runtime error fixed**: tsup now uses `jsx: 'automatic'` via `esbuildOptions`, switching from `React.createElement` (classic) to `react/jsx-runtime` imports — prevents the bundler's React import deduplication from leaving stale `React` references in the ThemeProvider
- **`apps/example` CSS import order fixed**: `@import 'tailwindcss'` moved before the next-shell preset, matching the documented consumer usage

## What is intentionally NOT in this PR

- Removing `tw-animate-css` from `apps/*/package.json` (kept as explicit dep for consumer guidance even though it's no longer needed for CSS processing)

## Verification

```
pnpm format   ✓
pnpm lint     ✓ (0 warnings)
pnpm typecheck ✓
pnpm test     ✓ 508/508 tests
pnpm build    ✓
pnpm dev (apps/example) ✓ starts, no CSS/React errors
pnpm dev (apps/docs)    ✓ starts cleanly
```

## Checklist

- [x] No raw color literals introduced
- [x] Light + dark themes work
- [x] SSR-safe (no server/client boundary violations)
- [x] All 508 tests pass