### PR TITLE
chore(docs): publish docs site to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,66 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build library
+        run: pnpm --filter @jonmatum/next-shell build
+
+      - name: Build docs (static export)
+        run: pnpm --filter @jonmatum/next-shell-docs build
+        env:
+          GITHUB_PAGES: 'true'
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/docs/out
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -1,1 +1,2 @@
 .source/
+out/

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -1,5 +1,12 @@
-import { redirect } from 'next/navigation';
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 export default function HomePage() {
-  redirect('/docs');
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/docs');
+  }, [router]);
+  return null;
 }

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -3,9 +3,16 @@ import { createMDX } from 'fumadocs-mdx/next';
 
 const withMDX = createMDX();
 
+const isGitHubPages = process.env.GITHUB_PAGES === 'true';
+
 const config: NextConfig = {
   reactStrictMode: true,
   transpilePackages: ['@jonmatum/next-shell'],
+  ...(isGitHubPages && {
+    output: 'export',
+    basePath: '/next-shell',
+    images: { unoptimized: true },
+  }),
 };
 
 export default withMDX(config);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ export default [
       '**/dist/**',
       '**/node_modules/**',
       '**/.next/**',
+      '**/out/**',
       '**/.source/**',
       '**/coverage/**',
       '**/*.min.js',


### PR DESCRIPTION
## Summary

- Conditional `output: 'export'` + `basePath: '/next-shell'` in `next.config.ts` when `GITHUB_PAGES=true` — Vercel stays on SSR mode
- `app/page.tsx` converted from server `redirect()` to client-side `useRouter.replace` (static export doesn't support server redirects)
- `.github/workflows/deploy-docs.yml` — builds library → runs fumadocs static export → uploads artifact → deploys to Pages on every `main` push
- `eslint.config.js` adds `**/out/**` ignore (static export output)
- `apps/docs/.gitignore` ignores `out/`

## What is intentionally NOT in this PR

- Vercel config changes — Vercel keeps serving the SSR version at its own URL
- Search configuration — fumadocs uses client-side search in static export by default

## One-time GitHub setup required

Go to **Settings → Pages → Source** and set it to **"GitHub Actions"** (not the default branch/folder option). The workflow will handle the rest automatically.

Docs will be live at: https://jonmatum.github.io/next-shell/docs

## Verification

```
GITHUB_PAGES=true pnpm --filter @jonmatum/next-shell-docs build  ✓ 12 pages exported
pnpm lint     ✓
pnpm typecheck ✓
pnpm test     ✓ 508/508
```