### PR TITLE
chore: open-source readiness batch — #55 #64 #66 #69 #70 #71 #72

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in `@jonmatum/next-shell`,
+please report it through
+[GitHub Security Advisories](https://github.com/jonmatum/next-shell/security/advisories/new).
+
+**Do not open a public issue for security vulnerabilities.**
+
+You will receive an acknowledgement within 48 hours, and we will work
+with you to understand and address the issue before any public
+disclosure.
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 0.x     | Yes       |
+
+## Scope
+
+This policy covers the `@jonmatum/next-shell` npm package and the code
+in this repository. It does not cover third-party dependencies; please
+report vulnerabilities in those projects to their respective maintainers.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,249 @@
+# @jonmatum/next-shell
+
+> Reusable Next.js app shell built on shadcn/ui primitives with a strict semantic-token design system.
+
+- Repo: https://github.com/jonmatum/next-shell
+- Package: https://www.npmjs.com/package/@jonmatum/next-shell
+- License: MIT
+- Stack: Next.js 15, React 19, TypeScript, Tailwind CSS v4, Radix UI
+
+## Install
+
+```
+pnpm add @jonmatum/next-shell
+# Peers: next@^15 react@^19 react-dom@^19 tailwindcss@^4 (optional)
+```
+
+## Subpath exports
+
+Import only what you need. Each subpath tree-shakes independently.
+
+| Import path | Description |
+|---|---|
+| `@jonmatum/next-shell` | Root barrel: `cn`, `packageVersion`, `tokenSchemaVersion` |
+| `@jonmatum/next-shell/core` | Core utilities: `cn` (clsx + tailwind-merge), `packageVersion` |
+| `@jonmatum/next-shell/primitives` | 42 shadcn/ui primitives (client components) |
+| `@jonmatum/next-shell/providers` | `ThemeProvider`, `ThemeToggle`, `ThemeToggleDropdown`, `useTheme` (client) |
+| `@jonmatum/next-shell/providers/server` | SSR theme cookie helpers: `getThemeFromCookies`, `buildThemeCookieHeader`, `isThemeValue` (server-safe) |
+| `@jonmatum/next-shell/layout` | App shell layout: `AppShell`, `Sidebar*`, `TopBar`, `CommandBar*`, `ContentContainer`, `PageHeader`, `Footer`, status states (client) |
+| `@jonmatum/next-shell/layout/server` | SSR sidebar-state cookie helpers + stateless content surfaces (server-safe) |
+| `@jonmatum/next-shell/tokens` | TypeScript view of the semantic-token contract: literal unions, `cssVar`, `BrandOverrides`, `buildRootOverrides`, `brandOverridesCss` |
+| `@jonmatum/next-shell/tailwind-preset` | Tailwind v4 preset mapping tokens to `@theme` keys |
+| `@jonmatum/next-shell/styles/tokens.css` | CSS custom properties for `:root` + `[data-theme="dark"]` |
+| `@jonmatum/next-shell/styles/preset.css` | Combined preset: tokens + tw-animate-css + Tailwind `@theme` mappings |
+| `@jonmatum/next-shell/hooks` | Cross-cutting hooks: `useIsMobile` |
+| `@jonmatum/next-shell/auth` | Auth adapter interface (planned) |
+
+## Token catalog
+
+All colors use OKLCH values. No raw color literals are allowed in library code -- every color flows through semantic tokens.
+
+### Color tokens (43 tokens)
+
+Surface pairs (background + foreground):
+- `background`, `foreground` -- page-level defaults
+- `surface`, `surface-foreground` -- elevated surface
+- `card`, `card-foreground` -- card surfaces
+- `popover`, `popover-foreground` -- floating surfaces
+- `muted`, `muted-foreground` -- subdued content
+- `accent`, `accent-foreground` -- highlighted interactive elements
+- `primary`, `primary-foreground` -- primary actions
+- `secondary`, `secondary-foreground` -- secondary actions
+- `destructive`, `destructive-foreground` -- destructive actions
+- `success`, `success-foreground` -- success state
+- `warning`, `warning-foreground` -- warning state
+- `info`, `info-foreground` -- informational state
+
+Standalone:
+- `border` -- default borders
+- `input` -- form input borders
+- `ring` -- focus rings
+- `overlay` -- backdrop overlay
+
+Sidebar:
+- `sidebar`, `sidebar-foreground`, `sidebar-primary`, `sidebar-primary-foreground`, `sidebar-accent`, `sidebar-accent-foreground`, `sidebar-border`, `sidebar-ring`
+
+Charts:
+- `chart-1` through `chart-5`
+
+### Radius tokens (7)
+
+`xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `full` -- all derived from a single `--radius` base value.
+
+### Typography tokens
+
+Font families: `sans`, `mono`, `display`
+Text sizes (9-step fluid scale): `xs`, `sm`, `base`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`
+Leading: `tight`, `snug`, `normal`, `relaxed`, `loose`
+Tracking: `tight`, `normal`, `wide`, `wider`
+
+### Motion tokens
+
+Durations: `instant`, `fast`, `normal`, `slow`, `slowest`
+Easings: `standard`, `emphasized`, `decelerate`, `accelerate`
+
+### Elevation tokens (6)
+
+Shadows: `xs`, `sm`, `md`, `lg`, `xl`, `2xl` -- tuned per light/dark theme.
+
+### Density tokens (4)
+
+`pad-x`, `pad-y`, `gap`, `row-height`
+
+## Primitives (42 components)
+
+All vendored from shadcn/ui (new-york-v4 style), token-audited, and accessible via Radix UI.
+
+### Actions
+- `Button` -- primary interactive element with variants: default, destructive, outline, secondary, ghost, link; sizes: default, sm, lg, icon
+- `Toggle` -- two-state toggle button
+- `ToggleGroup` -- group of toggle buttons (single or multiple selection)
+
+### Forms
+- `Checkbox` -- boolean input with indeterminate state
+- `Input` -- text input field
+- `InputOTP` -- one-time password input (segmented)
+- `Label` -- accessible form label
+- `RadioGroup` -- single-selection radio button group
+- `Select` -- dropdown select with search
+- `Slider` -- range slider input
+- `Switch` -- on/off toggle switch
+- `Textarea` -- multi-line text input
+- `Form` -- react-hook-form integration with validation
+
+### Layout & containers
+- `Accordion` -- collapsible content sections
+- `AspectRatio` -- fixed aspect ratio container
+- `Card` (`CardHeader`, `CardTitle`, `CardDescription`, `CardContent`, `CardFooter`) -- content card
+- `Collapsible` -- simple collapsible panel
+- `Resizable` (`ResizablePanelGroup`, `ResizablePanel`, `ResizableHandle`) -- resizable split panels
+- `ScrollArea` -- custom scrollbar container
+- `Separator` -- visual divider (horizontal or vertical)
+- `Table` (`TableHeader`, `TableBody`, `TableRow`, `TableHead`, `TableCell`, `TableCaption`, `TableFooter`) -- data table
+- `Tabs` (`TabsList`, `TabsTrigger`, `TabsContent`) -- tabbed content
+
+### Feedback
+- `Alert` (`AlertTitle`, `AlertDescription`) -- static alert banner
+- `AlertDialog` -- modal confirmation dialog with required action
+- `Badge` -- small label/tag
+- `Progress` -- progress bar indicator
+- `Skeleton` -- loading placeholder
+- `Toaster` (Sonner) -- toast notification system
+
+### Overlays
+- `Dialog` (`DialogTrigger`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogFooter`, `DialogClose`) -- modal dialog
+- `Drawer` -- mobile-friendly bottom drawer (vaul)
+- `Sheet` (`SheetTrigger`, `SheetContent`, `SheetHeader`, `SheetTitle`, `SheetDescription`, `SheetFooter`, `SheetClose`) -- slide-out panel
+- `Popover` -- floating content anchored to a trigger
+- `HoverCard` -- content shown on hover
+- `Tooltip` -- brief text tooltip
+
+### Navigation
+- `Breadcrumb` (`BreadcrumbList`, `BreadcrumbItem`, `BreadcrumbLink`, `BreadcrumbSeparator`, `BreadcrumbEllipsis`, `BreadcrumbPage`) -- breadcrumb trail
+- `Command` (`CommandInput`, `CommandList`, `CommandEmpty`, `CommandGroup`, `CommandItem`, `CommandSeparator`) -- cmdk-based command palette
+- `ContextMenu` -- right-click context menu
+- `DropdownMenu` -- dropdown menu from a trigger
+- `Menubar` -- horizontal menu bar
+- `NavigationMenu` -- site-level navigation with mega-menu support
+- `Pagination` -- page navigation controls
+
+### Data visualization
+- `Calendar` -- date picker calendar (react-day-picker)
+- `Carousel` -- horizontal content carousel (embla)
+- `Chart` -- chart container with theme-aware colors (recharts)
+
+## Layout components
+
+The `@jonmatum/next-shell/layout` subpath provides a full app shell.
+
+### App shell orchestrator
+- `AppShell` -- root orchestrator combining sidebar, topbar, and content area
+
+### Sidebar system
+- `Sidebar`, `SidebarProvider`, `SidebarContent`, `SidebarHeader`, `SidebarFooter`, `SidebarGroup`, `SidebarGroupLabel`, `SidebarGroupAction`, `SidebarGroupContent`, `SidebarMenu`, `SidebarMenuItem`, `SidebarMenuButton`, `SidebarMenuAction`, `SidebarMenuBadge`, `SidebarMenuSkeleton`, `SidebarMenuSub`, `SidebarMenuSubButton`, `SidebarMenuSubItem`, `SidebarInput`, `SidebarInset`, `SidebarRail`, `SidebarSeparator`, `SidebarTrigger`
+- `SidebarNav` -- config-driven sidebar navigation
+- `useSidebar` -- sidebar state hook
+
+### Navigation
+- `TopBar` -- top application bar
+- `Breadcrumbs` -- route-aware breadcrumb trail
+- `CommandBar`, `CommandBarProvider`, `CommandBarTrigger`, `CommandBarActions` -- command palette (Cmd+K)
+- `useCommandBar`, `useCommandBarActions` -- command bar hooks
+- `buildNav` -- build navigation config from route definitions
+
+### Content surfaces
+- `ContentContainer` -- max-width content wrapper with padding variants
+- `PageHeader` -- page title + description + actions
+- `Footer` -- page/app footer
+
+### Status states
+- `EmptyState` -- placeholder for empty data
+- `ErrorState` -- error display with retry action
+- `LoadingState` -- loading spinner/skeleton
+
+### Server-safe (layout/server)
+- `getSidebarStateFromCookies`, `buildSidebarStateCookieHeader`, `isSidebarState` -- SSR sidebar cookie helpers
+- Plus all stateless content surfaces re-exported for Server Component use
+
+## Hooks
+
+From `@jonmatum/next-shell/hooks`:
+- `useIsMobile` -- responsive breakpoint hook for mobile detection
+
+## Theming
+
+### Quick setup (Tailwind v4)
+
+```css
+/* app/globals.css */
+@import 'tailwindcss';
+@import '@jonmatum/next-shell/styles/preset.css';
+```
+
+### Theme provider (client)
+
+```tsx
+import { ThemeProvider } from '@jonmatum/next-shell/providers';
+
+<ThemeProvider defaultTheme="system" enableSystem disableTransitionOnChange>
+  {children}
+</ThemeProvider>
+```
+
+### SSR theme (no flash of unstyled content)
+
+```tsx
+// Server Component
+import { getThemeFromCookies } from '@jonmatum/next-shell/providers/server';
+const theme = getThemeFromCookies(await cookies()) ?? 'system';
+<html data-theme={theme} suppressHydrationWarning>
+```
+
+### Brand overrides
+
+```tsx
+import type { BrandOverrides } from '@jonmatum/next-shell/tokens';
+
+const brand: BrandOverrides = {
+  light: { primary: 'oklch(0.6 0.2 258)' },
+  dark:  { primary: 'oklch(0.75 0.15 258)' },
+  radius: '0.5rem',
+  fontSans: 'Inter, sans-serif',
+};
+
+<ThemeProvider brand={brand}>{children}</ThemeProvider>
+```
+
+## Key design rules
+
+1. No raw color literals -- all colors via semantic tokens
+2. Client components have explicit `'use client'` directives
+3. Server-safe helpers live under `<subpath>/server/`
+4. Radix UI primitives are the default substrate
+5. Accessibility is non-negotiable: all primitives have accessible names, focus rings use `ring` token, Radix keyboard navigation preserved
+
+## Links
+
+- GitHub: https://github.com/jonmatum/next-shell
+- Issues: https://github.com/jonmatum/next-shell/issues
+- Extraction plan: https://github.com/jonmatum/next-shell/issues/13

--- a/packages/next-shell/README.md
+++ b/packages/next-shell/README.md
@@ -1,5 +1,12 @@
 # @jonmatum/next-shell
 
+[![npm version](https://img.shields.io/npm/v/@jonmatum/next-shell)](https://www.npmjs.com/package/@jonmatum/next-shell)
+[![CI](https://img.shields.io/github/actions/workflow/status/jonmatum/next-shell/ci.yml?branch=main)](https://github.com/jonmatum/next-shell/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/jonmatum/next-shell)](https://github.com/jonmatum/next-shell/blob/main/LICENSE)
+[![Bundle size](https://img.shields.io/bundlephobia/minzip/@jonmatum/next-shell)](https://bundlephobia.com/package/@jonmatum/next-shell)
+
+**[Documentation](https://jonmatum.github.io/next-shell/)**
+
 Reusable Next.js app shell built on **shadcn/ui** primitives with a strict **semantic-token** design system.
 
 > **Status:** All 11 phases complete. Published via Changesets. 508 tests, docs site, and a working example app all on `main`.
@@ -89,6 +96,96 @@ export function UserCard() {
 ```
 
 Every primitive ships with `data-slot` attributes for custom-styling hooks, `aria-*` semantics preserved from Radix, and variant systems driven by `class-variance-authority`.
+
+### 5. App shell layout
+
+```tsx
+import { AppShell, TopBar, Footer } from '@jonmatum/next-shell/layout';
+import { MySidebar } from './my-sidebar';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <AppShell
+      sidebar={<MySidebar />}
+      topBar={<TopBar left={<span>Acme Inc.</span>} right={<UserMenu />} />}
+      footer={<Footer>© 2026 Acme</Footer>}
+      commandBar
+    >
+      {children}
+    </AppShell>
+  );
+}
+```
+
+### 6. Navigation with buildNav
+
+```tsx
+import { buildNav, type NavConfig } from '@jonmatum/next-shell/layout';
+import { HomeIcon, SettingsIcon } from 'lucide-react';
+
+const nav: NavConfig = [
+  { id: 'home', label: 'Home', href: '/', icon: <HomeIcon />, matcher: 'exact' },
+  {
+    id: 'settings',
+    label: 'Settings',
+    href: '/settings',
+    icon: <SettingsIcon />,
+    requires: 'admin',
+    children: [{ id: 'profile', label: 'Profile', href: '/settings/profile' }],
+  },
+];
+
+const { items, breadcrumbs } = buildNav({
+  config: nav,
+  pathname: '/settings/profile',
+  permissions: ['admin'],
+});
+```
+
+### 7. Hooks
+
+```tsx
+'use client';
+
+import { useDisclosure } from '@jonmatum/next-shell/hooks';
+import { Dialog, DialogContent, DialogTitle } from '@jonmatum/next-shell/primitives';
+import { Button } from '@jonmatum/next-shell/primitives';
+
+export function ConfirmDialog() {
+  const { isOpen, open, onOpenChange } = useDisclosure();
+  return (
+    <>
+      <Button onClick={open}>Open</Button>
+      <Dialog open={isOpen} onOpenChange={onOpenChange}>
+        <DialogContent>
+          <DialogTitle>Confirm action</DialogTitle>
+          <p>Are you sure?</p>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+```
+
+### 8. Formatters
+
+```ts
+import {
+  formatDate,
+  formatRelativeTime,
+  formatCurrency,
+  formatFileSize,
+  truncate,
+  slugify,
+} from '@jonmatum/next-shell/formatters';
+
+formatDate(new Date(), { preset: 'short' }); // "Apr 26, 2026"
+formatRelativeTime(new Date(Date.now() - 60_000)); // "1 minute ago"
+formatCurrency(1234.5, { currency: 'USD' }); // "$1,234.50"
+formatFileSize(10_485_760); // "10 MB"
+truncate('A very long string indeed', { length: 15 }); // "A very long ..."
+slugify('Hello World!'); // "hello-world"
+```
 
 ## Subpath entry points
 

--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -159,7 +159,6 @@
     }
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.99.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -179,6 +178,7 @@
     "vaul": "^1.1.2"
   },
   "devDependencies": {
+    "@tanstack/react-query": "^5.99.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",

--- a/packages/next-shell/src/primitives/accordion.tsx
+++ b/packages/next-shell/src/primitives/accordion.tsx
@@ -6,10 +6,12 @@ import { Accordion as AccordionPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible accordion component built on Radix UI. @see https://ui.shadcn.com/docs/components/accordion */
 function Accordion({ ...props }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
   return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
 }
 
+/** Accessible accordion item component built on Radix UI. @see https://ui.shadcn.com/docs/components/accordion */
 function AccordionItem({
   className,
   ...props
@@ -23,6 +25,7 @@ function AccordionItem({
   );
 }
 
+/** Accessible accordion trigger component built on Radix UI. @see https://ui.shadcn.com/docs/components/accordion */
 function AccordionTrigger({
   className,
   children,
@@ -45,6 +48,7 @@ function AccordionTrigger({
   );
 }
 
+/** Accessible accordion content panel built on Radix UI. @see https://ui.shadcn.com/docs/components/accordion */
 function AccordionContent({
   className,
   children,

--- a/packages/next-shell/src/primitives/alert-dialog.tsx
+++ b/packages/next-shell/src/primitives/alert-dialog.tsx
@@ -6,20 +6,24 @@ import { AlertDialog as AlertDialogPrimitive } from 'radix-ui';
 import { cn } from '@/core/cn';
 import { Button } from '@/primitives/button';
 
+/** Accessible alert dialog component built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
   return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
 }
 
+/** Accessible alert dialog trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialogTrigger({
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
   return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
 }
 
+/** Accessible alert dialog portal built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
   return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
 }
 
+/** Accessible alert dialog overlay built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialogOverlay({
   className,
   ...props
@@ -36,6 +40,7 @@ function AlertDialogOverlay({
   );
 }
 
+/** Accessible alert dialog content built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialogContent({
   className,
   size = 'default',
@@ -59,6 +64,7 @@ function AlertDialogContent({
   );
 }
 
+/** Accessible alert dialog header built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -72,6 +78,7 @@ function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>)
   );
 }
 
+/** Accessible alert dialog footer built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -85,6 +92,7 @@ function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>)
   );
 }
 
+/** Accessible alert dialog title built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialogTitle({
   className,
   ...props
@@ -101,6 +109,7 @@ function AlertDialogTitle({
   );
 }
 
+/** Accessible alert dialog description built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialogDescription({
   className,
   ...props
@@ -114,6 +123,7 @@ function AlertDialogDescription({
   );
 }
 
+/** Accessible alert dialog media slot built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialogMedia({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -127,6 +137,7 @@ function AlertDialogMedia({ className, ...props }: React.ComponentProps<'div'>) 
   );
 }
 
+/** Accessible alert dialog action button built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialogAction({
   className,
   variant = 'default',
@@ -145,6 +156,7 @@ function AlertDialogAction({
   );
 }
 
+/** Accessible alert dialog cancel button built on Radix UI. @see https://ui.shadcn.com/docs/components/alert-dialog */
 function AlertDialogCancel({
   className,
   variant = 'outline',

--- a/packages/next-shell/src/primitives/alert.tsx
+++ b/packages/next-shell/src/primitives/alert.tsx
@@ -19,6 +19,7 @@ const alertVariants = cva(
   },
 );
 
+/** Accessible alert component for displaying important messages. @see https://ui.shadcn.com/docs/components/alert */
 function Alert({
   className,
   variant,
@@ -34,6 +35,7 @@ function Alert({
   );
 }
 
+/** Accessible alert title component. @see https://ui.shadcn.com/docs/components/alert */
 function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -44,6 +46,7 @@ function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible alert description component. @see https://ui.shadcn.com/docs/components/alert */
 function AlertDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div

--- a/packages/next-shell/src/primitives/aspect-ratio.tsx
+++ b/packages/next-shell/src/primitives/aspect-ratio.tsx
@@ -2,6 +2,7 @@
 
 import { AspectRatio as AspectRatioPrimitive } from 'radix-ui';
 
+/** Accessible aspect ratio container built on Radix UI. @see https://ui.shadcn.com/docs/components/aspect-ratio */
 function AspectRatio({ ...props }: React.ComponentProps<typeof AspectRatioPrimitive.Root>) {
   return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />;
 }

--- a/packages/next-shell/src/primitives/avatar.tsx
+++ b/packages/next-shell/src/primitives/avatar.tsx
@@ -5,6 +5,7 @@ import { Avatar as AvatarPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible avatar component built on Radix UI. @see https://ui.shadcn.com/docs/components/avatar */
 function Avatar({
   className,
   size = 'default',
@@ -25,6 +26,7 @@ function Avatar({
   );
 }
 
+/** Accessible avatar image component built on Radix UI. @see https://ui.shadcn.com/docs/components/avatar */
 function AvatarImage({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
   return (
     <AvatarPrimitive.Image
@@ -35,6 +37,7 @@ function AvatarImage({ className, ...props }: React.ComponentProps<typeof Avatar
   );
 }
 
+/** Accessible avatar fallback component built on Radix UI. @see https://ui.shadcn.com/docs/components/avatar */
 function AvatarFallback({
   className,
   ...props
@@ -51,6 +54,7 @@ function AvatarFallback({
   );
 }
 
+/** Accessible avatar badge indicator. @see https://ui.shadcn.com/docs/components/avatar */
 function AvatarBadge({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
@@ -67,6 +71,7 @@ function AvatarBadge({ className, ...props }: React.ComponentProps<'span'>) {
   );
 }
 
+/** Accessible avatar group layout container. @see https://ui.shadcn.com/docs/components/avatar */
 function AvatarGroup({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -80,6 +85,7 @@ function AvatarGroup({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible avatar group overflow count indicator. @see https://ui.shadcn.com/docs/components/avatar */
 function AvatarGroupCount({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div

--- a/packages/next-shell/src/primitives/badge.tsx
+++ b/packages/next-shell/src/primitives/badge.tsx
@@ -25,6 +25,7 @@ const badgeVariants = cva(
   },
 );
 
+/** Accessible badge component for status indicators and labels. @see https://ui.shadcn.com/docs/components/badge */
 function Badge({
   className,
   variant = 'default',

--- a/packages/next-shell/src/primitives/breadcrumb.tsx
+++ b/packages/next-shell/src/primitives/breadcrumb.tsx
@@ -4,10 +4,12 @@ import { Slot } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible breadcrumb navigation component. @see https://ui.shadcn.com/docs/components/breadcrumb */
 function Breadcrumb({ ...props }: React.ComponentProps<'nav'>) {
   return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;
 }
 
+/** Accessible breadcrumb list container. @see https://ui.shadcn.com/docs/components/breadcrumb */
 function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
   return (
     <ol
@@ -21,6 +23,7 @@ function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
   );
 }
 
+/** Accessible breadcrumb item component. @see https://ui.shadcn.com/docs/components/breadcrumb */
 function BreadcrumbItem({ className, ...props }: React.ComponentProps<'li'>) {
   return (
     <li
@@ -31,6 +34,7 @@ function BreadcrumbItem({ className, ...props }: React.ComponentProps<'li'>) {
   );
 }
 
+/** Accessible breadcrumb link component. @see https://ui.shadcn.com/docs/components/breadcrumb */
 function BreadcrumbLink({
   asChild,
   className,
@@ -49,6 +53,7 @@ function BreadcrumbLink({
   );
 }
 
+/** Accessible breadcrumb current page indicator. @see https://ui.shadcn.com/docs/components/breadcrumb */
 function BreadcrumbPage({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
@@ -62,6 +67,7 @@ function BreadcrumbPage({ className, ...props }: React.ComponentProps<'span'>) {
   );
 }
 
+/** Accessible breadcrumb separator component. @see https://ui.shadcn.com/docs/components/breadcrumb */
 function BreadcrumbSeparator({ children, className, ...props }: React.ComponentProps<'li'>) {
   return (
     <li
@@ -76,6 +82,7 @@ function BreadcrumbSeparator({ children, className, ...props }: React.ComponentP
   );
 }
 
+/** Accessible breadcrumb ellipsis overflow indicator. @see https://ui.shadcn.com/docs/components/breadcrumb */
 function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span

--- a/packages/next-shell/src/primitives/button.tsx
+++ b/packages/next-shell/src/primitives/button.tsx
@@ -36,6 +36,7 @@ const buttonVariants = cva(
   },
 );
 
+/** Accessible button component with multiple variants and sizes. @see https://ui.shadcn.com/docs/components/button */
 function Button({
   className,
   variant = 'default',

--- a/packages/next-shell/src/primitives/calendar.tsx
+++ b/packages/next-shell/src/primitives/calendar.tsx
@@ -7,6 +7,7 @@ import { DayPicker, getDefaultClassNames, type DayButton } from 'react-day-picke
 import { cn } from '@/core/cn';
 import { Button, buttonVariants } from '@/primitives/button';
 
+/** Accessible calendar date picker component. @see https://ui.shadcn.com/docs/components/calendar */
 function Calendar({
   className,
   classNames,
@@ -139,6 +140,7 @@ function Calendar({
   );
 }
 
+/** Accessible calendar day button component. @see https://ui.shadcn.com/docs/components/calendar */
 function CalendarDayButton({
   className,
   day,

--- a/packages/next-shell/src/primitives/card.tsx
+++ b/packages/next-shell/src/primitives/card.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { cn } from '@/core/cn';
 
+/** Accessible card container component. @see https://ui.shadcn.com/docs/components/card */
 function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -15,6 +16,7 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible card header component. @see https://ui.shadcn.com/docs/components/card */
 function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -28,6 +30,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible card title component. @see https://ui.shadcn.com/docs/components/card */
 function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -38,6 +41,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible card description component. @see https://ui.shadcn.com/docs/components/card */
 function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -48,6 +52,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible card action slot component. @see https://ui.shadcn.com/docs/components/card */
 function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -58,10 +63,12 @@ function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible card content component. @see https://ui.shadcn.com/docs/components/card */
 function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
   return <div data-slot="card-content" className={cn('px-6', className)} {...props} />;
 }
 
+/** Accessible card footer component. @see https://ui.shadcn.com/docs/components/card */
 function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div

--- a/packages/next-shell/src/primitives/carousel.tsx
+++ b/packages/next-shell/src/primitives/carousel.tsx
@@ -40,6 +40,7 @@ function useCarousel() {
   return context;
 }
 
+/** Accessible carousel component built on Embla Carousel. @see https://ui.shadcn.com/docs/components/carousel */
 function Carousel({
   orientation = 'horizontal',
   opts,
@@ -129,6 +130,7 @@ function Carousel({
   );
 }
 
+/** Accessible carousel content container. @see https://ui.shadcn.com/docs/components/carousel */
 function CarouselContent({ className, ...props }: React.ComponentProps<'div'>) {
   const { carouselRef, orientation } = useCarousel();
 
@@ -142,6 +144,7 @@ function CarouselContent({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible carousel slide item. @see https://ui.shadcn.com/docs/components/carousel */
 function CarouselItem({ className, ...props }: React.ComponentProps<'div'>) {
   const { orientation } = useCarousel();
 
@@ -160,6 +163,7 @@ function CarouselItem({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible carousel previous slide button. @see https://ui.shadcn.com/docs/components/carousel */
 function CarouselPrevious({
   className,
   variant = 'outline',
@@ -190,6 +194,7 @@ function CarouselPrevious({
   );
 }
 
+/** Accessible carousel next slide button. @see https://ui.shadcn.com/docs/components/carousel */
 function CarouselNext({
   className,
   variant = 'outline',

--- a/packages/next-shell/src/primitives/chart.tsx
+++ b/packages/next-shell/src/primitives/chart.tsx
@@ -39,6 +39,7 @@ function useChart() {
   return context;
 }
 
+/** Accessible chart container component wrapping Recharts. @see https://ui.shadcn.com/docs/components/chart */
 function ChartContainer({
   id,
   className,
@@ -86,6 +87,7 @@ function ChartContainer({
   );
 }
 
+/** Injects dynamic CSS custom properties for chart color theming. @see https://ui.shadcn.com/docs/components/chart */
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(([, config]) => config.theme ?? config.color);
 
@@ -115,8 +117,10 @@ ${colorConfig
   );
 };
 
+/** Accessible chart tooltip component wrapping Recharts. @see https://ui.shadcn.com/docs/components/chart */
 const ChartTooltip = RechartsPrimitive.Tooltip;
 
+/** Accessible chart tooltip content renderer. @see https://ui.shadcn.com/docs/components/chart */
 function ChartTooltipContent({
   active,
   payload,
@@ -256,8 +260,10 @@ function ChartTooltipContent({
   );
 }
 
+/** Accessible chart legend component wrapping Recharts. @see https://ui.shadcn.com/docs/components/chart */
 const ChartLegend = RechartsPrimitive.Legend;
 
+/** Accessible chart legend content renderer. @see https://ui.shadcn.com/docs/components/chart */
 function ChartLegendContent({
   className,
   hideIcon = false,

--- a/packages/next-shell/src/primitives/checkbox.tsx
+++ b/packages/next-shell/src/primitives/checkbox.tsx
@@ -6,6 +6,7 @@ import { Checkbox as CheckboxPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible checkbox component built on Radix UI. @see https://ui.shadcn.com/docs/components/checkbox */
 function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
   return (
     <CheckboxPrimitive.Root

--- a/packages/next-shell/src/primitives/collapsible.tsx
+++ b/packages/next-shell/src/primitives/collapsible.tsx
@@ -2,16 +2,19 @@
 
 import { Collapsible as CollapsiblePrimitive } from 'radix-ui';
 
+/** Accessible collapsible component built on Radix UI. @see https://ui.shadcn.com/docs/components/collapsible */
 function Collapsible({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
   return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
 }
 
+/** Accessible collapsible trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/collapsible */
 function CollapsibleTrigger({
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
   return <CollapsiblePrimitive.CollapsibleTrigger data-slot="collapsible-trigger" {...props} />;
 }
 
+/** Accessible collapsible content panel built on Radix UI. @see https://ui.shadcn.com/docs/components/collapsible */
 function CollapsibleContent({
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {

--- a/packages/next-shell/src/primitives/command.tsx
+++ b/packages/next-shell/src/primitives/command.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from '@/primitives/dialog';
 
+/** Accessible command palette component built on cmdk. @see https://ui.shadcn.com/docs/components/command */
 function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
   return (
     <CommandPrimitive
@@ -26,6 +27,7 @@ function Command({ className, ...props }: React.ComponentProps<typeof CommandPri
   );
 }
 
+/** Accessible command palette dialog wrapper. @see https://ui.shadcn.com/docs/components/command */
 function CommandDialog({
   title = 'Command Palette',
   description = 'Search for a command to run...',
@@ -57,6 +59,7 @@ function CommandDialog({
   );
 }
 
+/** Accessible command palette search input. @see https://ui.shadcn.com/docs/components/command */
 function CommandInput({
   className,
   ...props
@@ -76,6 +79,7 @@ function CommandInput({
   );
 }
 
+/** Accessible command palette results list. @see https://ui.shadcn.com/docs/components/command */
 function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
   return (
     <CommandPrimitive.List
@@ -86,6 +90,7 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
   );
 }
 
+/** Accessible command palette empty state. @see https://ui.shadcn.com/docs/components/command */
 function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
   return (
     <CommandPrimitive.Empty
@@ -96,6 +101,7 @@ function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive
   );
 }
 
+/** Accessible command palette group container. @see https://ui.shadcn.com/docs/components/command */
 function CommandGroup({
   className,
   ...props
@@ -112,6 +118,7 @@ function CommandGroup({
   );
 }
 
+/** Accessible command palette separator. @see https://ui.shadcn.com/docs/components/command */
 function CommandSeparator({
   className,
   ...props
@@ -125,6 +132,7 @@ function CommandSeparator({
   );
 }
 
+/** Accessible command palette item. @see https://ui.shadcn.com/docs/components/command */
 function CommandItem({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
   return (
     <CommandPrimitive.Item
@@ -138,6 +146,7 @@ function CommandItem({ className, ...props }: React.ComponentProps<typeof Comman
   );
 }
 
+/** Accessible command palette keyboard shortcut display. @see https://ui.shadcn.com/docs/components/command */
 function CommandShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span

--- a/packages/next-shell/src/primitives/context-menu.tsx
+++ b/packages/next-shell/src/primitives/context-menu.tsx
@@ -6,34 +6,41 @@ import { ContextMenu as ContextMenuPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible context menu component built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenu({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
   return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
 }
 
+/** Accessible context menu trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuTrigger({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
   return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />;
 }
 
+/** Accessible context menu group built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuGroup({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
   return <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />;
 }
 
+/** Accessible context menu portal built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuPortal({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
   return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />;
 }
 
+/** Accessible context menu sub-menu built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuSub({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
   return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />;
 }
 
+/** Accessible context menu radio group built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
   return <ContextMenuPrimitive.RadioGroup data-slot="context-menu-radio-group" {...props} />;
 }
 
+/** Accessible context menu sub-menu trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuSubTrigger({
   className,
   inset,
@@ -58,6 +65,7 @@ function ContextMenuSubTrigger({
   );
 }
 
+/** Accessible context menu sub-menu content built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuSubContent({
   className,
   ...props
@@ -74,6 +82,7 @@ function ContextMenuSubContent({
   );
 }
 
+/** Accessible context menu content built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuContent({
   className,
   ...props
@@ -92,6 +101,7 @@ function ContextMenuContent({
   );
 }
 
+/** Accessible context menu item built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuItem({
   className,
   inset,
@@ -115,6 +125,7 @@ function ContextMenuItem({
   );
 }
 
+/** Accessible context menu checkbox item built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuCheckboxItem({
   className,
   children,
@@ -141,6 +152,7 @@ function ContextMenuCheckboxItem({
   );
 }
 
+/** Accessible context menu radio item built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuRadioItem({
   className,
   children,
@@ -165,6 +177,7 @@ function ContextMenuRadioItem({
   );
 }
 
+/** Accessible context menu label built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuLabel({
   className,
   inset,
@@ -182,6 +195,7 @@ function ContextMenuLabel({
   );
 }
 
+/** Accessible context menu separator built on Radix UI. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuSeparator({
   className,
   ...props
@@ -195,6 +209,7 @@ function ContextMenuSeparator({
   );
 }
 
+/** Accessible context menu shortcut display. @see https://ui.shadcn.com/docs/components/context-menu */
 function ContextMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span

--- a/packages/next-shell/src/primitives/dialog.tsx
+++ b/packages/next-shell/src/primitives/dialog.tsx
@@ -7,22 +7,27 @@ import { Dialog as DialogPrimitive } from 'radix-ui';
 import { cn } from '@/core/cn';
 import { Button } from '@/primitives/button';
 
+/** Accessible dialog component built on Radix UI. @see https://ui.shadcn.com/docs/components/dialog */
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
+/** Accessible dialog trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/dialog */
 function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
+/** Accessible dialog portal built on Radix UI. @see https://ui.shadcn.com/docs/components/dialog */
 function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
+/** Accessible dialog close button built on Radix UI. @see https://ui.shadcn.com/docs/components/dialog */
 function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
+/** Accessible dialog overlay built on Radix UI. @see https://ui.shadcn.com/docs/components/dialog */
 function DialogOverlay({
   className,
   ...props
@@ -39,6 +44,7 @@ function DialogOverlay({
   );
 }
 
+/** Accessible dialog content built on Radix UI. @see https://ui.shadcn.com/docs/components/dialog */
 function DialogContent({
   className,
   children,
@@ -73,6 +79,7 @@ function DialogContent({
   );
 }
 
+/** Accessible dialog header built on Radix UI. @see https://ui.shadcn.com/docs/components/dialog */
 function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -83,6 +90,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible dialog footer built on Radix UI. @see https://ui.shadcn.com/docs/components/dialog */
 function DialogFooter({
   className,
   showCloseButton = false,
@@ -107,6 +115,7 @@ function DialogFooter({
   );
 }
 
+/** Accessible dialog title built on Radix UI. @see https://ui.shadcn.com/docs/components/dialog */
 function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
@@ -117,6 +126,7 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof Dialog
   );
 }
 
+/** Accessible dialog description built on Radix UI. @see https://ui.shadcn.com/docs/components/dialog */
 function DialogDescription({
   className,
   ...props

--- a/packages/next-shell/src/primitives/drawer.tsx
+++ b/packages/next-shell/src/primitives/drawer.tsx
@@ -5,22 +5,27 @@ import { Drawer as DrawerPrimitive } from 'vaul';
 
 import { cn } from '@/core/cn';
 
+/** Accessible drawer component built on Vaul. @see https://ui.shadcn.com/docs/components/drawer */
 function Drawer({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
   return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
 }
 
+/** Accessible drawer trigger built on Vaul. @see https://ui.shadcn.com/docs/components/drawer */
 function DrawerTrigger({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
   return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
 }
 
+/** Accessible drawer portal built on Vaul. @see https://ui.shadcn.com/docs/components/drawer */
 function DrawerPortal({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
   return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
 }
 
+/** Accessible drawer close button built on Vaul. @see https://ui.shadcn.com/docs/components/drawer */
 function DrawerClose({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Close>) {
   return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
 }
 
+/** Accessible drawer overlay built on Vaul. @see https://ui.shadcn.com/docs/components/drawer */
 function DrawerOverlay({
   className,
   ...props
@@ -37,6 +42,7 @@ function DrawerOverlay({
   );
 }
 
+/** Accessible drawer content panel built on Vaul. @see https://ui.shadcn.com/docs/components/drawer */
 function DrawerContent({
   className,
   children,
@@ -64,6 +70,7 @@ function DrawerContent({
   );
 }
 
+/** Accessible drawer header built on Vaul. @see https://ui.shadcn.com/docs/components/drawer */
 function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -77,6 +84,7 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible drawer footer built on Vaul. @see https://ui.shadcn.com/docs/components/drawer */
 function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -87,6 +95,7 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible drawer title built on Vaul. @see https://ui.shadcn.com/docs/components/drawer */
 function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
   return (
     <DrawerPrimitive.Title
@@ -97,6 +106,7 @@ function DrawerTitle({ className, ...props }: React.ComponentProps<typeof Drawer
   );
 }
 
+/** Accessible drawer description built on Vaul. @see https://ui.shadcn.com/docs/components/drawer */
 function DrawerDescription({
   className,
   ...props

--- a/packages/next-shell/src/primitives/dropdown-menu.tsx
+++ b/packages/next-shell/src/primitives/dropdown-menu.tsx
@@ -6,22 +6,26 @@ import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible dropdown menu component built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
+/** Accessible dropdown menu portal built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
   return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
 }
 
+/** Accessible dropdown menu trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuTrigger({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
   return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
 }
 
+/** Accessible dropdown menu content built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuContent({
   className,
   sideOffset = 4,
@@ -42,10 +46,12 @@ function DropdownMenuContent({
   );
 }
 
+/** Accessible dropdown menu group built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
   return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
 }
 
+/** Accessible dropdown menu item built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuItem({
   className,
   inset,
@@ -69,6 +75,7 @@ function DropdownMenuItem({
   );
 }
 
+/** Accessible dropdown menu checkbox item built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuCheckboxItem({
   className,
   children,
@@ -95,12 +102,14 @@ function DropdownMenuCheckboxItem({
   );
 }
 
+/** Accessible dropdown menu radio group built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
   return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
 }
 
+/** Accessible dropdown menu radio item built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuRadioItem({
   className,
   children,
@@ -125,6 +134,7 @@ function DropdownMenuRadioItem({
   );
 }
 
+/** Accessible dropdown menu label built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuLabel({
   className,
   inset,
@@ -142,6 +152,7 @@ function DropdownMenuLabel({
   );
 }
 
+/** Accessible dropdown menu separator built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuSeparator({
   className,
   ...props
@@ -155,6 +166,7 @@ function DropdownMenuSeparator({
   );
 }
 
+/** Accessible dropdown menu shortcut display. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
@@ -165,10 +177,12 @@ function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'spa
   );
 }
 
+/** Accessible dropdown menu sub-menu built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
   return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
 }
 
+/** Accessible dropdown menu sub-menu trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuSubTrigger({
   className,
   inset,
@@ -193,6 +207,7 @@ function DropdownMenuSubTrigger({
   );
 }
 
+/** Accessible dropdown menu sub-menu content built on Radix UI. @see https://ui.shadcn.com/docs/components/dropdown-menu */
 function DropdownMenuSubContent({
   className,
   ...props

--- a/packages/next-shell/src/primitives/form.tsx
+++ b/packages/next-shell/src/primitives/form.tsx
@@ -16,6 +16,7 @@ import {
 import { cn } from '@/core/cn';
 import { Label } from '@/primitives/label';
 
+/** Accessible form provider component wrapping react-hook-form. @see https://ui.shadcn.com/docs/components/form */
 const Form = FormProvider;
 
 type FormFieldContextValue<
@@ -27,6 +28,7 @@ type FormFieldContextValue<
 
 const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
 
+/** Accessible form field controller wrapping react-hook-form. @see https://ui.shadcn.com/docs/components/form */
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
@@ -40,6 +42,7 @@ const FormField = <
   );
 };
 
+/** Hook to access form field state within a FormField. @see https://ui.shadcn.com/docs/components/form */
 const useFormField = () => {
   const fieldContext = React.useContext(FormFieldContext);
   const itemContext = React.useContext(FormItemContext);
@@ -69,6 +72,7 @@ type FormItemContextValue = {
 
 const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
 
+/** Accessible form item container. @see https://ui.shadcn.com/docs/components/form */
 function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
   const id = React.useId();
 
@@ -79,6 +83,7 @@ function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible form label linked to its field. @see https://ui.shadcn.com/docs/components/form */
 function FormLabel({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   const { error, formItemId } = useFormField();
 
@@ -93,6 +98,7 @@ function FormLabel({ className, ...props }: React.ComponentProps<typeof LabelPri
   );
 }
 
+/** Accessible form control slot with ARIA bindings. @see https://ui.shadcn.com/docs/components/form */
 function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
 
@@ -107,6 +113,7 @@ function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
   );
 }
 
+/** Accessible form field description text. @see https://ui.shadcn.com/docs/components/form */
 function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
   const { formDescriptionId } = useFormField();
 
@@ -120,6 +127,7 @@ function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
   );
 }
 
+/** Accessible form field validation message. @see https://ui.shadcn.com/docs/components/form */
 function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
   const { error, formMessageId } = useFormField();
   const body = error ? String(error?.message ?? '') : props.children;

--- a/packages/next-shell/src/primitives/hover-card.tsx
+++ b/packages/next-shell/src/primitives/hover-card.tsx
@@ -5,14 +5,17 @@ import { HoverCard as HoverCardPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible hover card component built on Radix UI. @see https://ui.shadcn.com/docs/components/hover-card */
 function HoverCard({ ...props }: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
   return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
 }
 
+/** Accessible hover card trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/hover-card */
 function HoverCardTrigger({ ...props }: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
   return <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />;
 }
 
+/** Accessible hover card content built on Radix UI. @see https://ui.shadcn.com/docs/components/hover-card */
 function HoverCardContent({
   className,
   align = 'center',

--- a/packages/next-shell/src/primitives/input-otp.tsx
+++ b/packages/next-shell/src/primitives/input-otp.tsx
@@ -6,6 +6,7 @@ import { MinusIcon } from 'lucide-react';
 
 import { cn } from '@/core/cn';
 
+/** Accessible one-time password input component. @see https://ui.shadcn.com/docs/components/input-otp */
 function InputOTP({
   className,
   containerClassName,
@@ -23,12 +24,14 @@ function InputOTP({
   );
 }
 
+/** Accessible OTP input group container. @see https://ui.shadcn.com/docs/components/input-otp */
 function InputOTPGroup({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div data-slot="input-otp-group" className={cn('flex items-center', className)} {...props} />
   );
 }
 
+/** Accessible OTP input slot for a single digit. @see https://ui.shadcn.com/docs/components/input-otp */
 function InputOTPSlot({
   index,
   className,
@@ -59,6 +62,7 @@ function InputOTPSlot({
   );
 }
 
+/** Accessible OTP input separator. @see https://ui.shadcn.com/docs/components/input-otp */
 function InputOTPSeparator({ ...props }: React.ComponentProps<'div'>) {
   return (
     <div data-slot="input-otp-separator" role="separator" {...props}>

--- a/packages/next-shell/src/primitives/input.tsx
+++ b/packages/next-shell/src/primitives/input.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { cn } from '@/core/cn';
 
+/** Accessible text input component. @see https://ui.shadcn.com/docs/components/input */
 function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (
     <input

--- a/packages/next-shell/src/primitives/label.tsx
+++ b/packages/next-shell/src/primitives/label.tsx
@@ -5,6 +5,7 @@ import { Label as LabelPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible label component built on Radix UI. @see https://ui.shadcn.com/docs/components/label */
 function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (
     <LabelPrimitive.Root

--- a/packages/next-shell/src/primitives/menubar.tsx
+++ b/packages/next-shell/src/primitives/menubar.tsx
@@ -6,6 +6,7 @@ import { Menubar as MenubarPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible menubar component built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function Menubar({ className, ...props }: React.ComponentProps<typeof MenubarPrimitive.Root>) {
   return (
     <MenubarPrimitive.Root
@@ -19,22 +20,27 @@ function Menubar({ className, ...props }: React.ComponentProps<typeof MenubarPri
   );
 }
 
+/** Accessible menubar menu container built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarMenu({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Menu>) {
   return <MenubarPrimitive.Menu data-slot="menubar-menu" {...props} />;
 }
 
+/** Accessible menubar group built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarGroup({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Group>) {
   return <MenubarPrimitive.Group data-slot="menubar-group" {...props} />;
 }
 
+/** Accessible menubar portal built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarPortal({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Portal>) {
   return <MenubarPrimitive.Portal data-slot="menubar-portal" {...props} />;
 }
 
+/** Accessible menubar radio group built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarRadioGroup({ ...props }: React.ComponentProps<typeof MenubarPrimitive.RadioGroup>) {
   return <MenubarPrimitive.RadioGroup data-slot="menubar-radio-group" {...props} />;
 }
 
+/** Accessible menubar trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarTrigger({
   className,
   ...props
@@ -51,6 +57,7 @@ function MenubarTrigger({
   );
 }
 
+/** Accessible menubar content built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarContent({
   className,
   align = 'start',
@@ -75,6 +82,7 @@ function MenubarContent({
   );
 }
 
+/** Accessible menubar item built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarItem({
   className,
   inset,
@@ -98,6 +106,7 @@ function MenubarItem({
   );
 }
 
+/** Accessible menubar checkbox item built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarCheckboxItem({
   className,
   children,
@@ -124,6 +133,7 @@ function MenubarCheckboxItem({
   );
 }
 
+/** Accessible menubar radio item built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarRadioItem({
   className,
   children,
@@ -148,6 +158,7 @@ function MenubarRadioItem({
   );
 }
 
+/** Accessible menubar label built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarLabel({
   className,
   inset,
@@ -165,6 +176,7 @@ function MenubarLabel({
   );
 }
 
+/** Accessible menubar separator built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarSeparator({
   className,
   ...props
@@ -178,6 +190,7 @@ function MenubarSeparator({
   );
 }
 
+/** Accessible menubar shortcut display. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
@@ -188,10 +201,12 @@ function MenubarShortcut({ className, ...props }: React.ComponentProps<'span'>) 
   );
 }
 
+/** Accessible menubar sub-menu built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarSub({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Sub>) {
   return <MenubarPrimitive.Sub data-slot="menubar-sub" {...props} />;
 }
 
+/** Accessible menubar sub-menu trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarSubTrigger({
   className,
   inset,
@@ -216,6 +231,7 @@ function MenubarSubTrigger({
   );
 }
 
+/** Accessible menubar sub-menu content built on Radix UI. @see https://ui.shadcn.com/docs/components/menubar */
 function MenubarSubContent({
   className,
   ...props

--- a/packages/next-shell/src/primitives/navigation-menu.tsx
+++ b/packages/next-shell/src/primitives/navigation-menu.tsx
@@ -5,6 +5,7 @@ import { NavigationMenu as NavigationMenuPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible navigation menu component built on Radix UI. @see https://ui.shadcn.com/docs/components/navigation-menu */
 function NavigationMenu({
   className,
   children,
@@ -29,6 +30,7 @@ function NavigationMenu({
   );
 }
 
+/** Accessible navigation menu list built on Radix UI. @see https://ui.shadcn.com/docs/components/navigation-menu */
 function NavigationMenuList({
   className,
   ...props
@@ -42,6 +44,7 @@ function NavigationMenuList({
   );
 }
 
+/** Accessible navigation menu item built on Radix UI. @see https://ui.shadcn.com/docs/components/navigation-menu */
 function NavigationMenuItem({
   className,
   ...props
@@ -59,6 +62,7 @@ const navigationMenuTriggerStyle = cva(
   'group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-[color,box-shadow] outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-accent/50 data-[state=open]:text-accent-foreground data-[state=open]:hover:bg-accent data-[state=open]:focus:bg-accent',
 );
 
+/** Accessible navigation menu trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/navigation-menu */
 function NavigationMenuTrigger({
   className,
   children,
@@ -79,6 +83,7 @@ function NavigationMenuTrigger({
   );
 }
 
+/** Accessible navigation menu content panel built on Radix UI. @see https://ui.shadcn.com/docs/components/navigation-menu */
 function NavigationMenuContent({
   className,
   ...props
@@ -96,6 +101,7 @@ function NavigationMenuContent({
   );
 }
 
+/** Accessible navigation menu viewport built on Radix UI. @see https://ui.shadcn.com/docs/components/navigation-menu */
 function NavigationMenuViewport({
   className,
   ...props
@@ -114,6 +120,7 @@ function NavigationMenuViewport({
   );
 }
 
+/** Accessible navigation menu link built on Radix UI. @see https://ui.shadcn.com/docs/components/navigation-menu */
 function NavigationMenuLink({
   className,
   ...props
@@ -130,6 +137,7 @@ function NavigationMenuLink({
   );
 }
 
+/** Accessible navigation menu indicator built on Radix UI. @see https://ui.shadcn.com/docs/components/navigation-menu */
 function NavigationMenuIndicator({
   className,
   ...props

--- a/packages/next-shell/src/primitives/pagination.tsx
+++ b/packages/next-shell/src/primitives/pagination.tsx
@@ -4,6 +4,7 @@ import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from 'lucide-re
 import { cn } from '@/core/cn';
 import { buttonVariants, type Button } from '@/primitives/button';
 
+/** Accessible pagination navigation component. @see https://ui.shadcn.com/docs/components/pagination */
 function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
   return (
     <nav
@@ -16,6 +17,7 @@ function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
   );
 }
 
+/** Accessible pagination content list. @see https://ui.shadcn.com/docs/components/pagination */
 function PaginationContent({ className, ...props }: React.ComponentProps<'ul'>) {
   return (
     <ul
@@ -26,6 +28,7 @@ function PaginationContent({ className, ...props }: React.ComponentProps<'ul'>) 
   );
 }
 
+/** Accessible pagination item container. @see https://ui.shadcn.com/docs/components/pagination */
 function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
   return <li data-slot="pagination-item" {...props} />;
 }
@@ -35,6 +38,7 @@ type PaginationLinkProps = {
 } & Pick<React.ComponentProps<typeof Button>, 'size'> &
   React.ComponentProps<'a'>;
 
+/** Accessible pagination page link. @see https://ui.shadcn.com/docs/components/pagination */
 function PaginationLink({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) {
   return (
     <a
@@ -53,6 +57,7 @@ function PaginationLink({ className, isActive, size = 'icon', ...props }: Pagina
   );
 }
 
+/** Accessible pagination previous page link. @see https://ui.shadcn.com/docs/components/pagination */
 function PaginationPrevious({ className, ...props }: React.ComponentProps<typeof PaginationLink>) {
   return (
     <PaginationLink
@@ -67,6 +72,7 @@ function PaginationPrevious({ className, ...props }: React.ComponentProps<typeof
   );
 }
 
+/** Accessible pagination next page link. @see https://ui.shadcn.com/docs/components/pagination */
 function PaginationNext({ className, ...props }: React.ComponentProps<typeof PaginationLink>) {
   return (
     <PaginationLink
@@ -81,6 +87,7 @@ function PaginationNext({ className, ...props }: React.ComponentProps<typeof Pag
   );
 }
 
+/** Accessible pagination ellipsis overflow indicator. @see https://ui.shadcn.com/docs/components/pagination */
 function PaginationEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span

--- a/packages/next-shell/src/primitives/popover.tsx
+++ b/packages/next-shell/src/primitives/popover.tsx
@@ -5,14 +5,17 @@ import { Popover as PopoverPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible popover component built on Radix UI. @see https://ui.shadcn.com/docs/components/popover */
 function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
+/** Accessible popover trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/popover */
 function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
+/** Accessible popover content built on Radix UI. @see https://ui.shadcn.com/docs/components/popover */
 function PopoverContent({
   className,
   align = 'center',
@@ -35,10 +38,12 @@ function PopoverContent({
   );
 }
 
+/** Accessible popover anchor built on Radix UI. @see https://ui.shadcn.com/docs/components/popover */
 function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 
+/** Accessible popover header component. @see https://ui.shadcn.com/docs/components/popover */
 function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -49,10 +54,12 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible popover title component. @see https://ui.shadcn.com/docs/components/popover */
 function PopoverTitle({ className, ...props }: React.ComponentProps<'h2'>) {
   return <div data-slot="popover-title" className={cn('font-medium', className)} {...props} />;
 }
 
+/** Accessible popover description component. @see https://ui.shadcn.com/docs/components/popover */
 function PopoverDescription({ className, ...props }: React.ComponentProps<'p'>) {
   return (
     <p

--- a/packages/next-shell/src/primitives/progress.tsx
+++ b/packages/next-shell/src/primitives/progress.tsx
@@ -5,6 +5,7 @@ import { Progress as ProgressPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible progress bar component built on Radix UI. @see https://ui.shadcn.com/docs/components/progress */
 function Progress({
   className,
   value,

--- a/packages/next-shell/src/primitives/radio-group.tsx
+++ b/packages/next-shell/src/primitives/radio-group.tsx
@@ -6,6 +6,7 @@ import { RadioGroup as RadioGroupPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible radio group component built on Radix UI. @see https://ui.shadcn.com/docs/components/radio-group */
 function RadioGroup({
   className,
   ...props
@@ -19,6 +20,7 @@ function RadioGroup({
   );
 }
 
+/** Accessible radio group item built on Radix UI. @see https://ui.shadcn.com/docs/components/radio-group */
 function RadioGroupItem({
   className,
   ...props

--- a/packages/next-shell/src/primitives/resizable.tsx
+++ b/packages/next-shell/src/primitives/resizable.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/core/cn';
 // shadcn upstream source uses the namespace-member style expected by
 // their internal wrapper; we access the real export names directly.
 
+/** Accessible resizable panel group container. @see https://ui.shadcn.com/docs/components/resizable */
 function ResizablePanelGroup({ className, ...props }: ResizablePrimitive.PanelGroupProps) {
   return (
     <ResizablePrimitive.PanelGroup
@@ -20,10 +21,12 @@ function ResizablePanelGroup({ className, ...props }: ResizablePrimitive.PanelGr
   );
 }
 
+/** Accessible resizable panel component. @see https://ui.shadcn.com/docs/components/resizable */
 function ResizablePanel({ ...props }: ResizablePrimitive.PanelProps) {
   return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />;
 }
 
+/** Accessible resizable panel drag handle. @see https://ui.shadcn.com/docs/components/resizable */
 function ResizableHandle({
   withHandle,
   className,

--- a/packages/next-shell/src/primitives/scroll-area.tsx
+++ b/packages/next-shell/src/primitives/scroll-area.tsx
@@ -5,6 +5,7 @@ import { ScrollArea as ScrollAreaPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible scroll area component built on Radix UI. @see https://ui.shadcn.com/docs/components/scroll-area */
 function ScrollArea({
   className,
   children,
@@ -28,6 +29,7 @@ function ScrollArea({
   );
 }
 
+/** Accessible scroll area scrollbar built on Radix UI. @see https://ui.shadcn.com/docs/components/scroll-area */
 function ScrollBar({
   className,
   orientation = 'vertical',

--- a/packages/next-shell/src/primitives/select.tsx
+++ b/packages/next-shell/src/primitives/select.tsx
@@ -6,18 +6,22 @@ import { Select as SelectPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible select component built on Radix UI. @see https://ui.shadcn.com/docs/components/select */
 function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
   return <SelectPrimitive.Root data-slot="select" {...props} />;
 }
 
+/** Accessible select option group built on Radix UI. @see https://ui.shadcn.com/docs/components/select */
 function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
+/** Accessible select value display built on Radix UI. @see https://ui.shadcn.com/docs/components/select */
 function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
   return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
+/** Accessible select trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/select */
 function SelectTrigger({
   className,
   size = 'default',
@@ -44,6 +48,7 @@ function SelectTrigger({
   );
 }
 
+/** Accessible select content dropdown built on Radix UI. @see https://ui.shadcn.com/docs/components/select */
 function SelectContent({
   className,
   children,
@@ -81,6 +86,7 @@ function SelectContent({
   );
 }
 
+/** Accessible select label built on Radix UI. @see https://ui.shadcn.com/docs/components/select */
 function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
   return (
     <SelectPrimitive.Label
@@ -91,6 +97,7 @@ function SelectLabel({ className, ...props }: React.ComponentProps<typeof Select
   );
 }
 
+/** Accessible select option item built on Radix UI. @see https://ui.shadcn.com/docs/components/select */
 function SelectItem({
   className,
   children,
@@ -118,6 +125,7 @@ function SelectItem({
   );
 }
 
+/** Accessible select separator built on Radix UI. @see https://ui.shadcn.com/docs/components/select */
 function SelectSeparator({
   className,
   ...props
@@ -131,6 +139,7 @@ function SelectSeparator({
   );
 }
 
+/** Accessible select scroll up button built on Radix UI. @see https://ui.shadcn.com/docs/components/select */
 function SelectScrollUpButton({
   className,
   ...props
@@ -146,6 +155,7 @@ function SelectScrollUpButton({
   );
 }
 
+/** Accessible select scroll down button built on Radix UI. @see https://ui.shadcn.com/docs/components/select */
 function SelectScrollDownButton({
   className,
   ...props

--- a/packages/next-shell/src/primitives/separator.tsx
+++ b/packages/next-shell/src/primitives/separator.tsx
@@ -5,6 +5,7 @@ import { Separator as SeparatorPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible separator component built on Radix UI. @see https://ui.shadcn.com/docs/components/separator */
 function Separator({
   className,
   orientation = 'horizontal',

--- a/packages/next-shell/src/primitives/sheet.tsx
+++ b/packages/next-shell/src/primitives/sheet.tsx
@@ -6,14 +6,17 @@ import { Dialog as SheetPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible sheet (side panel) component built on Radix UI. @see https://ui.shadcn.com/docs/components/sheet */
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
 
+/** Accessible sheet trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/sheet */
 function SheetTrigger({ ...props }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
   return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
 }
 
+/** Accessible sheet close button built on Radix UI. @see https://ui.shadcn.com/docs/components/sheet */
 function SheetClose({ ...props }: React.ComponentProps<typeof SheetPrimitive.Close>) {
   return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
 }
@@ -38,6 +41,7 @@ function SheetOverlay({
   );
 }
 
+/** Accessible sheet content panel built on Radix UI. @see https://ui.shadcn.com/docs/components/sheet */
 function SheetContent({
   className,
   children,
@@ -79,6 +83,7 @@ function SheetContent({
   );
 }
 
+/** Accessible sheet header component. @see https://ui.shadcn.com/docs/components/sheet */
 function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -89,6 +94,7 @@ function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible sheet footer component. @see https://ui.shadcn.com/docs/components/sheet */
 function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
@@ -99,6 +105,7 @@ function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+/** Accessible sheet title built on Radix UI. @see https://ui.shadcn.com/docs/components/sheet */
 function SheetTitle({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Title>) {
   return (
     <SheetPrimitive.Title
@@ -109,6 +116,7 @@ function SheetTitle({ className, ...props }: React.ComponentProps<typeof SheetPr
   );
 }
 
+/** Accessible sheet description built on Radix UI. @see https://ui.shadcn.com/docs/components/sheet */
 function SheetDescription({
   className,
   ...props

--- a/packages/next-shell/src/primitives/skeleton.tsx
+++ b/packages/next-shell/src/primitives/skeleton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { cn } from '@/core/cn';
 
+/** Accessible skeleton loading placeholder component. @see https://ui.shadcn.com/docs/components/skeleton */
 function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div

--- a/packages/next-shell/src/primitives/slider.tsx
+++ b/packages/next-shell/src/primitives/slider.tsx
@@ -5,6 +5,7 @@ import { Slider as SliderPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible slider component built on Radix UI. @see https://ui.shadcn.com/docs/components/slider */
 function Slider({
   className,
   defaultValue,

--- a/packages/next-shell/src/primitives/sonner.tsx
+++ b/packages/next-shell/src/primitives/sonner.tsx
@@ -10,6 +10,7 @@ import {
 import { useTheme } from 'next-themes';
 import { Toaster as Sonner, type ToasterProps } from 'sonner';
 
+/** Accessible toast notification provider built on Sonner. @see https://ui.shadcn.com/docs/components/sonner */
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = 'system' } = useTheme();
 

--- a/packages/next-shell/src/primitives/switch.tsx
+++ b/packages/next-shell/src/primitives/switch.tsx
@@ -5,6 +5,7 @@ import { Switch as SwitchPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible switch toggle component built on Radix UI. @see https://ui.shadcn.com/docs/components/switch */
 function Switch({
   className,
   size = 'default',

--- a/packages/next-shell/src/primitives/table.tsx
+++ b/packages/next-shell/src/primitives/table.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { cn } from '@/core/cn';
 
+/** Accessible table component. @see https://ui.shadcn.com/docs/components/table */
 function Table({ className, ...props }: React.ComponentProps<'table'>) {
   return (
     <div data-slot="table-container" className="relative w-full overflow-x-auto">
@@ -16,10 +17,12 @@ function Table({ className, ...props }: React.ComponentProps<'table'>) {
   );
 }
 
+/** Accessible table header component. @see https://ui.shadcn.com/docs/components/table */
 function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
   return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />;
 }
 
+/** Accessible table body component. @see https://ui.shadcn.com/docs/components/table */
 function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
   return (
     <tbody
@@ -30,6 +33,7 @@ function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
   );
 }
 
+/** Accessible table footer component. @see https://ui.shadcn.com/docs/components/table */
 function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
   return (
     <tfoot
@@ -40,6 +44,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
   );
 }
 
+/** Accessible table row component. @see https://ui.shadcn.com/docs/components/table */
 function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
   return (
     <tr
@@ -53,6 +58,7 @@ function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
   );
 }
 
+/** Accessible table head cell component. @see https://ui.shadcn.com/docs/components/table */
 function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
   return (
     <th
@@ -66,6 +72,7 @@ function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
   );
 }
 
+/** Accessible table data cell component. @see https://ui.shadcn.com/docs/components/table */
 function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
   return (
     <td
@@ -79,6 +86,7 @@ function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
   );
 }
 
+/** Accessible table caption component. @see https://ui.shadcn.com/docs/components/table */
 function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
   return (
     <caption

--- a/packages/next-shell/src/primitives/tabs.tsx
+++ b/packages/next-shell/src/primitives/tabs.tsx
@@ -6,6 +6,7 @@ import { Tabs as TabsPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible tabs component built on Radix UI. @see https://ui.shadcn.com/docs/components/tabs */
 function Tabs({
   className,
   orientation = 'horizontal',
@@ -37,6 +38,7 @@ const tabsListVariants = cva(
   },
 );
 
+/** Accessible tabs list container built on Radix UI. @see https://ui.shadcn.com/docs/components/tabs */
 function TabsList({
   className,
   variant = 'default',
@@ -52,6 +54,7 @@ function TabsList({
   );
 }
 
+/** Accessible tabs trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/tabs */
 function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
   return (
     <TabsPrimitive.Trigger
@@ -68,6 +71,7 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
   );
 }
 
+/** Accessible tabs content panel built on Radix UI. @see https://ui.shadcn.com/docs/components/tabs */
 function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
   return (
     <TabsPrimitive.Content

--- a/packages/next-shell/src/primitives/textarea.tsx
+++ b/packages/next-shell/src/primitives/textarea.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { cn } from '@/core/cn';
 
+/** Accessible textarea component. @see https://ui.shadcn.com/docs/components/textarea */
 function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
   return (
     <textarea

--- a/packages/next-shell/src/primitives/toggle-group.tsx
+++ b/packages/next-shell/src/primitives/toggle-group.tsx
@@ -17,6 +17,7 @@ const ToggleGroupContext = React.createContext<
   spacing: 0,
 });
 
+/** Accessible toggle group component built on Radix UI. @see https://ui.shadcn.com/docs/components/toggle-group */
 function ToggleGroup({
   className,
   variant,
@@ -48,6 +49,7 @@ function ToggleGroup({
   );
 }
 
+/** Accessible toggle group item built on Radix UI. @see https://ui.shadcn.com/docs/components/toggle-group */
 function ToggleGroupItem({
   className,
   children,

--- a/packages/next-shell/src/primitives/toggle.tsx
+++ b/packages/next-shell/src/primitives/toggle.tsx
@@ -28,6 +28,7 @@ const toggleVariants = cva(
   },
 );
 
+/** Accessible toggle button component built on Radix UI. @see https://ui.shadcn.com/docs/components/toggle */
 function Toggle({
   className,
   variant,

--- a/packages/next-shell/src/primitives/tooltip.tsx
+++ b/packages/next-shell/src/primitives/tooltip.tsx
@@ -5,6 +5,7 @@ import { Tooltip as TooltipPrimitive } from 'radix-ui';
 
 import { cn } from '@/core/cn';
 
+/** Accessible tooltip provider built on Radix UI. @see https://ui.shadcn.com/docs/components/tooltip */
 function TooltipProvider({
   delayDuration = 0,
   ...props
@@ -18,14 +19,17 @@ function TooltipProvider({
   );
 }
 
+/** Accessible tooltip component built on Radix UI. @see https://ui.shadcn.com/docs/components/tooltip */
 function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
+/** Accessible tooltip trigger built on Radix UI. @see https://ui.shadcn.com/docs/components/tooltip */
 function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
+/** Accessible tooltip content built on Radix UI. @see https://ui.shadcn.com/docs/components/tooltip */
 function TooltipContent({
   className,
   sideOffset = 0,

--- a/packages/next-shell/src/tokens/hex-to-oklch.ts
+++ b/packages/next-shell/src/tokens/hex-to-oklch.ts
@@ -1,0 +1,127 @@
+/**
+ * hexToOklch — convert a hex color string to an OKLCH CSS value.
+ *
+ * Pipeline: sRGB hex → linear RGB → CIE XYZ (D65) → OKLab → OKLCH
+ *
+ * Returns a string like `oklch(0.627 0.194 163.1)` with L rounded to 3
+ * decimals, C to 3 decimals, and H to 1 decimal. When chroma is near zero
+ * (achromatic), hue is reported as 0.
+ */
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Step 1 — Parse hex
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function parseHex(hex: string): [r: number, g: number, b: number] {
+  let h = hex.startsWith('#') ? hex.slice(1) : hex;
+
+  if (h.length === 3) {
+    h = h[0]! + h[0]! + h[1]! + h[1]! + h[2]! + h[2]!;
+  }
+
+  if (h.length !== 6 || !/^[0-9a-fA-F]{6}$/.test(h)) {
+    throw new Error(`hexToOklch: invalid hex color "${hex}"`);
+  }
+
+  return [
+    parseInt(h.slice(0, 2), 16) / 255,
+    parseInt(h.slice(2, 4), 16) / 255,
+    parseInt(h.slice(4, 6), 16) / 255,
+  ];
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Step 2 — sRGB → linear RGB
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function srgbToLinear(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Step 3 — linear RGB → CIE XYZ (D65)
+ *
+ * Using the standard sRGB-to-XYZ matrix (IEC 61966-2-1).
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function linearRgbToXyz(r: number, g: number, b: number): [x: number, y: number, z: number] {
+  return [
+    0.4123907992659595 * r + 0.357584339383878 * g + 0.1804807884018343 * b,
+    0.21263900587151027 * r + 0.715168678767756 * g + 0.07219231536073371 * b,
+    0.01933081871559182 * r + 0.11919477979462598 * g + 0.9505321522496607 * b,
+  ];
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Step 4 — XYZ → OKLab
+ *
+ * Uses the Björn Ottosson matrices (2020).
+ * XYZ → LMS (M1) → cube-root → OKLab (M2)
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function xyzToOklab(x: number, y: number, z: number): [L: number, a: number, b: number] {
+  // M1: XYZ → approximate cone responses (LMS)
+  const l = 0.8189330101 * x + 0.3618667424 * y - 0.1288597137 * z;
+  const m = 0.0329845436 * x + 0.9293118715 * y + 0.0361456387 * z;
+  const s = 0.0482003018 * x + 0.2643662691 * y + 0.633851707 * z;
+
+  // Cube root
+  const l_ = Math.cbrt(l);
+  const m_ = Math.cbrt(m);
+  const s_ = Math.cbrt(s);
+
+  // M2: LMS cube-root → OKLab
+  return [
+    0.2104542553 * l_ + 0.793617785 * m_ - 0.0040720468 * s_,
+    1.9779984951 * l_ - 2.428592205 * m_ + 0.4505937099 * s_,
+    0.0259040371 * l_ + 0.7827717662 * m_ - 0.808675766 * s_,
+  ];
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Step 5 — OKLab → OKLCH
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function oklabToOklch(L: number, a: number, b: number): [L: number, C: number, H: number] {
+  const C = Math.sqrt(a * a + b * b);
+  let H = (Math.atan2(b, a) * 180) / Math.PI;
+  if (H < 0) H += 360;
+
+  // When chroma rounds to "0.000" at 3 decimal places the hue is meaningless
+  if (C < 0.0005) {
+    return [L, 0, 0];
+  }
+
+  return [L, C, H];
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Public API
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Convert a hex color string to an OKLCH CSS function value.
+ *
+ * @param hex - A 3- or 6-digit hex string, with or without leading `#`.
+ * @returns A string like `oklch(0.627 0.194 163.1)`.
+ * @throws If the input is not a valid hex color.
+ *
+ * @example
+ * ```ts
+ * hexToOklch('#10b981'); // → "oklch(0.696 0.174 162.5)"
+ * hexToOklch('fff');     // → "oklch(1.000 0.000 0.0)"
+ * ```
+ */
+export function hexToOklch(hex: string): string {
+  const [r, g, b] = parseHex(hex);
+
+  const lr = srgbToLinear(r);
+  const lg = srgbToLinear(g);
+  const lb = srgbToLinear(b);
+
+  const [x, y, z] = linearRgbToXyz(lr, lg, lb);
+  const [labL, labA, labB] = xyzToOklab(x, y, z);
+  const [L, C, H] = oklabToOklch(labL, labA, labB);
+
+  return `oklch(${L.toFixed(3)} ${C.toFixed(3)} ${H.toFixed(1)})`;
+}

--- a/packages/next-shell/src/tokens/index.ts
+++ b/packages/next-shell/src/tokens/index.ts
@@ -250,3 +250,5 @@ export function cssVar(
 ): string {
   return `var(--${token})`;
 }
+
+export { hexToOklch } from './hex-to-oklch.js';

--- a/packages/next-shell/tests/breadcrumbs.test.tsx
+++ b/packages/next-shell/tests/breadcrumbs.test.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Breadcrumbs } from '../src/layout/breadcrumbs.js';
+import type { NavConfig } from '../src/layout/nav-config.js';
+
+const NAV: NavConfig = [
+  { id: 'home', label: 'Home', href: '/' },
+  {
+    id: 'settings',
+    label: 'Settings',
+    href: '/settings',
+    children: [
+      { id: 'profile', label: 'Profile', href: '/settings/profile' },
+      { id: 'security', label: 'Security', href: '/settings/security', requires: 'admin' },
+    ],
+  },
+];
+
+describe('Breadcrumbs', () => {
+  it('renders nothing when no item is active', () => {
+    const { container } = render(<Breadcrumbs config={NAV} pathname="/unknown" />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders a single breadcrumb for a root item', () => {
+    render(<Breadcrumbs config={NAV} pathname="/" />);
+    expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+
+  it('renders ancestor + leaf for nested items', () => {
+    render(<Breadcrumbs config={NAV} pathname="/settings/profile" />);
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('Profile')).toBeInTheDocument();
+  });
+
+  it('ancestor crumbs render as links', () => {
+    render(<Breadcrumbs config={NAV} pathname="/settings/profile" />);
+    const settingsLink = screen.getByText('Settings').closest('a');
+    expect(settingsLink).toHaveAttribute('href', '/settings');
+  });
+
+  it('respects permission gating', () => {
+    render(<Breadcrumbs config={NAV} pathname="/settings/security" permissions={[]} />);
+    expect(screen.queryByText('Security')).toBeNull();
+  });
+
+  it('shows gated items when user has permission', () => {
+    render(<Breadcrumbs config={NAV} pathname="/settings/security" permissions={['admin']} />);
+    expect(screen.getByText('Security')).toBeInTheDocument();
+  });
+
+  it('supports custom renderLink', () => {
+    render(
+      <Breadcrumbs
+        config={NAV}
+        pathname="/settings/profile"
+        renderLink={(item, children) => (
+          <a data-testid={`link-${item.id}`} href={item.href!}>
+            {children}
+          </a>
+        )}
+      />,
+    );
+    expect(screen.getByTestId('link-settings')).toBeInTheDocument();
+  });
+});

--- a/packages/next-shell/tests/command-bar-actions.test.tsx
+++ b/packages/next-shell/tests/command-bar-actions.test.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CommandBarProvider, useCommandBar } from '../src/layout/command-bar.js';
+import { CommandBarActions } from '../src/layout/command-bar-actions.js';
+import type { NavConfig } from '../src/layout/nav-config.js';
+
+const NAV: NavConfig = [
+  { id: 'home', label: 'Home', href: '/' },
+  {
+    id: 'settings',
+    label: 'Settings',
+    href: '/settings',
+    children: [{ id: 'profile', label: 'Profile', href: '/settings/profile' }],
+  },
+  { id: 'admin', label: 'Admin', href: '/admin', requires: 'admin' },
+];
+
+describe('CommandBarActions', () => {
+  it('renders nothing (side-effect only)', () => {
+    const { container } = render(
+      <CommandBarProvider>
+        <CommandBarActions config={NAV} pathname="/" />
+      </CommandBarProvider>,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('mounts without throwing', () => {
+    expect(() =>
+      render(
+        <CommandBarProvider>
+          <CommandBarActions config={NAV} pathname="/" />
+        </CommandBarProvider>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('accepts permissions prop', () => {
+    expect(() =>
+      render(
+        <CommandBarProvider>
+          <CommandBarActions config={NAV} pathname="/" permissions={['admin']} />
+        </CommandBarProvider>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('accepts onNavigate callback', () => {
+    const onNavigate = vi.fn();
+    expect(() =>
+      render(
+        <CommandBarProvider>
+          <CommandBarActions config={NAV} pathname="/" onNavigate={onNavigate} />
+        </CommandBarProvider>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('works with empty config', () => {
+    expect(() =>
+      render(
+        <CommandBarProvider>
+          <CommandBarActions config={[]} pathname="/" />
+        </CommandBarProvider>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('registers actions in the provider context', () => {
+    function Probe() {
+      const { open } = useCommandBar();
+      return <span data-testid="open">{String(open)}</span>;
+    }
+    render(
+      <CommandBarProvider>
+        <CommandBarActions config={NAV} pathname="/" />
+        <Probe />
+      </CommandBarProvider>,
+    );
+    expect(screen.getByTestId('open')).toHaveTextContent('false');
+  });
+});

--- a/packages/next-shell/tests/hex-to-oklch.test.ts
+++ b/packages/next-shell/tests/hex-to-oklch.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { hexToOklch } from '../src/tokens/index.js';
+
+describe('hexToOklch', () => {
+  describe('6-digit hex', () => {
+    it('converts #10b981 (with hash)', () => {
+      expect(hexToOklch('#10b981')).toBe('oklch(0.696 0.149 162.5)');
+    });
+
+    it('converts 10b981 (without hash)', () => {
+      expect(hexToOklch('10b981')).toBe('oklch(0.696 0.149 162.5)');
+    });
+  });
+
+  describe('3-digit hex', () => {
+    it('converts #fff to white', () => {
+      const result = hexToOklch('#fff');
+      expect(result).toBe('oklch(1.000 0.000 0.0)');
+    });
+
+    it('converts #000 to black', () => {
+      const result = hexToOklch('#000');
+      expect(result).toBe('oklch(0.000 0.000 0.0)');
+    });
+  });
+
+  describe('primary colors — hue ranges', () => {
+    it('pure red (#ff0000) has hue in 20-40 range', () => {
+      const result = hexToOklch('#ff0000');
+      const match = result.match(/oklch\(([\d.]+) ([\d.]+) ([\d.]+)\)/);
+      expect(match).not.toBeNull();
+      const h = parseFloat(match![3]!);
+      expect(h).toBeGreaterThanOrEqual(20);
+      expect(h).toBeLessThanOrEqual(40);
+    });
+
+    it('pure green (#00ff00) has hue in 130-155 range', () => {
+      const result = hexToOklch('#00ff00');
+      const match = result.match(/oklch\(([\d.]+) ([\d.]+) ([\d.]+)\)/);
+      expect(match).not.toBeNull();
+      const h = parseFloat(match![3]!);
+      expect(h).toBeGreaterThanOrEqual(130);
+      expect(h).toBeLessThanOrEqual(155);
+    });
+
+    it('pure blue (#0000ff) has hue in 260-270 range', () => {
+      const result = hexToOklch('#0000ff');
+      const match = result.match(/oklch\(([\d.]+) ([\d.]+) ([\d.]+)\)/);
+      expect(match).not.toBeNull();
+      const h = parseFloat(match![3]!);
+      expect(h).toBeGreaterThanOrEqual(260);
+      expect(h).toBeLessThanOrEqual(270);
+    });
+  });
+
+  describe('achromatic extremes', () => {
+    it('black (#000000) has L=0', () => {
+      const result = hexToOklch('#000000');
+      expect(result).toMatch(/^oklch\(0\.000 /);
+    });
+
+    it('white (#ffffff) has L close to 1', () => {
+      const result = hexToOklch('#ffffff');
+      expect(result).toMatch(/^oklch\(1\.000 /);
+    });
+
+    it('achromatic colors have C=0 and H=0', () => {
+      const black = hexToOklch('#000000');
+      expect(black).toBe('oklch(0.000 0.000 0.0)');
+
+      // White is also achromatic
+      const white = hexToOklch('#ffffff');
+      expect(white).toBe('oklch(1.000 0.000 0.0)');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('throws on empty string', () => {
+      expect(() => hexToOklch('')).toThrow('invalid hex color');
+    });
+
+    it('throws on too-short input', () => {
+      expect(() => hexToOklch('#ab')).toThrow('invalid hex color');
+    });
+
+    it('throws on too-long input', () => {
+      expect(() => hexToOklch('#1234567')).toThrow('invalid hex color');
+    });
+
+    it('throws on non-hex characters', () => {
+      expect(() => hexToOklch('#gggggg')).toThrow('invalid hex color');
+    });
+
+    it('throws on 4-digit hex', () => {
+      expect(() => hexToOklch('#abcd')).toThrow('invalid hex color');
+    });
+  });
+});

--- a/packages/next-shell/tests/tailwind-preset.test.ts
+++ b/packages/next-shell/tests/tailwind-preset.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { preset, presetCssImportPath, tokensCssImportPath } from '../src/tailwind-preset/index.js';
+import { colorTokens, radiusTokens, tokenSchemaVersion } from '../src/tokens/index.js';
+import defaultExport from '../src/tailwind-preset/index.js';
+
+describe('tailwind-preset', () => {
+  it('exports presetCssImportPath as a package path', () => {
+    expect(presetCssImportPath).toBe('@jonmatum/next-shell/styles/preset.css');
+  });
+
+  it('exports tokensCssImportPath as a package path', () => {
+    expect(tokensCssImportPath).toBe('@jonmatum/next-shell/styles/tokens.css');
+  });
+
+  it('preset.version matches tokenSchemaVersion', () => {
+    expect(preset.version).toBe(tokenSchemaVersion);
+  });
+
+  it('preset.colors references colorTokens', () => {
+    expect(preset.colors).toBe(colorTokens);
+    expect(preset.colors.length).toBeGreaterThan(0);
+  });
+
+  it('preset.radii references radiusTokens', () => {
+    expect(preset.radii).toBe(radiusTokens);
+    expect(preset.radii.length).toBeGreaterThan(0);
+  });
+
+  it('preset.cssImports matches named exports', () => {
+    expect(preset.cssImports.preset).toBe(presetCssImportPath);
+    expect(preset.cssImports.tokensOnly).toBe(tokensCssImportPath);
+  });
+
+  it('default export is the same as named preset', () => {
+    expect(defaultExport).toBe(preset);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,9 +160,6 @@ importers:
 
   packages/next-shell:
     dependencies:
-      '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -218,6 +215,9 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.99.0
+        version: 5.99.0(react@19.2.5)
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.1


### PR DESCRIPTION
## Summary

7 issues from the open-source readiness epic (#54) in one batch.

Closes #55, #64, #66, #69, #70, #71, #72.

## Changes

- **#55** `docs/public/llms.txt` — AI-consumable documentation (llmstxt.org format) covering subpaths, tokens, components, hooks
- **#64** README usage examples for AppShell layout, buildNav, useDisclosure hook, formatters
- **#66** `hexToOklch()` utility in `@jonmatum/next-shell/tokens` — sRGB → linear → XYZ D65 → OKLab → OKLCH pipeline + 15 tests
- **#69** README badges (npm version, CI, license, bundle size) + docs site link
- **#70** JSDoc comments on all 42+ vendored primitive components with `@see` links
- **#71** SECURITY.md with GitHub Security Advisories reporting instructions
- **#72** New tests: Breadcrumbs (7), CommandBarActions (6), tailwind-preset (7)

## Verification

```
pnpm format     ok
pnpm lint       ok (0 warnings)
pnpm typecheck  ok (library; docs app has separate unrelated issue)
pnpm test       ok — 25 files, 553 tests
pnpm build      ok
```

https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4

---
_Generated by [Claude Code](https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4)_