### PR TITLE
fix(qa): @source in globals.css, remove transpilePackages, fix hydration mismatch

### DIFF
--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -1,3 +1,4 @@
 @import 'fumadocs-ui/style.css';
 @import 'tailwindcss';
+@source "../../node_modules/@jonmatum/next-shell/dist/**/*.{js,cjs}";
 @import '@jonmatum/next-shell/styles/preset.css';

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -28,8 +28,11 @@ The Tailwind preset wires every semantic token into Tailwind's `@theme` scale an
 
 ```css title="app/globals.css"
 @import 'tailwindcss';
+@source "node_modules/@jonmatum/next-shell/dist/**/*.{js,cjs}";
 @import '@jonmatum/next-shell/styles/preset.css';
 ```
+
+The `@source` line is required — Tailwind v4 only generates CSS for classes it finds in scanned files, and `node_modules` is skipped by default. This tells Tailwind to scan the library's bundled output so all component classes are included.
 
 Now utilities like `bg-background`, `text-foreground`, `border-border`, `animate-in`, and `duration-normal` are available everywhere.
 

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -7,7 +7,6 @@ const isGitHubPages = process.env.GITHUB_PAGES === 'true';
 
 const config: NextConfig = {
   reactStrictMode: true,
-  transpilePackages: ['@jonmatum/next-shell'],
   ...(isGitHubPages && {
     output: 'export',
     basePath: '/next-shell',

--- a/apps/example/app/globals.css
+++ b/apps/example/app/globals.css
@@ -1,2 +1,3 @@
 @import 'tailwindcss';
+@source "../../node_modules/@jonmatum/next-shell/dist/**/*.{js,cjs}";
 @import '@jonmatum/next-shell/styles/preset.css';

--- a/apps/example/next.config.ts
+++ b/apps/example/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from 'next';
 
-const config: NextConfig = {
-  transpilePackages: ['@jonmatum/next-shell'],
-};
+const config: NextConfig = {};
 
 export default config;

--- a/packages/next-shell/README.md
+++ b/packages/next-shell/README.md
@@ -23,10 +23,13 @@ Runtime deps (pulled in automatically): `radix-ui`, `class-variance-authority`, 
 ```css
 /* app/globals.css */
 @import 'tailwindcss';
+@source "node_modules/@jonmatum/next-shell/dist/**/*.{js,cjs}";
 @import '@jonmatum/next-shell/styles/preset.css';
 ```
 
-The preset pulls in `tokens.css` + `tw-animate-css` and wires every semantic token to the Tailwind `@theme` scale. Utilities like `bg-background`, `text-foreground`, `border-border`, `ring-ring`, `animate-in`, and `duration-fast` are now live.
+The `@source` line tells Tailwind v4 to scan the library's bundled output for class names — required because Tailwind only generates CSS for classes it finds in scanned files, and library code in `node_modules` is not scanned by default.
+
+The preset pulls in `tokens.css` + `tw-animate-css` (inlined, no extra dep needed) and wires every semantic token to the Tailwind `@theme` scale. Utilities like `bg-background`, `text-foreground`, `border-border`, `ring-ring`, `animate-in`, and `duration-fast` are now live.
 
 ### 2. Mount the theme provider (client)
 

--- a/packages/next-shell/src/providers/theme/theme-toggle-dropdown.tsx
+++ b/packages/next-shell/src/providers/theme/theme-toggle-dropdown.tsx
@@ -72,6 +72,7 @@ export function ThemeToggleDropdown({
           aria-label={label}
           data-theme-value={current}
           data-resolved-theme={resolved}
+          suppressHydrationWarning
           {...rest}
         >
           <TriggerIcon aria-hidden className="size-4" />

--- a/packages/next-shell/src/providers/theme/theme-toggle.tsx
+++ b/packages/next-shell/src/providers/theme/theme-toggle.tsx
@@ -58,6 +58,7 @@ export function ThemeToggle({ labels, className, onClick, ...rest }: ThemeToggle
       title={label}
       data-theme-value={current}
       data-resolved-theme={resolved}
+      suppressHydrationWarning
       onClick={(event) => {
         setTheme(target);
         onClick?.(event);

--- a/packages/next-shell/src/styles/preset.css
+++ b/packages/next-shell/src/styles/preset.css
@@ -18,10 +18,6 @@
 
 @import './tokens.css';
 
-/* Tell Tailwind v4 to scan this package's bundled output for used class names
-   so tree-shaking doesn't strip utilities that only appear in library code. */
-@source "../**/*.{js,cjs}";
-
 /* Animation utilities — `animate-in`, `fade-in-0`, `zoom-in-95`,
    `slide-in-from-*`, etc. Required by every shadcn/ui overlay primitive
    (Tooltip, Dialog, Popover, DropdownMenu, Sheet, Drawer, …).


### PR DESCRIPTION
## Summary

Three QA fixes discovered while running `pnpm dev` against the example app:

- **`@source` moved to `globals.css`** — Tailwind v4 with Turbopack only processes `@source` directives in the root CSS entry file; the directive in `preset.css` was silently ignored. Moved to both app `globals.css` files. Consumers must add `@source "node_modules/@jonmatum/next-shell/dist/**/*.{js,cjs}"` to their own `globals.css` (documented in README and docs site).
- **`transpilePackages` removed** — Turbopack with `transpilePackages: ['@jonmatum/next-shell']` failed to resolve `@jonmatum/next-shell/auth` while other subpaths worked. Since `@source` now covers Tailwind class detection, this workaround is no longer needed and was removed from both apps.
- **Hydration mismatch fixed on theme toggles** — `data-resolved-theme` is written from `next-themes`' `resolvedTheme` which is `undefined` server-side. Added `suppressHydrationWarning` to the button elements in `ThemeToggle` and `ThemeToggleDropdown`.

## Verification

```
pnpm lint      ✓
pnpm typecheck ✓
pnpm test      ✓ 508/508
pnpm build     ✓
pnpm dev (apps/example) ✓ no module errors, no hydration warnings
```