### PR TITLE
chore: open-source readiness batch 3 — #58 #60 #62 #65 #67 #71 #85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,3 @@ jobs:
         run: pnpm test
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
-
-      - name: Build
-        run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build library
+        run: pnpm build
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+        env:
+          NODE_OPTIONS: '--max-old-space-size=6144'
+
       - name: Create Release PR or Publish
         uses: changesets/action@v1
         with:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to making participation in this project a welcoming
+experience for everyone, regardless of background or identity.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+- Trolling, insulting or derogatory comments, and personal attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported by opening an issue
+or contacting the maintainers via
+[GitHub Discussions](https://github.com/jonmatum/next-shell/discussions).
+
+All complaints will be reviewed and investigated and will result in a
+response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/apps/docs/content/docs/design-system/index.mdx
+++ b/apps/docs/content/docs/design-system/index.mdx
@@ -82,3 +82,31 @@ const brand: BrandOverrides = {
 ```
 
 Overrides are applied as inline CSS custom properties — zero JS re-render on theme switch.
+
+## CSS-only brand override (no JS)
+
+If you prefer plain CSS (or don't use `ThemeProvider`), override tokens directly after the preset import:
+
+```css
+/* app/globals.css */
+@import 'tailwindcss';
+@import '@jonmatum/next-shell/styles/preset.css';
+
+/* Brand overrides — applied after the preset so they win by cascade */
+:root {
+  --primary: oklch(0.65 0.2 145);
+  --primary-foreground: oklch(0.98 0 0);
+  --accent: oklch(0.75 0.12 145);
+  --accent-foreground: oklch(0.25 0 0);
+  --radius: 0.75rem;
+}
+
+[data-theme='dark'] {
+  --primary: oklch(0.75 0.18 145);
+  --primary-foreground: oklch(0.15 0 0);
+  --accent: oklch(0.35 0.1 145);
+  --accent-foreground: oklch(0.95 0 0);
+}
+```
+
+This works for any consumer — React, Vue, plain HTML. No JavaScript needed.

--- a/apps/docs/content/docs/layout/index.mdx
+++ b/apps/docs/content/docs/layout/index.mdx
@@ -170,6 +170,178 @@ export default function Page() {
 }
 ```
 
+---
+
+## API Reference
+
+### AppShell
+
+| Prop                  | Type           | Default | Description                                                                                                            |
+| --------------------- | -------------- | ------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `children`            | `ReactNode`    | —       | Page content rendered inside the main scrollable area between `topBar` and `footer`.                                   |
+| `sidebar`             | `ReactNode`    | —       | Sidebar nav tree. When omitted the sidebar rail and provider are not rendered and the content stretches to full width. |
+| `topBar`              | `ReactNode`    | —       | Top bar element (e.g. `<TopBar />`). Rendered as a sticky header inside `SidebarInset`.                                |
+| `footer`              | `ReactNode`    | —       | Footer element rendered below the content area inside `SidebarInset`.                                                  |
+| `commandBar`          | `boolean`      | `false` | Mount a `CommandBarProvider` wrapping the whole shell so descendants can call `useCommandBarActions`.                  |
+| `initialSidebarState` | `SidebarState` | —       | Initial sidebar open/closed state read from the SSR cookie so the server render matches the first client paint.        |
+| `className`           | `string`       | —       | Additional CSS class names.                                                                                            |
+
+### SidebarProvider
+
+| Prop           | Type                      | Default | Description                               |
+| -------------- | ------------------------- | ------- | ----------------------------------------- |
+| `defaultOpen`  | `boolean`                 | `true`  | Initial open state for uncontrolled mode. |
+| `open`         | `boolean`                 | —       | Controlled open state.                    |
+| `onOpenChange` | `(open: boolean) => void` | —       | Callback when the open state changes.     |
+| `className`    | `string`                  | —       | Additional CSS class names.               |
+| `style`        | `CSSProperties`           | —       | Inline styles.                            |
+| `children`     | `ReactNode`               | —       | Child elements.                           |
+
+### Sidebar
+
+| Prop          | Type                                 | Default       | Description                                                                                                       |
+| ------------- | ------------------------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `side`        | `'left' \| 'right'`                  | `'left'`      | Which side of the viewport the sidebar renders on.                                                                |
+| `variant`     | `'sidebar' \| 'floating' \| 'inset'` | `'sidebar'`   | Visual style variant. `sidebar` is a standard rail, `floating` adds shadow, `inset` sits within the content area. |
+| `collapsible` | `'offcanvas' \| 'icon' \| 'none'`    | `'offcanvas'` | Collapse behavior. `offcanvas` slides off-screen, `icon` collapses to icon-only rail, `none` disables collapsing. |
+| `className`   | `string`                             | —             | Additional CSS class names.                                                                                       |
+| `children`    | `ReactNode`                          | —             | Sidebar content (e.g. `SidebarHeader`, `SidebarContent`, `SidebarFooter`).                                        |
+
+### TopBar
+
+| Prop        | Type        | Default | Description                                                                                       |
+| ----------- | ----------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `left`      | `ReactNode` | —       | Left-anchored slot — typically the brand and breadcrumb.                                          |
+| `center`    | `ReactNode` | —       | Center slot — typically a search input or `CommandBarTrigger`. Stretches to fill available space. |
+| `right`     | `ReactNode` | —       | Right-anchored slot — typically the theme toggle, user menu, notifications, etc.                  |
+| `sticky`    | `boolean`   | `true`  | Sticky positioning at the top of the viewport. Set `false` to control positioning externally.     |
+| `className` | `string`    | —       | Additional CSS class names.                                                                       |
+
+### PageHeader
+
+| Prop          | Type                   | Default        | Description                                                                         |
+| ------------- | ---------------------- | -------------- | ----------------------------------------------------------------------------------- |
+| `title`       | `ReactNode`            | **(required)** | Page title rendered as a heading element.                                           |
+| `description` | `ReactNode`            | —              | Optional short description rendered under the title.                                |
+| `breadcrumb`  | `ReactNode`            | —              | Breadcrumb / eyebrow slot rendered above the title.                                 |
+| `actions`     | `ReactNode`            | —              | Action slot rendered to the right of the title on desktop, stacked below on mobile. |
+| `headingAs`   | `'h1' \| 'h2' \| 'h3'` | `'h1'`         | Heading level used for the title.                                                   |
+| `className`   | `string`               | —              | Additional CSS class names.                                                         |
+
+### Footer
+
+| Prop        | Type        | Default | Description                 |
+| ----------- | ----------- | ------- | --------------------------- |
+| `children`  | `ReactNode` | —       | Footer content.             |
+| `className` | `string`    | —       | Additional CSS class names. |
+
+Extends all native `<footer>` HTML attributes.
+
+### ContentContainer
+
+| Prop        | Type                                        | Default | Description                                                                                                |
+| ----------- | ------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `size`      | `'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'`    | `'lg'`  | Max-width tier. `sm` = `max-w-3xl`, `md` = `max-w-5xl`, `lg` = `max-w-7xl`, `xl` = `96rem`, `full` = none. |
+| `as`        | `'div' \| 'section' \| 'main' \| 'article'` | `'div'` | HTML element to render. Use `as="main"` for the primary page landmark.                                     |
+| `className` | `string`                                    | —       | Additional CSS class names.                                                                                |
+| `children`  | `ReactNode`                                 | —       | Page body content.                                                                                         |
+
+### CommandBarProvider
+
+| Prop           | Type                      | Default | Description                                                                                      |
+| -------------- | ------------------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `children`     | `ReactNode`               | —       | App subtree that can register and trigger command-bar actions.                                   |
+| `open`         | `boolean`                 | —       | Controlled open state. Uncontrolled when omitted.                                                |
+| `onOpenChange` | `(open: boolean) => void` | —       | Callback when the open state changes.                                                            |
+| `shortcut`     | `string \| null`          | `'k'`   | Keyboard shortcut that toggles the bar (fires on `Cmd+key` / `Ctrl+key`). Set `null` to disable. |
+
+### CommandBar
+
+| Prop          | Type        | Default                               | Description                                      |
+| ------------- | ----------- | ------------------------------------- | ------------------------------------------------ |
+| `title`       | `string`    | `'Command palette'`                   | Label announced to screen readers on the dialog. |
+| `description` | `string`    | `'Search for an action or navigate.'` | Description for screen readers.                  |
+| `placeholder` | `string`    | `'Type a command or search…'`         | Placeholder for the search input.                |
+| `emptyState`  | `ReactNode` | `'No matching actions.'`              | Content rendered when there are zero matches.    |
+
+### CommandBarTrigger
+
+| Prop        | Type            | Default     | Description                                         |
+| ----------- | --------------- | ----------- | --------------------------------------------------- |
+| `label`     | `string`        | `'Search…'` | Display label rendered alongside the search icon.   |
+| `shortcut`  | `string`        | `'⌘K'`      | Shortcut hint text displayed in the button.         |
+| `variant`   | `ButtonVariant` | `'outline'` | Button variant passed to the underlying `<Button>`. |
+| `className` | `string`        | —           | Additional CSS class names.                         |
+
+### SidebarNav
+
+| Prop         | Type                              | Default        | Description                                                                                       |
+| ------------ | --------------------------------- | -------------- | ------------------------------------------------------------------------------------------------- |
+| `items`      | `ReadonlyArray<ResolvedNavItem>`  | **(required)** | Resolved nav items from `buildNav()`. The component handles nested collapsible groups.            |
+| `label`      | `string`                          | —              | Label rendered as a `SidebarGroupLabel` above the menu. Omit for an unlabelled group.             |
+| `onNavigate` | `(item: ResolvedNavItem) => void` | —              | Override the default anchor-tag navigation. Useful with client-side routers (e.g. `router.push`). |
+| `className`  | `string`                          | —              | Additional CSS class names.                                                                       |
+
+### Breadcrumbs
+
+| Prop          | Type                                                        | Default        | Description                                                                                  |
+| ------------- | ----------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------- |
+| `config`      | `NavConfig`                                                 | **(required)** | Nav config to derive the breadcrumb trail from. Pass the same config used by `<SidebarNav>`. |
+| `pathname`    | `string`                                                    | **(required)** | Current pathname. Must match the format used in `NavItem.href` values.                       |
+| `permissions` | `ReadonlyArray<string>`                                     | `[]`           | Permission keys the current user holds — must match what was passed to `buildNav`.           |
+| `renderLink`  | `(item: ResolvedNavItem, children: ReactNode) => ReactNode` | —              | Custom link renderer for each ancestor item (e.g. Next.js `<Link>`).                         |
+
+### ErrorPage
+
+| Prop          | Type        | Default        | Description                                          |
+| ------------- | ----------- | -------------- | ---------------------------------------------------- |
+| `statusCode`  | `number`    | **(required)** | HTTP status code displayed prominently.              |
+| `title`       | `string`    | **(required)** | Short subtitle below the status code.                |
+| `description` | `string`    | —              | Explanatory text below the title.                    |
+| `icon`        | `ReactNode` | —              | Icon rendered above the status code.                 |
+| `action`      | `ReactNode` | —              | Action slot (e.g. "Go home" button or button group). |
+| `className`   | `string`    | —              | Additional CSS class names.                          |
+| `children`    | `ReactNode` | —              | Additional content rendered inside the card.         |
+
+Pre-configured variants (`BadRequest`, `Unauthorized`, `Forbidden`, `NotFound`, `InternalServerError`, `ServiceUnavailable`) accept the same props minus `statusCode` (preset) and with `title` optional (has a sensible default per status code).
+
+### EmptyState
+
+| Prop          | Type        | Default     | Description                                         |
+| ------------- | ----------- | ----------- | --------------------------------------------------- |
+| `icon`        | `ReactNode` | `<Inbox />` | Leading icon.                                       |
+| `title`       | `ReactNode` | —           | Headline text.                                      |
+| `description` | `ReactNode` | —           | Supporting description text.                        |
+| `action`      | `ReactNode` | —           | Action slot (e.g. a button to create a first item). |
+| `className`   | `string`    | —           | Additional CSS class names.                         |
+| `children`    | `ReactNode` | —           | Additional content.                                 |
+
+### ErrorState
+
+| Prop            | Type        | Default             | Description                                   |
+| --------------- | ----------- | ------------------- | --------------------------------------------- |
+| `icon`          | `ReactNode` | `<AlertTriangle />` | Leading icon (tinted destructive by default). |
+| `title`         | `ReactNode` | —                   | Headline text.                                |
+| `description`   | `ReactNode` | —                   | Supporting description text.                  |
+| `action`        | `ReactNode` | —                   | Action slot (e.g. a retry button).            |
+| `iconClassName` | `string`    | —                   | Additional class names for the icon wrapper.  |
+| `className`     | `string`    | —                   | Additional CSS class names.                   |
+| `children`      | `ReactNode` | —                   | Additional content.                           |
+
+### LoadingState
+
+| Prop            | Type        | Default                          | Description                                  |
+| --------------- | ----------- | -------------------------------- | -------------------------------------------- |
+| `icon`          | `ReactNode` | `<Loader2 />` (animated spinner) | Leading icon.                                |
+| `title`         | `ReactNode` | —                                | Headline text.                               |
+| `description`   | `ReactNode` | —                                | Supporting description text.                 |
+| `action`        | `ReactNode` | —                                | Action slot.                                 |
+| `iconClassName` | `string`    | —                                | Additional class names for the icon wrapper. |
+| `className`     | `string`    | —                                | Additional CSS class names.                  |
+| `children`      | `ReactNode` | —                                | Additional content.                          |
+
+---
+
 ## SSR sidebar state
 
 Eliminate layout shift by reading the sidebar cookie in a Server Component:

--- a/apps/docs/content/docs/providers/index.mdx
+++ b/apps/docs/content/docs/providers/index.mdx
@@ -148,21 +148,58 @@ function MyComponent() {
 }
 ```
 
-## SSR cookie helpers
+## ThemeToggle
 
-Read the theme before React renders to eliminate the light-flash:
+A cycle button that rotates through light, dark, and system themes on click. Renders a sun/moon icon reflecting the current theme.
 
 ```tsx
-// app/layout.tsx (Server Component)
-import { cookies } from 'next/headers';
-import { getThemeFromCookies } from '@jonmatum/next-shell/providers/server';
+'use client';
 
-export default async function RootLayout({ children }) {
-  const theme = getThemeFromCookies(await cookies()) ?? 'system';
+import { ThemeToggle } from '@jonmatum/next-shell/providers';
+
+export function Header() {
   return (
-    <html lang="en" data-theme={theme} suppressHydrationWarning>
-      <body>{children}</body>
-    </html>
+    <header>
+      <h1>My App</h1>
+      <ThemeToggle />
+    </header>
   );
 }
 ```
+
+## ThemeToggleDropdown
+
+A dropdown menu variant that lets users pick a specific theme from a list.
+
+```tsx
+'use client';
+
+import { ThemeToggleDropdown } from '@jonmatum/next-shell/providers';
+
+export function Settings() {
+  return (
+    <div>
+      <span>Theme:</span>
+      <ThemeToggleDropdown />
+    </div>
+  );
+}
+```
+
+## SSR cookie helpers
+
+For flash-free server rendering, use the cookie helpers from the server-safe subpath:
+
+```tsx
+// Route handler or middleware
+import { getThemeFromCookies, buildThemeCookieHeader } from '@jonmatum/next-shell/providers/server';
+
+// Read the theme from incoming cookies
+const theme = getThemeFromCookies(cookies());
+
+// Set the theme cookie in a response
+const header = buildThemeCookieHeader('dark');
+response.headers.set('Set-Cookie', header);
+```
+
+The cookie persists across sessions with a 1-year max-age and `samesite=lax`.

--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -24,6 +24,9 @@
   "bugs": {
     "url": "https://github.com/jonmatum/next-shell/issues"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "type": "module",
   "sideEffects": [
     "**/*.css"
@@ -118,6 +121,11 @@
     },
     "./styles/tokens.css": "./dist/styles/tokens.css",
     "./styles/preset.css": "./dist/styles/preset.css",
+    "./styles/presets/neutral.css": "./src/styles/presets/neutral.css",
+    "./styles/presets/green.css": "./src/styles/presets/green.css",
+    "./styles/presets/orange.css": "./src/styles/presets/orange.css",
+    "./styles/presets/red.css": "./src/styles/presets/red.css",
+    "./styles/presets/violet.css": "./src/styles/presets/violet.css",
     "./fonts/BigBlueTerminal.woff2": "./dist/fonts/BigBlueTerminal.woff2",
     "./tailwind-preset": {
       "source": "./src/tailwind-preset/index.ts",
@@ -128,6 +136,7 @@
   },
   "files": [
     "dist",
+    "src/styles/presets",
     "README.md",
     "LICENSE"
   ],
@@ -194,7 +203,8 @@
     "tsup": "^8.3.5",
     "typescript": "^5.6.3",
     "vite": "^6.4.2",
-    "vitest": "^4.0.0"
+    "vitest": "^4.0.0",
+    "vitest-axe": "^0.1.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/next-shell/src/styles/presets/green.css
+++ b/packages/next-shell/src/styles/presets/green.css
@@ -1,0 +1,50 @@
+/*!
+ * @jonmatum/next-shell — green color palette preset
+ *
+ * An emerald/green palette centered on hue 155. Import after the base preset:
+ *
+ *   @import "@jonmatum/next-shell/styles/preset.css";
+ *   @import "@jonmatum/next-shell/styles/presets/green.css";
+ *
+ * Overrides: --primary, --primary-foreground, --accent, --accent-foreground,
+ * --destructive, --destructive-foreground, --ring, --chart-1…5.
+ */
+
+:root,
+[data-theme='light'] {
+  --primary: oklch(0.55 0.17 155);
+  --primary-foreground: oklch(0.985 0 0);
+
+  --accent: oklch(0.95 0.025 155);
+  --accent-foreground: oklch(0.25 0.04 155);
+
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --ring: oklch(0.55 0.17 155);
+
+  --chart-1: oklch(0.55 0.17 155);
+  --chart-2: oklch(0.65 0.14 170);
+  --chart-3: oklch(0.45 0.12 140);
+  --chart-4: oklch(0.72 0.15 162);
+  --chart-5: oklch(0.58 0.13 185);
+}
+
+[data-theme='dark'] {
+  --primary: oklch(0.65 0.18 155);
+  --primary-foreground: oklch(0.985 0 0);
+
+  --accent: oklch(0.2 0.03 155);
+  --accent-foreground: oklch(0.92 0.02 155);
+
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --ring: oklch(0.65 0.18 155);
+
+  --chart-1: oklch(0.65 0.18 155);
+  --chart-2: oklch(0.72 0.14 170);
+  --chart-3: oklch(0.55 0.12 140);
+  --chart-4: oklch(0.8 0.13 162);
+  --chart-5: oklch(0.68 0.13 185);
+}

--- a/packages/next-shell/src/styles/presets/neutral.css
+++ b/packages/next-shell/src/styles/presets/neutral.css
@@ -1,0 +1,50 @@
+/*!
+ * @jonmatum/next-shell — neutral color palette preset
+ *
+ * A gray/slate palette with minimal chroma. Import after the base preset:
+ *
+ *   @import "@jonmatum/next-shell/styles/preset.css";
+ *   @import "@jonmatum/next-shell/styles/presets/neutral.css";
+ *
+ * Overrides: --primary, --primary-foreground, --accent, --accent-foreground,
+ * --destructive, --destructive-foreground, --ring, --chart-1…5.
+ */
+
+:root,
+[data-theme='light'] {
+  --primary: oklch(0.35 0.005 265);
+  --primary-foreground: oklch(0.985 0 0);
+
+  --accent: oklch(0.94 0.003 265);
+  --accent-foreground: oklch(0.25 0.005 265);
+
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --ring: oklch(0.35 0.005 265);
+
+  --chart-1: oklch(0.55 0.01 265);
+  --chart-2: oklch(0.65 0.01 265);
+  --chart-3: oklch(0.45 0.01 265);
+  --chart-4: oklch(0.75 0.01 265);
+  --chart-5: oklch(0.35 0.01 265);
+}
+
+[data-theme='dark'] {
+  --primary: oklch(0.75 0.005 265);
+  --primary-foreground: oklch(0.13 0.005 265);
+
+  --accent: oklch(0.22 0.005 265);
+  --accent-foreground: oklch(0.92 0.003 265);
+
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --ring: oklch(0.75 0.005 265);
+
+  --chart-1: oklch(0.75 0.01 265);
+  --chart-2: oklch(0.65 0.01 265);
+  --chart-3: oklch(0.55 0.01 265);
+  --chart-4: oklch(0.85 0.01 265);
+  --chart-5: oklch(0.45 0.01 265);
+}

--- a/packages/next-shell/src/styles/presets/orange.css
+++ b/packages/next-shell/src/styles/presets/orange.css
@@ -1,0 +1,50 @@
+/*!
+ * @jonmatum/next-shell — orange color palette preset
+ *
+ * An amber/orange palette centered on hue 65. Import after the base preset:
+ *
+ *   @import "@jonmatum/next-shell/styles/preset.css";
+ *   @import "@jonmatum/next-shell/styles/presets/orange.css";
+ *
+ * Overrides: --primary, --primary-foreground, --accent, --accent-foreground,
+ * --destructive, --destructive-foreground, --ring, --chart-1…5.
+ */
+
+:root,
+[data-theme='light'] {
+  --primary: oklch(0.65 0.18 55);
+  --primary-foreground: oklch(0.985 0 0);
+
+  --accent: oklch(0.95 0.025 65);
+  --accent-foreground: oklch(0.3 0.06 55);
+
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --ring: oklch(0.65 0.18 55);
+
+  --chart-1: oklch(0.65 0.18 55);
+  --chart-2: oklch(0.72 0.15 75);
+  --chart-3: oklch(0.55 0.16 40);
+  --chart-4: oklch(0.78 0.14 85);
+  --chart-5: oklch(0.6 0.13 30);
+}
+
+[data-theme='dark'] {
+  --primary: oklch(0.72 0.17 55);
+  --primary-foreground: oklch(0.16 0.025 55);
+
+  --accent: oklch(0.22 0.03 55);
+  --accent-foreground: oklch(0.92 0.02 65);
+
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --ring: oklch(0.72 0.17 55);
+
+  --chart-1: oklch(0.72 0.17 55);
+  --chart-2: oklch(0.78 0.14 75);
+  --chart-3: oklch(0.62 0.15 40);
+  --chart-4: oklch(0.83 0.12 85);
+  --chart-5: oklch(0.68 0.13 30);
+}

--- a/packages/next-shell/src/styles/presets/red.css
+++ b/packages/next-shell/src/styles/presets/red.css
@@ -1,0 +1,50 @@
+/*!
+ * @jonmatum/next-shell — red color palette preset
+ *
+ * A rose/red palette centered on hue 15. Import after the base preset:
+ *
+ *   @import "@jonmatum/next-shell/styles/preset.css";
+ *   @import "@jonmatum/next-shell/styles/presets/red.css";
+ *
+ * Overrides: --primary, --primary-foreground, --accent, --accent-foreground,
+ * --destructive, --destructive-foreground, --ring, --chart-1…5.
+ */
+
+:root,
+[data-theme='light'] {
+  --primary: oklch(0.55 0.22 15);
+  --primary-foreground: oklch(0.985 0 0);
+
+  --accent: oklch(0.95 0.02 15);
+  --accent-foreground: oklch(0.3 0.06 15);
+
+  --destructive: oklch(0.45 0.25 30);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --ring: oklch(0.55 0.22 15);
+
+  --chart-1: oklch(0.55 0.22 15);
+  --chart-2: oklch(0.65 0.17 355);
+  --chart-3: oklch(0.5 0.18 30);
+  --chart-4: oklch(0.7 0.15 340);
+  --chart-5: oklch(0.6 0.14 45);
+}
+
+[data-theme='dark'] {
+  --primary: oklch(0.65 0.21 15);
+  --primary-foreground: oklch(0.985 0 0);
+
+  --accent: oklch(0.2 0.035 15);
+  --accent-foreground: oklch(0.92 0.02 15);
+
+  --destructive: oklch(0.55 0.23 30);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --ring: oklch(0.65 0.21 15);
+
+  --chart-1: oklch(0.65 0.21 15);
+  --chart-2: oklch(0.72 0.16 355);
+  --chart-3: oklch(0.58 0.17 30);
+  --chart-4: oklch(0.78 0.13 340);
+  --chart-5: oklch(0.68 0.13 45);
+}

--- a/packages/next-shell/src/styles/presets/violet.css
+++ b/packages/next-shell/src/styles/presets/violet.css
@@ -1,0 +1,50 @@
+/*!
+ * @jonmatum/next-shell — violet color palette preset
+ *
+ * A purple/violet palette centered on hue 295. Import after the base preset:
+ *
+ *   @import "@jonmatum/next-shell/styles/preset.css";
+ *   @import "@jonmatum/next-shell/styles/presets/violet.css";
+ *
+ * Overrides: --primary, --primary-foreground, --accent, --accent-foreground,
+ * --destructive, --destructive-foreground, --ring, --chart-1…5.
+ */
+
+:root,
+[data-theme='light'] {
+  --primary: oklch(0.5 0.2 295);
+  --primary-foreground: oklch(0.985 0 0);
+
+  --accent: oklch(0.95 0.02 295);
+  --accent-foreground: oklch(0.25 0.05 295);
+
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --ring: oklch(0.5 0.2 295);
+
+  --chart-1: oklch(0.5 0.2 295);
+  --chart-2: oklch(0.6 0.17 275);
+  --chart-3: oklch(0.45 0.16 315);
+  --chart-4: oklch(0.68 0.15 260);
+  --chart-5: oklch(0.55 0.14 330);
+}
+
+[data-theme='dark'] {
+  --primary: oklch(0.65 0.2 295);
+  --primary-foreground: oklch(0.985 0 0);
+
+  --accent: oklch(0.2 0.035 295);
+  --accent-foreground: oklch(0.92 0.02 295);
+
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  --ring: oklch(0.65 0.2 295);
+
+  --chart-1: oklch(0.65 0.2 295);
+  --chart-2: oklch(0.72 0.16 275);
+  --chart-3: oklch(0.55 0.15 315);
+  --chart-4: oklch(0.78 0.14 260);
+  --chart-5: oklch(0.62 0.13 330);
+}

--- a/packages/next-shell/src/tokens/index.ts
+++ b/packages/next-shell/src/tokens/index.ts
@@ -252,3 +252,13 @@ export function cssVar(
 }
 
 export { hexToOklch } from './hex-to-oklch.js';
+
+export {
+  neutralPreset,
+  greenPreset,
+  orangePreset,
+  redPreset,
+  violetPreset,
+  presetPalettes,
+  type PresetPaletteName,
+} from './presets.js';

--- a/packages/next-shell/src/tokens/presets.ts
+++ b/packages/next-shell/src/tokens/presets.ts
@@ -1,0 +1,205 @@
+/**
+ * @jonmatum/next-shell — preset color palettes as BrandOverrides objects
+ *
+ * Each palette provides complete light + dark OKLCH token overrides for
+ * primary, accent, destructive, ring, and chart colors. These are the
+ * TypeScript counterparts of the CSS files in `src/styles/presets/`.
+ *
+ * Usage:
+ * ```ts
+ * import { greenPreset } from '@jonmatum/next-shell/tokens';
+ * import { brandOverridesCss } from '@jonmatum/next-shell/tokens';
+ *
+ * const css = brandOverridesCss(greenPreset);
+ * ```
+ */
+
+import type { BrandOverrides } from './index.js';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Neutral — gray/slate tones with minimal chroma
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export const neutralPreset: BrandOverrides = {
+  light: {
+    primary: 'oklch(0.35 0.005 265)',
+    'primary-foreground': 'oklch(0.985 0 0)',
+    accent: 'oklch(0.94 0.003 265)',
+    'accent-foreground': 'oklch(0.25 0.005 265)',
+    destructive: 'oklch(0.577 0.245 27.325)',
+    'destructive-foreground': 'oklch(0.985 0 0)',
+    ring: 'oklch(0.35 0.005 265)',
+    'chart-1': 'oklch(0.55 0.01 265)',
+    'chart-2': 'oklch(0.65 0.01 265)',
+    'chart-3': 'oklch(0.45 0.01 265)',
+    'chart-4': 'oklch(0.75 0.01 265)',
+    'chart-5': 'oklch(0.35 0.01 265)',
+  },
+  dark: {
+    primary: 'oklch(0.75 0.005 265)',
+    'primary-foreground': 'oklch(0.13 0.005 265)',
+    accent: 'oklch(0.22 0.005 265)',
+    'accent-foreground': 'oklch(0.92 0.003 265)',
+    destructive: 'oklch(0.704 0.191 22.216)',
+    'destructive-foreground': 'oklch(0.985 0 0)',
+    ring: 'oklch(0.75 0.005 265)',
+    'chart-1': 'oklch(0.75 0.01 265)',
+    'chart-2': 'oklch(0.65 0.01 265)',
+    'chart-3': 'oklch(0.55 0.01 265)',
+    'chart-4': 'oklch(0.85 0.01 265)',
+    'chart-5': 'oklch(0.45 0.01 265)',
+  },
+} as const;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Green — emerald/green tones centered on hue 155
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export const greenPreset: BrandOverrides = {
+  light: {
+    primary: 'oklch(0.55 0.17 155)',
+    'primary-foreground': 'oklch(0.985 0 0)',
+    accent: 'oklch(0.95 0.025 155)',
+    'accent-foreground': 'oklch(0.25 0.04 155)',
+    destructive: 'oklch(0.577 0.245 27.325)',
+    'destructive-foreground': 'oklch(0.985 0 0)',
+    ring: 'oklch(0.55 0.17 155)',
+    'chart-1': 'oklch(0.55 0.17 155)',
+    'chart-2': 'oklch(0.65 0.14 170)',
+    'chart-3': 'oklch(0.45 0.12 140)',
+    'chart-4': 'oklch(0.72 0.15 162)',
+    'chart-5': 'oklch(0.58 0.13 185)',
+  },
+  dark: {
+    primary: 'oklch(0.65 0.18 155)',
+    'primary-foreground': 'oklch(0.985 0 0)',
+    accent: 'oklch(0.2 0.03 155)',
+    'accent-foreground': 'oklch(0.92 0.02 155)',
+    destructive: 'oklch(0.704 0.191 22.216)',
+    'destructive-foreground': 'oklch(0.985 0 0)',
+    ring: 'oklch(0.65 0.18 155)',
+    'chart-1': 'oklch(0.65 0.18 155)',
+    'chart-2': 'oklch(0.72 0.14 170)',
+    'chart-3': 'oklch(0.55 0.12 140)',
+    'chart-4': 'oklch(0.8 0.13 162)',
+    'chart-5': 'oklch(0.68 0.13 185)',
+  },
+} as const;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Orange — amber/orange tones centered on hue 55
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export const orangePreset: BrandOverrides = {
+  light: {
+    primary: 'oklch(0.65 0.18 55)',
+    'primary-foreground': 'oklch(0.985 0 0)',
+    accent: 'oklch(0.95 0.025 65)',
+    'accent-foreground': 'oklch(0.3 0.06 55)',
+    destructive: 'oklch(0.577 0.245 27.325)',
+    'destructive-foreground': 'oklch(0.985 0 0)',
+    ring: 'oklch(0.65 0.18 55)',
+    'chart-1': 'oklch(0.65 0.18 55)',
+    'chart-2': 'oklch(0.72 0.15 75)',
+    'chart-3': 'oklch(0.55 0.16 40)',
+    'chart-4': 'oklch(0.78 0.14 85)',
+    'chart-5': 'oklch(0.6 0.13 30)',
+  },
+  dark: {
+    primary: 'oklch(0.72 0.17 55)',
+    'primary-foreground': 'oklch(0.16 0.025 55)',
+    accent: 'oklch(0.22 0.03 55)',
+    'accent-foreground': 'oklch(0.92 0.02 65)',
+    destructive: 'oklch(0.704 0.191 22.216)',
+    'destructive-foreground': 'oklch(0.985 0 0)',
+    ring: 'oklch(0.72 0.17 55)',
+    'chart-1': 'oklch(0.72 0.17 55)',
+    'chart-2': 'oklch(0.78 0.14 75)',
+    'chart-3': 'oklch(0.62 0.15 40)',
+    'chart-4': 'oklch(0.83 0.12 85)',
+    'chart-5': 'oklch(0.68 0.13 30)',
+  },
+} as const;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Red — rose/red tones centered on hue 15
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export const redPreset: BrandOverrides = {
+  light: {
+    primary: 'oklch(0.55 0.22 15)',
+    'primary-foreground': 'oklch(0.985 0 0)',
+    accent: 'oklch(0.95 0.02 15)',
+    'accent-foreground': 'oklch(0.3 0.06 15)',
+    destructive: 'oklch(0.45 0.25 30)',
+    'destructive-foreground': 'oklch(0.985 0 0)',
+    ring: 'oklch(0.55 0.22 15)',
+    'chart-1': 'oklch(0.55 0.22 15)',
+    'chart-2': 'oklch(0.65 0.17 355)',
+    'chart-3': 'oklch(0.5 0.18 30)',
+    'chart-4': 'oklch(0.7 0.15 340)',
+    'chart-5': 'oklch(0.6 0.14 45)',
+  },
+  dark: {
+    primary: 'oklch(0.65 0.21 15)',
+    'primary-foreground': 'oklch(0.985 0 0)',
+    accent: 'oklch(0.2 0.035 15)',
+    'accent-foreground': 'oklch(0.92 0.02 15)',
+    destructive: 'oklch(0.55 0.23 30)',
+    'destructive-foreground': 'oklch(0.985 0 0)',
+    ring: 'oklch(0.65 0.21 15)',
+    'chart-1': 'oklch(0.65 0.21 15)',
+    'chart-2': 'oklch(0.72 0.16 355)',
+    'chart-3': 'oklch(0.58 0.17 30)',
+    'chart-4': 'oklch(0.78 0.13 340)',
+    'chart-5': 'oklch(0.68 0.13 45)',
+  },
+} as const;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Violet — purple/violet tones centered on hue 295
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export const violetPreset: BrandOverrides = {
+  light: {
+    primary: 'oklch(0.5 0.2 295)',
+    'primary-foreground': 'oklch(0.985 0 0)',
+    accent: 'oklch(0.95 0.02 295)',
+    'accent-foreground': 'oklch(0.25 0.05 295)',
+    destructive: 'oklch(0.577 0.245 27.325)',
+    'destructive-foreground': 'oklch(0.985 0 0)',
+    ring: 'oklch(0.5 0.2 295)',
+    'chart-1': 'oklch(0.5 0.2 295)',
+    'chart-2': 'oklch(0.6 0.17 275)',
+    'chart-3': 'oklch(0.45 0.16 315)',
+    'chart-4': 'oklch(0.68 0.15 260)',
+    'chart-5': 'oklch(0.55 0.14 330)',
+  },
+  dark: {
+    primary: 'oklch(0.65 0.2 295)',
+    'primary-foreground': 'oklch(0.985 0 0)',
+    accent: 'oklch(0.2 0.035 295)',
+    'accent-foreground': 'oklch(0.92 0.02 295)',
+    destructive: 'oklch(0.704 0.191 22.216)',
+    'destructive-foreground': 'oklch(0.985 0 0)',
+    ring: 'oklch(0.65 0.2 295)',
+    'chart-1': 'oklch(0.65 0.2 295)',
+    'chart-2': 'oklch(0.72 0.16 275)',
+    'chart-3': 'oklch(0.55 0.15 315)',
+    'chart-4': 'oklch(0.78 0.14 260)',
+    'chart-5': 'oklch(0.62 0.13 330)',
+  },
+} as const;
+
+/**
+ * All preset palettes keyed by name. Useful for dynamic palette selection.
+ */
+export const presetPalettes = {
+  neutral: neutralPreset,
+  green: greenPreset,
+  orange: orangePreset,
+  red: redPreset,
+  violet: violetPreset,
+} as const;
+
+export type PresetPaletteName = keyof typeof presetPalettes;

--- a/packages/next-shell/tests/a11y.test.tsx
+++ b/packages/next-shell/tests/a11y.test.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import { describe, expect, it } from 'vitest';
+
+declare module 'vitest' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface Assertion<T> {
+    toHaveNoViolations(): void;
+  }
+}
+
+import { AppShell } from '../src/layout/app-shell.js';
+import { TopBar } from '../src/layout/topbar.js';
+import { PageHeader } from '../src/layout/page-header.js';
+import { Footer } from '../src/layout/footer.js';
+import { EmptyState, ErrorState, LoadingState } from '../src/layout/status-states.js';
+
+describe('Accessibility — axe-core automated checks', () => {
+  it('AppShell (no sidebar) has no a11y violations', async () => {
+    const { container } = render(
+      <AppShell topBar={<TopBar left={<span>Brand</span>} />} footer={<Footer>© 2026</Footer>}>
+        <h1>Dashboard</h1>
+        <p>Welcome to the app.</p>
+      </AppShell>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('TopBar has no a11y violations', async () => {
+    const { container } = render(
+      <TopBar
+        left={<span>Brand</span>}
+        center={<input aria-label="Search" placeholder="Search..." />}
+        right={<button type="button">Menu</button>}
+      />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('PageHeader has no a11y violations', async () => {
+    const { container } = render(
+      <PageHeader
+        title="Settings"
+        description="Manage your account preferences."
+        actions={<button type="button">Save</button>}
+      />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('PageHeader with custom heading level has no a11y violations', async () => {
+    const { container } = render(<PageHeader title="Sub-section" headingAs="h2" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('EmptyState has no a11y violations', async () => {
+    const { container } = render(
+      <EmptyState
+        title="No items yet"
+        description="Create your first item to get started."
+        action={<button type="button">Create</button>}
+      />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('ErrorState has no a11y violations', async () => {
+    const { container } = render(
+      <ErrorState
+        title="Something went wrong"
+        description="We could not load your data. Please try again."
+        action={<button type="button">Retry</button>}
+      />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('LoadingState has no a11y violations', async () => {
+    const { container } = render(
+      <LoadingState title="Loading..." description="Please wait while we fetch your data." />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Footer has no a11y violations', async () => {
+    const { container } = render(
+      <Footer>
+        <span>© 2026 Acme Inc.</span>
+        <nav aria-label="Footer navigation">
+          <a href="/privacy">Privacy</a>
+          <a href="/terms">Terms</a>
+        </nav>
+      </Footer>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/next-shell/tests/presets.test.ts
+++ b/packages/next-shell/tests/presets.test.ts
@@ -1,0 +1,178 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  greenPreset,
+  neutralPreset,
+  orangePreset,
+  presetPalettes,
+  redPreset,
+  violetPreset,
+} from '../src/tokens/index.js';
+import type { BrandOverrides } from '../src/tokens/index.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PRESETS_DIR = resolve(HERE, '../src/styles/presets');
+
+const PALETTE_NAMES = ['neutral', 'green', 'orange', 'red', 'violet'] as const;
+
+/** Tokens that every preset CSS file must override in both :root and dark blocks. */
+const EXPECTED_TOKENS = [
+  '--primary',
+  '--primary-foreground',
+  '--accent',
+  '--accent-foreground',
+  '--destructive',
+  '--destructive-foreground',
+  '--ring',
+  '--chart-1',
+  '--chart-2',
+  '--chart-3',
+  '--chart-4',
+  '--chart-5',
+];
+
+describe('preset CSS files — existence', () => {
+  for (const name of PALETTE_NAMES) {
+    it(`${name}.css exists`, () => {
+      const filePath = resolve(PRESETS_DIR, `${name}.css`);
+      expect(existsSync(filePath)).toBe(true);
+    });
+  }
+});
+
+describe('preset CSS files — token coverage', () => {
+  for (const name of PALETTE_NAMES) {
+    describe(name, () => {
+      const filePath = resolve(PRESETS_DIR, `${name}.css`);
+      const css = readFileSync(filePath, 'utf8');
+
+      // Extract the light block (:root / [data-theme='light'])
+      const lightMatch = css.match(/:root[\s\S]*?\{([\s\S]*?)\}/);
+      const lightBlock = lightMatch?.[1] ?? '';
+
+      // Extract the dark block ([data-theme='dark'])
+      const darkMatch = css.match(/\[data-theme='dark'\]\s*\{([\s\S]*?)\}/);
+      const darkBlock = darkMatch?.[1] ?? '';
+
+      it('has a light theme block with all expected tokens', () => {
+        const missing = EXPECTED_TOKENS.filter((t) => !lightBlock.includes(`${t}:`));
+        expect(missing).toEqual([]);
+      });
+
+      it('has a dark theme block with all expected tokens', () => {
+        const missing = EXPECTED_TOKENS.filter((t) => !darkBlock.includes(`${t}:`));
+        expect(missing).toEqual([]);
+      });
+
+      it('uses OKLCH values exclusively', () => {
+        // Every CSS custom-property declaration line should contain oklch(
+        const valueLines = css
+          .split('\n')
+          .filter((line) => {
+            const trimmed = line.trim();
+            // Skip comment lines (/* … */ and * … in multi-line comments)
+            if (trimmed.startsWith('/*') || trimmed.startsWith('*')) return false;
+            // Must be a custom-property declaration
+            return trimmed.startsWith('--') && trimmed.includes(':');
+          })
+          .map((line) => line.trim());
+
+        for (const line of valueLines) {
+          expect(line).toMatch(/oklch\(/);
+        }
+      });
+    });
+  }
+});
+
+describe('preset TS objects — structure', () => {
+  const presets: Record<string, BrandOverrides> = {
+    neutral: neutralPreset,
+    green: greenPreset,
+    orange: orangePreset,
+    red: redPreset,
+    violet: violetPreset,
+  };
+
+  for (const [name, preset] of Object.entries(presets)) {
+    describe(name, () => {
+      it('has light overrides', () => {
+        expect(preset.light).toBeDefined();
+      });
+
+      it('has dark overrides', () => {
+        expect(preset.dark).toBeDefined();
+      });
+
+      it('light overrides include primary, accent, and chart tokens', () => {
+        const keys = Object.keys(preset.light ?? {});
+        expect(keys).toContain('primary');
+        expect(keys).toContain('primary-foreground');
+        expect(keys).toContain('accent');
+        expect(keys).toContain('accent-foreground');
+        expect(keys).toContain('chart-1');
+        expect(keys).toContain('chart-2');
+        expect(keys).toContain('chart-3');
+        expect(keys).toContain('chart-4');
+        expect(keys).toContain('chart-5');
+      });
+
+      it('dark overrides include primary, accent, and chart tokens', () => {
+        const keys = Object.keys(preset.dark ?? {});
+        expect(keys).toContain('primary');
+        expect(keys).toContain('primary-foreground');
+        expect(keys).toContain('accent');
+        expect(keys).toContain('accent-foreground');
+        expect(keys).toContain('chart-1');
+        expect(keys).toContain('chart-2');
+        expect(keys).toContain('chart-3');
+        expect(keys).toContain('chart-4');
+        expect(keys).toContain('chart-5');
+      });
+
+      it('all values are OKLCH strings', () => {
+        const allValues = [
+          ...Object.values(preset.light ?? {}),
+          ...Object.values(preset.dark ?? {}),
+        ];
+        for (const value of allValues) {
+          expect(value).toMatch(/^oklch\(/);
+        }
+      });
+    });
+  }
+});
+
+describe('presetPalettes map', () => {
+  it('contains all 5 palettes', () => {
+    expect(Object.keys(presetPalettes).sort()).toEqual([...PALETTE_NAMES].sort());
+  });
+
+  it('each entry matches the named export', () => {
+    expect(presetPalettes.neutral).toBe(neutralPreset);
+    expect(presetPalettes.green).toBe(greenPreset);
+    expect(presetPalettes.orange).toBe(orangePreset);
+    expect(presetPalettes.red).toBe(redPreset);
+    expect(presetPalettes.violet).toBe(violetPreset);
+  });
+});
+
+describe('CSS ↔ TS parity', () => {
+  for (const name of PALETTE_NAMES) {
+    it(`${name} CSS and TS preset have matching light primary values`, () => {
+      const filePath = resolve(PRESETS_DIR, `${name}.css`);
+      const css = readFileSync(filePath, 'utf8');
+      const preset = presetPalettes[name];
+
+      // Extract the primary value from the light block in CSS
+      const lightMatch = css.match(/:root[\s\S]*?\{([\s\S]*?)\}/);
+      const lightBlock = lightMatch?.[1] ?? '';
+      const primaryMatch = lightBlock.match(/--primary:\s*([^;]+);/);
+      const cssPrimary = primaryMatch?.[1]?.trim();
+
+      expect(cssPrimary).toBe(preset.light?.primary);
+    });
+  }
+});

--- a/packages/next-shell/tests/setup.ts
+++ b/packages/next-shell/tests/setup.ts
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom/vitest';
-import { vi } from 'vitest';
+import { expect, vi } from 'vitest';
+import * as vitestAxeMatchers from 'vitest-axe/matchers';
+
+// Register vitest-axe matchers (toHaveNoViolations) globally.
+// The vitest-axe/extend-expect entry point is empty in 0.1.0 + Vitest 4,
+// so we extend manually.
+expect.extend(vitestAxeMatchers);
 
 // jsdom doesn't implement `matchMedia`, which next-themes uses to watch the
 // `prefers-color-scheme` media query. Provide a minimal stub that reports
@@ -38,6 +44,15 @@ if (typeof Element !== 'undefined' && typeof Element.prototype.scrollIntoView !=
   Element.prototype.scrollIntoView = function scrollIntoView(): void {
     /* no-op in jsdom */
   };
+}
+
+// jsdom doesn't implement `HTMLCanvasElement.prototype.getContext`, which
+// axe-core uses for icon-ligature detection in its color-contrast rule.
+// Stub to a no-op that returns null (no 2D context) to suppress the error.
+if (typeof HTMLCanvasElement !== 'undefined') {
+  HTMLCanvasElement.prototype.getContext = function getContext() {
+    return null;
+  } as typeof HTMLCanvasElement.prototype.getContext;
 }
 
 // jsdom doesn't implement `IntersectionObserver`, which embla-carousel

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       vitest:
         specifier: ^4.0.0
         version: 4.1.4(@types/node@22.19.17)(jsdom@25.0.1)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@4.1.4(@types/node@22.19.17)(jsdom@25.0.1)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))
 
   tools/eslint-plugin-next-shell:
     dependencies:
@@ -2187,6 +2190,10 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  axe-core@4.11.3:
+    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
+    engines: {node: '>=4'}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -3330,6 +3337,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -4635,6 +4645,11 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
 
   vitest@4.1.4:
     resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
@@ -6674,6 +6689,8 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  axe-core@4.11.3: {}
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
@@ -7989,6 +8006,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.merge@4.6.2: {}
 
@@ -9679,6 +9698,16 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       yaml: 2.8.3
+
+  vitest-axe@0.1.0(vitest@4.1.4(@types/node@22.19.17)(jsdom@25.0.1)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.11.3
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 4.1.4(@types/node@22.19.17)(jsdom@25.0.1)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
 
   vitest@4.1.4(@types/node@22.19.17)(jsdom@25.0.1)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
## Summary

7 more issues from epic #54. Closes #58, #60, #62, #65, #67, #71, #85.

## Changes

- **#58** CSS-only brand override example in design-system docs
- **#60** API reference prop tables for all 16 layout components
- **#62** ThemeToggle, ThemeToggleDropdown, SSR cookie helper docs
- **#65** 5 preset color palettes (neutral/green/orange/red/violet) as CSS + JS exports + 5 tests
- **#67** Remove duplicate CI build step, add release.yml verification gate, engines field
- **#71** CODE_OF_CONDUCT.md
- **#85** axe-core a11y tests (8 tests) for AppShell, TopBar, PageHeader, status states, Footer

## Verification

```
pnpm format     ok
pnpm lint       ok (0 warnings)
pnpm typecheck  ok (library)
pnpm test       ok — 27 files, 613 tests
pnpm build      ok
```

https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4

---
_Generated by [Claude Code](https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4)_