### PR TITLE
chore: open-source readiness batch 4 — #56 #61 #63 #68 #84 #86

### DIFF
--- a/.claude/skills/next-shell-contributor/SKILL.md
+++ b/.claude/skills/next-shell-contributor/SKILL.md
@@ -19,13 +19,13 @@ Each phase has its own tracking issue and its own branch:
 |     2 | ThemeProvider + useTheme + ThemeToggle      | `#3`                  |
 |     3 | shadcn primitives (Button, Dialog, etc.)    | `#4`                  |
 |     4 | Layout primitives + AppShell                | `#5`                  |
-|     5 | Auth primitives (useSession, guards)        | `#6`                  |
+|     5 | Navigation (buildNav, SidebarNav, etc.)     | `#6`                  |
 |     6 | Providers composer (Query, Toast, Errors)   | `#7`                  |
-|     7 | Hooks grab-bag (useDebounce, useMedia, …)   | `#8`                  |
-|     8 | Utilities (`cn`, formatters, guards)        | `#9`                  |
+|     7 | Auth adapter (useSession, guards)           | `#8`                  |
+|     8 | Hooks + formatters (useDebounce, etc.)      | `#9`                  |
 |     9 | Docs site + Storybook                       | `#10`                 |
 |    10 | Publishing + changeset release workflow     | `#11`                 |
-|    11 | Integration back into Smart Pad Rules       | `#12`                 |
+|    11 | Example consumer app                        | `#12`                 |
 
 Refer to [#13](https://github.com/jonmatum/next-shell/issues/13) for the authoritative breakdown — the numbers above may shift as issues are reorganized.
 
@@ -78,7 +78,7 @@ Pre-commit runs `lint-staged` via Husky, which formats staged files and runs ESL
 
 ## Token discipline (the one rule that is NEVER negotiable)
 
-**No raw color literals.** Every color reaches the DOM through the semantic-token CSS variables defined in `packages/next-shell/src/tokens/tokens.css`. The custom `no-raw-colors` ESLint rule in `tools/eslint-plugin-next-shell` enforces this; a regression here will fail CI immediately. If you need a brand-specific value, use the `brand` prop on `ThemeProvider` — don't hardcode it in a component.
+**No raw color literals.** Every color reaches the DOM through the semantic-token CSS variables defined in `packages/next-shell/src/styles/tokens.css`. The custom `no-raw-colors` ESLint rule in `tools/eslint-plugin-next-shell` enforces this; a regression here will fail CI immediately. If you need a brand-specific value, use the `brand` prop on `ThemeProvider` — don't hardcode it in a component.
 
 See the companion `shadcn-next-shell` skill for the full token catalog and the Tailwind utility ↔ token mapping.
 

--- a/.claude/skills/shadcn-next-shell/SKILL.md
+++ b/.claude/skills/shadcn-next-shell/SKILL.md
@@ -32,7 +32,7 @@ npx shadcn@latest add button dialog dropdown-menu   # etc.
 
 ### 1. Semantic tokens only — no raw colors
 
-Every primitive must style through the semantic token set defined in `src/tokens/tokens.css` and surfaced by `src/tokens/brand.ts`:
+Every primitive must style through the semantic token set defined in `src/styles/tokens.css` and surfaced by `src/tokens/index.ts`:
 
 | Intent                    | Use                                                    | Never                              |
 | ------------------------- | ------------------------------------------------------ | ---------------------------------- |
@@ -100,4 +100,4 @@ Never hard-code `duration-200` / `ease-in-out` when a semantic motion token exis
 
 - Read an existing primitive (once Phase 3 lands, `src/primitives/button/` is the canonical reference).
 - Consult the upstream shadcn docs via the MCP server; re-theme the generated output through the semantic tokens before committing.
-- If a new token is genuinely needed, add it in `src/tokens/brand.ts` + `src/tokens/tokens.css` *first*, update tests, then use it.
+- If a new token is genuinely needed, add it in `src/tokens/index.ts` + `src/styles/tokens.css` *first*, update tests, then use it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,6 @@ jobs:
         run: pnpm test
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
+
+      - name: Size check
+        run: pnpm --filter @jonmatum/next-shell size

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,8 @@ packages/next-shell/
 │   │   └── preset.css           # Tailwind v4 @theme mappings
 │   ├── tailwind-preset/
 │   ├── layout/                  # (Phase 4)
-│   ├── auth/                    # (Phase 5)
-│   └── hooks/                   # (Phase 7)
+│   ├── auth/                    # (Phase 7)
+│   └── hooks/                   # (Phase 8)
 ├── tsup.config.ts
 ├── vitest.config.ts
 └── package.json
@@ -152,7 +152,12 @@ Subpaths exported through `package.json#exports`:
 @jonmatum/next-shell/tailwind-preset
 @jonmatum/next-shell/styles/{tokens,preset}.css
 @jonmatum/next-shell/layout
+@jonmatum/next-shell/layout/server
+@jonmatum/next-shell/formatters
 @jonmatum/next-shell/auth
+@jonmatum/next-shell/auth/nextauth
+@jonmatum/next-shell/auth/mock
+@jonmatum/next-shell/auth/server
 @jonmatum/next-shell/hooks
 ```
 
@@ -229,10 +234,10 @@ here alongside the existing ones.
 - Phase 2 (theme) · [#3](https://github.com/jonmatum/next-shell/issues/3)
 - Phase 3 (shadcn primitives) · [#4](https://github.com/jonmatum/next-shell/issues/4)
 - Phase 4 (app shell) · [#5](https://github.com/jonmatum/next-shell/issues/5)
-- Phase 5 (auth) · [#6](https://github.com/jonmatum/next-shell/issues/6)
+- Phase 5 (navigation) · [#6](https://github.com/jonmatum/next-shell/issues/6)
 - Phase 6 (providers composer) · [#7](https://github.com/jonmatum/next-shell/issues/7)
-- Phase 7 (hooks) · [#8](https://github.com/jonmatum/next-shell/issues/8)
-- Phase 8 (utilities) · [#9](https://github.com/jonmatum/next-shell/issues/9)
+- Phase 7 (auth) · [#8](https://github.com/jonmatum/next-shell/issues/8)
+- Phase 8 (hooks + formatters) · [#9](https://github.com/jonmatum/next-shell/issues/9)
 - Phase 9 (docs + Storybook) · [#10](https://github.com/jonmatum/next-shell/issues/10)
 - Phase 10 (publishing) · [#11](https://github.com/jonmatum/next-shell/issues/11)
-- Phase 11 (integration back into Smart Pad Rules) · [#12](https://github.com/jonmatum/next-shell/issues/12)
+- Phase 11 (example consumer app) · [#12](https://github.com/jonmatum/next-shell/issues/12)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,24 @@ chore(ci): cache pnpm store
 - Include tests for behavior changes
 - Fill out the PR template
 
+## Breaking Changes
+
+Any change that falls into the categories below is considered a breaking change:
+
+- **Token renames or removals** — changes to `tokens.css`, `preset.css`, or the `colorTokens` array in `src/tokens/index.ts`
+- **Removed exports** — a named export dropped from any public subpath barrel
+- **Changed component props** — required prop added, prop type narrowed, prop renamed or removed
+- **CSS class / data-attribute changes** — `data-theme` attribute renamed, Tailwind utility class prefix changed
+- **Peer dependency bumps** — minimum React, Next.js, or Tailwind version increased
+- **Subpath removals** — a `package.json#exports` entry removed or path changed
+
+When introducing a breaking change:
+
+1. Add a new version section to [`packages/next-shell/MIGRATION.md`](./packages/next-shell/MIGRATION.md) following the template at the top of that file.
+2. Include before/after code snippets and step-by-step migration instructions.
+3. Mention the breaking change prominently in the PR description.
+4. Update the docs migration page at `apps/docs/content/docs/migration/index.mdx`.
+
 ## Releasing
 
 Releases are automated via Changesets (lands in Phase 10). Don't publish manually.

--- a/apps/docs/content/docs/design-system/index.mdx
+++ b/apps/docs/content/docs/design-system/index.mdx
@@ -51,6 +51,48 @@ The custom ESLint rule `next-shell/no-raw-colors` fails CI immediately on any re
 | `ease-decelerate` | `--ease-decelerate` | `cubic-bezier(0, 0, 0.2, 1)` |
 | `ease-accelerate` | `--ease-accelerate` | `cubic-bezier(0.3, 0, 1, 1)` |
 
+## Elevation / shadow tokens
+
+Shadows are tuned per theme — the dark theme uses higher opacity so shadows remain visible on dark surfaces.
+
+| Token          | Utility      | Light value                                                               |
+| -------------- | ------------ | ------------------------------------------------------------------------- |
+| `--shadow-xs`  | `shadow-xs`  | `0 1px 2px 0 oklch(0 0 0 / 0.05)`                                         |
+| `--shadow-sm`  | `shadow-sm`  | `0 1px 3px 0 oklch(0 0 0 / 0.1), 0 1px 2px -1px oklch(0 0 0 / 0.1)`       |
+| `--shadow-md`  | `shadow-md`  | `0 4px 6px -1px oklch(0 0 0 / 0.1), 0 2px 4px -2px oklch(0 0 0 / 0.1)`    |
+| `--shadow-lg`  | `shadow-lg`  | `0 10px 15px -3px oklch(0 0 0 / 0.1), 0 4px 6px -4px oklch(0 0 0 / 0.1)`  |
+| `--shadow-xl`  | `shadow-xl`  | `0 20px 25px -5px oklch(0 0 0 / 0.1), 0 8px 10px -6px oklch(0 0 0 / 0.1)` |
+| `--shadow-2xl` | `shadow-2xl` | `0 25px 50px -12px oklch(0 0 0 / 0.25)`                                   |
+
+Use shadow tokens for layered surfaces like cards, popovers, and dropdown menus:
+
+```tsx
+<div className="rounded-lg bg-card shadow-md">Elevated card</div>
+<div className="rounded-lg bg-popover shadow-xl">Popover panel</div>
+```
+
+## Density tokens
+
+Density tokens control component padding, gap, and row height. Override them on any container to switch between compact and comfortable density without touching individual components.
+
+| Token                  | Utility                         | Default value |
+| ---------------------- | ------------------------------- | ------------- |
+| `--density-pad-x`      | `px-[var(--density-pad-x)]`     | `1rem`        |
+| `--density-pad-y`      | `py-[var(--density-pad-y)]`     | `0.5rem`      |
+| `--density-gap`        | `gap-[var(--density-gap)]`      | `0.5rem`      |
+| `--density-row-height` | `h-[var(--density-row-height)]` | `2.5rem`      |
+
+Switch to a compact density by overriding all four tokens on a container:
+
+```css
+.compact {
+  --density-pad-x: 0.5rem;
+  --density-pad-y: 0.25rem;
+  --density-gap: 0.25rem;
+  --density-row-height: 2rem;
+}
+```
+
 ## Dark mode
 
 Tokens are scoped to `[data-theme="dark"]`. next-themes writes `data-theme` on the `<html>` element — add `suppressHydrationWarning` to avoid React hydration warnings:

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -8,6 +8,8 @@
     "auth",
     "hooks",
     "formatters",
-    "primitives"
+    "primitives",
+    "recipes",
+    "migration"
   ]
 }

--- a/apps/docs/content/docs/migration/index.mdx
+++ b/apps/docs/content/docs/migration/index.mdx
@@ -1,0 +1,64 @@
+---
+title: Migration Guide
+description: Upgrade instructions between versions of @jonmatum/next-shell.
+---
+
+This page documents how to upgrade between versions of `@jonmatum/next-shell`. For a detailed changelog with the full API surface of each release, see [`MIGRATION.md`](https://github.com/jonmatum/next-shell/blob/main/packages/next-shell/MIGRATION.md) in the package source.
+
+## v0.1.0 — Baseline
+
+v0.1.0 is the initial release. There are no prior versions to migrate from.
+
+This version establishes the following API surface that future upgrades are measured against:
+
+### Subpath exports
+
+```
+@jonmatum/next-shell              # root barrel
+@jonmatum/next-shell/core         # cn(), packageVersion
+@jonmatum/next-shell/primitives   # 42 shadcn/ui primitives (client)
+@jonmatum/next-shell/providers    # AppProviders, ThemeProvider, etc. (client)
+@jonmatum/next-shell/providers/server  # SSR cookie helpers
+@jonmatum/next-shell/tokens       # TS token contract + brand overrides
+@jonmatum/next-shell/layout       # AppShell, Sidebar, TopBar, etc. (client)
+@jonmatum/next-shell/layout/server
+@jonmatum/next-shell/auth         # AuthProvider, useSession, guards (client)
+@jonmatum/next-shell/auth/server
+@jonmatum/next-shell/auth/nextauth
+@jonmatum/next-shell/auth/mock
+@jonmatum/next-shell/hooks        # useDisclosure, useLocalStorage, etc. (client)
+@jonmatum/next-shell/formatters   # date, number, string formatters
+@jonmatum/next-shell/tailwind-preset
+@jonmatum/next-shell/styles/tokens.css
+@jonmatum/next-shell/styles/preset.css
+```
+
+### Peer dependencies
+
+| Package               | Version                     |
+| --------------------- | --------------------------- |
+| `next`                | `^15.0.0`                   |
+| `react` / `react-dom` | `^19.0.0`                   |
+| `tailwindcss`         | `^4.0.0` (optional)         |
+| `tw-animate-css`      | `^1.0.0` (optional)         |
+| `next-auth`           | `>=5.0.0-beta.0` (optional) |
+
+### Token schema version
+
+The token contract is published at schema version `1.0.0`. Consumers can assert this at runtime via:
+
+```ts
+import { tokenSchemaVersion } from '@jonmatum/next-shell/tokens';
+// tokenSchemaVersion === '1.0.0'
+```
+
+### What counts as breaking
+
+Future migration entries will document any of the following changes:
+
+- Semantic token renames or removals
+- Removed or renamed subpath exports
+- Changed component props (new required props, narrowed types, removals)
+- CSS class or `data-*` attribute changes
+- Peer dependency version bumps
+- Default behavior changes in components

--- a/apps/docs/content/docs/primitives/index.mdx
+++ b/apps/docs/content/docs/primitives/index.mdx
@@ -132,6 +132,364 @@ function LoginForm() {
 }
 ```
 
+## Accordion
+
+```tsx
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '@jonmatum/next-shell/primitives';
+
+<Accordion type="single" collapsible>
+  <AccordionItem value="shipping">
+    <AccordionTrigger>What are the shipping options?</AccordionTrigger>
+    <AccordionContent>
+      We offer standard (5-7 days) and express (1-2 days) shipping.
+    </AccordionContent>
+  </AccordionItem>
+  <AccordionItem value="returns">
+    <AccordionTrigger>How do I return an item?</AccordionTrigger>
+    <AccordionContent>
+      Items can be returned within 30 days of purchase for a full refund.
+    </AccordionContent>
+  </AccordionItem>
+</Accordion>;
+```
+
+## Alert
+
+```tsx
+import { Alert, AlertTitle, AlertDescription } from '@jonmatum/next-shell/primitives';
+
+<Alert>
+  <AlertTitle>Heads up!</AlertTitle>
+  <AlertDescription>
+    You can add components to your app using the CLI.
+  </AlertDescription>
+</Alert>
+
+<Alert variant="destructive">
+  <AlertTitle>Error</AlertTitle>
+  <AlertDescription>
+    Your session has expired. Please log in again.
+  </AlertDescription>
+</Alert>;
+```
+
+## AlertDialog
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@jonmatum/next-shell/primitives';
+
+<AlertDialog>
+  <AlertDialogTrigger asChild>
+    <Button variant="destructive">Delete account</Button>
+  </AlertDialogTrigger>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+      <AlertDialogDescription>
+        This will permanently delete your account and all associated data.
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>Cancel</AlertDialogCancel>
+      <AlertDialogAction>Yes, delete my account</AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>;
+```
+
+## Avatar
+
+```tsx
+import { Avatar, AvatarImage, AvatarFallback } from '@jonmatum/next-shell/primitives';
+
+<Avatar>
+  <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
+  <AvatarFallback>CN</AvatarFallback>
+</Avatar>
+
+<Avatar>
+  <AvatarFallback>JD</AvatarFallback>
+</Avatar>;
+```
+
+The `AvatarFallback` renders when the image is missing or still loading.
+
+## Badge
+
+```tsx
+import { Badge } from '@jonmatum/next-shell/primitives';
+
+<Badge>Default</Badge>
+<Badge variant="secondary">Secondary</Badge>
+<Badge variant="outline">Outline</Badge>
+<Badge variant="destructive">Destructive</Badge>;
+```
+
+Variants: `default` · `secondary` · `outline` · `destructive`
+
+## Checkbox
+
+```tsx
+import { Checkbox } from '@jonmatum/next-shell/primitives';
+import { Label } from '@jonmatum/next-shell/primitives';
+
+<div className="flex items-center gap-2">
+  <Checkbox id="terms" />
+  <Label htmlFor="terms">Accept terms and conditions</Label>
+</div>
+
+<div className="flex items-center gap-2">
+  <Checkbox id="marketing" defaultChecked />
+  <Label htmlFor="marketing">Receive marketing emails</Label>
+</div>;
+```
+
+## DropdownMenu
+
+```tsx
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@jonmatum/next-shell/primitives';
+
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button variant="outline">Open menu</Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent>
+    <DropdownMenuLabel>My Account</DropdownMenuLabel>
+    <DropdownMenuSeparator />
+    <DropdownMenuItem>Profile</DropdownMenuItem>
+    <DropdownMenuItem>Settings</DropdownMenuItem>
+    <DropdownMenuItem>Billing</DropdownMenuItem>
+    <DropdownMenuSeparator />
+    <DropdownMenuItem>Log out</DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>;
+```
+
+## Input
+
+```tsx
+import { Input } from '@jonmatum/next-shell/primitives';
+import { Label } from '@jonmatum/next-shell/primitives';
+
+<div className="grid w-full max-w-sm gap-1.5">
+  <Label htmlFor="email">Email</Label>
+  <Input type="email" id="email" placeholder="you@example.com" />
+</div>
+
+<Input disabled placeholder="Disabled input" />
+<Input type="file" />;
+```
+
+## Popover
+
+```tsx
+import { Popover, PopoverContent, PopoverTrigger } from '@jonmatum/next-shell/primitives';
+
+<Popover>
+  <PopoverTrigger asChild>
+    <Button variant="outline">Open popover</Button>
+  </PopoverTrigger>
+  <PopoverContent className="w-80">
+    <div className="grid gap-4">
+      <div className="space-y-2">
+        <h4 className="font-medium leading-none">Dimensions</h4>
+        <p className="text-muted-foreground text-sm">Set the dimensions for the layer.</p>
+      </div>
+      <Input placeholder="Width" defaultValue="100%" />
+    </div>
+  </PopoverContent>
+</Popover>;
+```
+
+## Select
+
+```tsx
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@jonmatum/next-shell/primitives';
+
+<Select>
+  <SelectTrigger className="w-[180px]">
+    <SelectValue placeholder="Select a fruit" />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectGroup>
+      <SelectLabel>Fruits</SelectLabel>
+      <SelectItem value="apple">Apple</SelectItem>
+      <SelectItem value="banana">Banana</SelectItem>
+      <SelectItem value="orange">Orange</SelectItem>
+      <SelectItem value="grape">Grape</SelectItem>
+    </SelectGroup>
+  </SelectContent>
+</Select>;
+```
+
+## Sheet
+
+```tsx
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@jonmatum/next-shell/primitives';
+
+<Sheet>
+  <SheetTrigger asChild>
+    <Button variant="outline">Open sheet</Button>
+  </SheetTrigger>
+  <SheetContent>
+    <SheetHeader>
+      <SheetTitle>Edit profile</SheetTitle>
+      <SheetDescription>Make changes to your profile here. Click save when done.</SheetDescription>
+    </SheetHeader>
+    <div className="grid gap-4 py-4">
+      <Input placeholder="Name" />
+      <Input placeholder="Username" />
+    </div>
+    <Button>Save changes</Button>
+  </SheetContent>
+</Sheet>;
+```
+
+## Switch
+
+```tsx
+import { Switch } from '@jonmatum/next-shell/primitives';
+import { Label } from '@jonmatum/next-shell/primitives';
+
+<div className="flex items-center gap-2">
+  <Switch id="airplane-mode" />
+  <Label htmlFor="airplane-mode">Airplane Mode</Label>
+</div>
+
+<div className="flex items-center gap-2">
+  <Switch id="notifications" defaultChecked />
+  <Label htmlFor="notifications">Enable notifications</Label>
+</div>;
+```
+
+## Table
+
+```tsx
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@jonmatum/next-shell/primitives';
+
+<Table>
+  <TableCaption>A list of recent invoices.</TableCaption>
+  <TableHeader>
+    <TableRow>
+      <TableHead className="w-[100px]">Invoice</TableHead>
+      <TableHead>Status</TableHead>
+      <TableHead>Method</TableHead>
+      <TableHead className="text-right">Amount</TableHead>
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    <TableRow>
+      <TableCell className="font-medium">INV001</TableCell>
+      <TableCell>Paid</TableCell>
+      <TableCell>Credit Card</TableCell>
+      <TableCell className="text-right">$250.00</TableCell>
+    </TableRow>
+  </TableBody>
+</Table>;
+```
+
+## Tabs
+
+```tsx
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@jonmatum/next-shell/primitives';
+
+<Tabs defaultValue="account" className="w-[400px]">
+  <TabsList>
+    <TabsTrigger value="account">Account</TabsTrigger>
+    <TabsTrigger value="password">Password</TabsTrigger>
+  </TabsList>
+  <TabsContent value="account">
+    <p className="text-muted-foreground text-sm">Make changes to your account here.</p>
+  </TabsContent>
+  <TabsContent value="password">
+    <p className="text-muted-foreground text-sm">Change your password here.</p>
+  </TabsContent>
+</Tabs>;
+```
+
+## Textarea
+
+```tsx
+import { Textarea } from '@jonmatum/next-shell/primitives';
+import { Label } from '@jonmatum/next-shell/primitives';
+
+<div className="grid w-full gap-1.5">
+  <Label htmlFor="message">Your message</Label>
+  <Textarea id="message" placeholder="Type your message here." />
+</div>
+
+<Textarea disabled placeholder="Disabled textarea" />;
+```
+
+## Tooltip
+
+```tsx
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@jonmatum/next-shell/primitives';
+
+<TooltipProvider>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button variant="outline">Hover me</Button>
+    </TooltipTrigger>
+    <TooltipContent>
+      <p>Add to library</p>
+    </TooltipContent>
+  </Tooltip>
+</TooltipProvider>;
+```
+
+Wrap your app (or a subtree) with `TooltipProvider` once; all nested `Tooltip` instances share the same delay group.
+
 ## Not vendored (recipes)
 
 These are common patterns intentionally left as consumer-side compositions:

--- a/apps/docs/content/docs/recipes/index.mdx
+++ b/apps/docs/content/docs/recipes/index.mdx
@@ -1,0 +1,518 @@
+---
+title: Recipes
+description: Composed patterns built from @jonmatum/next-shell primitives.
+---
+
+Ready-made patterns that combine multiple primitives. Each recipe is copy-pasteable — just make sure the required peer dependencies are installed.
+
+---
+
+## DatePicker
+
+Compose **Popover**, **Calendar**, and **Button** into a single date-picker control.
+
+**Peer dependencies:** `react-day-picker`, `lucide-react`
+
+```tsx title="components/date-picker.tsx"
+'use client';
+
+import * as React from 'react';
+import { format } from 'date-fns';
+import { CalendarIcon } from 'lucide-react';
+
+import {
+  Button,
+  Calendar,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@jonmatum/next-shell/primitives';
+import { cn } from '@jonmatum/next-shell/core';
+
+export function DatePicker() {
+  const [date, setDate] = React.useState<Date>();
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn(
+            'w-[280px] justify-start text-left font-normal',
+            !date && 'text-muted-foreground',
+          )}
+        >
+          <CalendarIcon className="mr-2 size-4" />
+          {date ? format(date, 'PPP') : <span>Pick a date</span>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0">
+        <Calendar mode="single" selected={date} onSelect={setDate} autoFocus />
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+### DateRangePicker variant
+
+```tsx title="components/date-range-picker.tsx"
+'use client';
+
+import * as React from 'react';
+import { format } from 'date-fns';
+import { CalendarIcon } from 'lucide-react';
+import type { DateRange } from 'react-day-picker';
+
+import {
+  Button,
+  Calendar,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@jonmatum/next-shell/primitives';
+import { cn } from '@jonmatum/next-shell/core';
+
+export function DateRangePicker({ className }: React.HTMLAttributes<HTMLDivElement>) {
+  const [range, setRange] = React.useState<DateRange | undefined>();
+
+  return (
+    <div className={cn('grid gap-2', className)}>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            className={cn(
+              'w-[300px] justify-start text-left font-normal',
+              !range && 'text-muted-foreground',
+            )}
+          >
+            <CalendarIcon className="mr-2 size-4" />
+            {range?.from ? (
+              range.to ? (
+                <>
+                  {format(range.from, 'LLL dd, y')} – {format(range.to, 'LLL dd, y')}
+                </>
+              ) : (
+                format(range.from, 'LLL dd, y')
+              )
+            ) : (
+              <span>Pick a date range</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="range"
+            defaultMonth={range?.from}
+            selected={range}
+            onSelect={setRange}
+            numberOfMonths={2}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+```
+
+---
+
+## DataTable
+
+Compose **Table** with `@tanstack/react-table` for sortable, filterable, paginated data grids.
+
+**Peer dependencies:** `@tanstack/react-table`
+
+```bash
+pnpm add @tanstack/react-table
+```
+
+### Generic DataTable component
+
+```tsx title="components/data-table.tsx"
+'use client';
+
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable,
+} from '@tanstack/react-table';
+import * as React from 'react';
+
+import {
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@jonmatum/next-shell/primitives';
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+}
+
+export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    onSortingChange: setSorting,
+    state: { sorting },
+  });
+
+  return (
+    <div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end gap-2 py-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+### Usage example
+
+```tsx title="app/payments/columns.tsx"
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDownIcon } from 'lucide-react';
+
+import { Button } from '@jonmatum/next-shell/primitives';
+
+export type Payment = {
+  id: string;
+  amount: number;
+  status: 'pending' | 'processing' | 'success' | 'failed';
+  email: string;
+};
+
+export const columns: ColumnDef<Payment>[] = [
+  {
+    accessorKey: 'status',
+    header: 'Status',
+  },
+  {
+    accessorKey: 'email',
+    header: ({ column }) => (
+      <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+        Email
+        <ArrowUpDownIcon className="ml-2 size-4" />
+      </Button>
+    ),
+  },
+  {
+    accessorKey: 'amount',
+    header: () => <div className="text-right">Amount</div>,
+    cell: ({ row }) => {
+      const amount = parseFloat(row.getValue('amount'));
+      const formatted = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+      }).format(amount);
+      return <div className="text-right font-medium">{formatted}</div>;
+    },
+  },
+];
+```
+
+```tsx title="app/payments/page.tsx"
+import { DataTable } from '@/components/data-table';
+import { columns, type Payment } from './columns';
+
+const data: Payment[] = [
+  { id: '1', amount: 100, status: 'pending', email: 'alice@example.com' },
+  { id: '2', amount: 250, status: 'success', email: 'bob@example.com' },
+  { id: '3', amount: 50, status: 'processing', email: 'carol@example.com' },
+];
+
+export default function PaymentsPage() {
+  return (
+    <div className="container mx-auto py-10">
+      <DataTable columns={columns} data={data} />
+    </div>
+  );
+}
+```
+
+---
+
+## Combobox
+
+Compose **Popover** and **Command** into an accessible, searchable select control.
+
+```tsx title="components/combobox.tsx"
+'use client';
+
+import * as React from 'react';
+import { CheckIcon, ChevronsUpDownIcon } from 'lucide-react';
+
+import {
+  Button,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@jonmatum/next-shell/primitives';
+import { cn } from '@jonmatum/next-shell/core';
+
+interface ComboboxOption {
+  value: string;
+  label: string;
+}
+
+interface ComboboxProps {
+  options: ComboboxOption[];
+  placeholder?: string;
+  emptyMessage?: string;
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+export function Combobox({
+  options,
+  placeholder = 'Select an option...',
+  emptyMessage = 'No results found.',
+  value: controlledValue,
+  onValueChange,
+}: ComboboxProps) {
+  const [open, setOpen] = React.useState(false);
+  const [internalValue, setInternalValue] = React.useState('');
+
+  const value = controlledValue ?? internalValue;
+  const setValue = onValueChange ?? setInternalValue;
+
+  const selectedLabel = options.find((opt) => opt.value === value)?.label;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-[200px] justify-between"
+        >
+          {selectedLabel ?? placeholder}
+          <ChevronsUpDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[200px] p-0">
+        <Command>
+          <CommandInput placeholder={`Search...`} />
+          <CommandList>
+            <CommandEmpty>{emptyMessage}</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => (
+                <CommandItem
+                  key={option.value}
+                  value={option.value}
+                  onSelect={(currentValue) => {
+                    setValue(currentValue === value ? '' : currentValue);
+                    setOpen(false);
+                  }}
+                >
+                  <CheckIcon
+                    className={cn(
+                      'mr-2 size-4',
+                      value === option.value ? 'opacity-100' : 'opacity-0',
+                    )}
+                  />
+                  {option.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+### Usage
+
+```tsx title="app/example/page.tsx"
+'use client';
+
+import { Combobox } from '@/components/combobox';
+
+const frameworks = [
+  { value: 'next', label: 'Next.js' },
+  { value: 'remix', label: 'Remix' },
+  { value: 'astro', label: 'Astro' },
+  { value: 'nuxt', label: 'Nuxt' },
+  { value: 'svelte', label: 'SvelteKit' },
+];
+
+export default function ExamplePage() {
+  return (
+    <div className="flex items-center gap-4 p-8">
+      <Combobox options={frameworks} placeholder="Select framework..." />
+    </div>
+  );
+}
+```
+
+---
+
+## Typography
+
+A styling guide for semantic heading and paragraph elements using Tailwind utility classes from the design system.
+
+These are not separate components — they are utility class recipes you can apply directly to standard HTML elements.
+
+### Heading styles
+
+```tsx title="components/typography-demo.tsx"
+export function TypographyDemo() {
+  return (
+    <div className="space-y-6">
+      <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl">
+        The Joke Tax Chronicles
+      </h1>
+
+      <p className="text-muted-foreground text-xl">
+        Once upon a time, in a far-off land, there was a very lazy king who spent all day lounging
+        on his throne.
+      </p>
+
+      <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
+        The King's Plan
+      </h2>
+
+      <p className="leading-7 [&:not(:first-child)]:mt-6">
+        The king thought long and hard, and finally came up with{' '}
+        <a href="#" className="text-primary font-medium underline underline-offset-4">
+          a brilliant plan
+        </a>
+        : he would tax the jokes.
+      </p>
+
+      <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">The Joke Tax</h3>
+
+      <p className="leading-7 [&:not(:first-child)]:mt-6">
+        The king's subjects were not amused. They grumbled and complained, but the king was firm.
+      </p>
+
+      <h4 className="scroll-m-20 text-xl font-semibold tracking-tight">
+        People stopped telling jokes
+      </h4>
+
+      <p className="leading-7 [&:not(:first-child)]:mt-6">
+        People stopped telling jokes, and the kingdom fell into a deep silence.
+      </p>
+    </div>
+  );
+}
+```
+
+### Quick reference
+
+| Element | Classes                                                           |
+| ------- | ----------------------------------------------------------------- |
+| `h1`    | `scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl`  |
+| `h2`    | `scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight` |
+| `h3`    | `scroll-m-20 text-2xl font-semibold tracking-tight`               |
+| `h4`    | `scroll-m-20 text-xl font-semibold tracking-tight`                |
+| `p`     | `leading-7 [&:not(:first-child)]:mt-6`                            |
+| `lead`  | `text-muted-foreground text-xl`                                   |
+| `large` | `text-lg font-semibold`                                           |
+| `small` | `text-sm font-medium leading-none`                                |
+| `muted` | `text-muted-foreground text-sm`                                   |
+| `a`     | `text-primary font-medium underline underline-offset-4`           |
+
+### Blockquote and list styles
+
+```tsx title="components/typography-extras.tsx"
+export function TypographyExtras() {
+  return (
+    <div className="space-y-6">
+      <blockquote className="border-l-2 pl-6 italic">
+        "After all," he said, "everyone enjoys a good joke, so it's only fair that they should pay
+        for the privilege."
+      </blockquote>
+
+      <ul className="my-6 ml-6 list-disc [&>li]:mt-2">
+        <li>1st level of puns: 5 gold coins</li>
+        <li>2nd level of jokes: 10 gold coins</li>
+        <li>3rd level of one-liners: 20 gold coins</li>
+      </ul>
+
+      <div className="my-6 w-full overflow-y-auto">
+        <code className="bg-muted relative rounded px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold">
+          @jonmatum/next-shell
+        </code>
+      </div>
+    </div>
+  );
+}
+```

--- a/packages/next-shell/.size-limit.cjs
+++ b/packages/next-shell/.size-limit.cjs
@@ -4,20 +4,23 @@
  * Run with: pnpm size
  * CI runs this after the build step to catch bundle regressions.
  *
+ * Limits are set ~20% above current measured sizes to catch regressions
+ * without false positives on minor additions.
+ *
  * @see https://github.com/ai/size-limit
  */
 module.exports = [
   {
     path: 'dist/primitives/index.js',
-    limit: '80 KB',
+    limit: '230 KB',
   },
   {
     path: 'dist/layout/index.js',
-    limit: '40 KB',
+    limit: '55 KB',
   },
   {
     path: 'dist/providers/index.js',
-    limit: '20 KB',
+    limit: '65 KB',
   },
   {
     path: 'dist/auth/index.js',

--- a/packages/next-shell/.size-limit.js
+++ b/packages/next-shell/.size-limit.js
@@ -1,0 +1,38 @@
+/**
+ * Size-limit configuration for @jonmatum/next-shell.
+ *
+ * Run with: pnpm size
+ * CI runs this after the build step to catch bundle regressions.
+ *
+ * @see https://github.com/ai/size-limit
+ */
+module.exports = [
+  {
+    path: 'dist/primitives/index.js',
+    limit: '80 KB',
+  },
+  {
+    path: 'dist/layout/index.js',
+    limit: '40 KB',
+  },
+  {
+    path: 'dist/providers/index.js',
+    limit: '20 KB',
+  },
+  {
+    path: 'dist/auth/index.js',
+    limit: '10 KB',
+  },
+  {
+    path: 'dist/hooks/index.js',
+    limit: '10 KB',
+  },
+  {
+    path: 'dist/formatters/index.js',
+    limit: '10 KB',
+  },
+  {
+    path: 'dist/tokens/index.js',
+    limit: '5 KB',
+  },
+];

--- a/packages/next-shell/MIGRATION.md
+++ b/packages/next-shell/MIGRATION.md
@@ -1,0 +1,110 @@
+# Migration Guide
+
+This document tracks breaking changes between versions of `@jonmatum/next-shell` and provides upgrade instructions.
+
+---
+
+## Migration entry template
+
+When documenting a new version, use this structure:
+
+> **## vX.Y.Z**
+>
+> **Release date:** YYYY-MM-DD
+>
+> **Breaking changes** — list each change with before/after code snippets.
+>
+> **Deprecations** — list deprecated APIs and their replacements.
+>
+> **Migration steps** — numbered, independently verifiable steps.
+>
+> **Codemods / find-and-replace** — regex or codemod commands if applicable.
+
+---
+
+## What counts as a breaking change
+
+Any of the following constitutes a breaking change and requires a major (or pre-1.0 minor) version bump:
+
+| Category                               | Examples                                                                              |
+| -------------------------------------- | ------------------------------------------------------------------------------------- |
+| **Token renames**                      | `--primary` renamed to `--brand-primary`; `ColorToken` union changes                  |
+| **Token removals**                     | A token deleted from `tokens.css` / `preset.css` / the `colorTokens` array            |
+| **Removed exports**                    | A named export dropped from any public subpath barrel                                 |
+| **Changed component props**            | Required prop added, prop type narrowed, prop renamed or removed                      |
+| **CSS class / data-attribute changes** | `data-theme` attribute renamed, Tailwind utility class prefix changed                 |
+| **Peer dependency bumps**              | Minimum React, Next.js, or Tailwind version increased                                 |
+| **Subpath removals**                   | A `package.json#exports` entry removed or path changed                                |
+| **Default behavior changes**           | A component's default variant, size, or behavior changes in a way consumers depend on |
+
+---
+
+## v0.1.0 — Baseline
+
+**Release date:** 2025 (initial extraction)
+
+This is the first published version. There are no prior versions to migrate from. This entry documents the initial API surface as the baseline contract that future versions are compared against.
+
+### Subpath exports
+
+| Subpath                                     | Description                                                                                                                                                                                                                                                                       |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@jonmatum/next-shell`                      | Root barrel (re-exports core + primitives + providers + tokens)                                                                                                                                                                                                                   |
+| `@jonmatum/next-shell/core`                 | `cn()`, `packageVersion`                                                                                                                                                                                                                                                          |
+| `@jonmatum/next-shell/primitives`           | 42 shadcn/ui primitives (client)                                                                                                                                                                                                                                                  |
+| `@jonmatum/next-shell/providers`            | `AppProviders`, `ThemeProvider`, `QueryProvider`, `ToastProvider`, `ErrorBoundary`, `I18nProvider` (client)                                                                                                                                                                       |
+| `@jonmatum/next-shell/providers/server`     | SSR cookie helpers (server-safe)                                                                                                                                                                                                                                                  |
+| `@jonmatum/next-shell/tokens`               | TypeScript token contract, `BrandOverrides`, `buildRootOverrides()`, `brandOverridesCss()`, `cssVar()`, `hexToOklch()`, presets                                                                                                                                                   |
+| `@jonmatum/next-shell/layout`               | `AppShell`, `Sidebar`, `TopBar`, `CommandBar`, `Footer`, `PageHeader`, `ContentContainer`, error pages, status states (client)                                                                                                                                                    |
+| `@jonmatum/next-shell/layout/server`        | Server-safe layout utilities                                                                                                                                                                                                                                                      |
+| `@jonmatum/next-shell/auth`                 | `AuthProvider`, `useSession`, auth guards, auth components (client)                                                                                                                                                                                                               |
+| `@jonmatum/next-shell/auth/server`          | Server-side auth helpers                                                                                                                                                                                                                                                          |
+| `@jonmatum/next-shell/auth/nextauth`        | NextAuth.js v5 adapter                                                                                                                                                                                                                                                            |
+| `@jonmatum/next-shell/auth/mock`            | Mock auth adapter for development/testing                                                                                                                                                                                                                                         |
+| `@jonmatum/next-shell/hooks`                | `useIsMobile`, `useMediaQuery`, `useBreakpoint`, `useMounted`, `useIsomorphicLayoutEffect`, `useDisclosure`, `useControllableState`, `useLocalStorage`, `useSessionStorage`, `useCopyToClipboard`, `useDebouncedValue`, `useDebouncedCallback`, `useHotkey`, `useLocale` (client) |
+| `@jonmatum/next-shell/formatters`           | `formatDate`, `formatNumber`, `formatCurrency`, `truncate`, and string/number/date utilities                                                                                                                                                                                      |
+| `@jonmatum/next-shell/tailwind-preset`      | Tailwind v4 preset (programmatic)                                                                                                                                                                                                                                                 |
+| `@jonmatum/next-shell/styles/tokens.css`    | CSS custom property definitions (`:root` + `[data-theme='dark']`)                                                                                                                                                                                                                 |
+| `@jonmatum/next-shell/styles/preset.css`    | Tailwind v4 `@theme` mappings                                                                                                                                                                                                                                                     |
+| `@jonmatum/next-shell/styles/presets/*.css` | Color palette presets: `neutral`, `green`, `orange`, `red`, `violet`                                                                                                                                                                                                              |
+
+### Semantic color tokens
+
+Defined in `src/styles/tokens.css` and mirrored in `src/tokens/index.ts`:
+
+`background`, `foreground`, `surface`, `surface-foreground`, `card`, `card-foreground`, `popover`, `popover-foreground`, `muted`, `muted-foreground`, `accent`, `accent-foreground`, `primary`, `primary-foreground`, `secondary`, `secondary-foreground`, `destructive`, `destructive-foreground`, `success`, `success-foreground`, `warning`, `warning-foreground`, `info`, `info-foreground`, `border`, `input`, `ring`, `overlay`, `sidebar`, `sidebar-foreground`, `sidebar-primary`, `sidebar-primary-foreground`, `sidebar-accent`, `sidebar-accent-foreground`, `sidebar-border`, `sidebar-ring`, `chart-1` through `chart-5`
+
+Token schema version: `1.0.0`
+
+### Other token categories
+
+- **Radius:** `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `full`
+- **Font families:** `sans`, `mono`, `display`
+- **Text sizes:** `xs`, `sm`, `base`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`
+- **Leading:** `tight`, `snug`, `normal`, `relaxed`, `loose`
+- **Tracking:** `tight`, `normal`, `wide`, `wider`
+- **Duration:** `instant`, `fast`, `normal`, `slow`, `slowest`
+- **Easing:** `standard`, `emphasized`, `decelerate`, `accelerate`
+- **Shadows:** `xs`, `sm`, `md`, `lg`, `xl`, `2xl`
+- **Density:** `pad-x`, `pad-y`, `gap`, `row-height`
+
+### Key component props (baseline)
+
+- **Button:** `variant` (`default | destructive | outline | secondary | ghost | link`), `size` (`default | sm | lg | icon`)
+- **Badge:** `variant` (`default | secondary | destructive | outline`)
+- **Toggle:** `variant` (`default | outline`), `size` (`default | sm | lg`)
+- **Tabs:** `TabsList` accepts `variant` via `tabsListVariants`
+- **AppShell:** `sidebar`, `topBar`, `commandBar`, `footer` props
+- **AppProviders:** `themeProps`, `queryProps`, `toastProps`, `i18nProps`, `authProps`
+- **ThemeProvider:** wraps `next-themes` with `data-theme` attribute
+
+### Peer dependencies
+
+| Package          | Version                     |
+| ---------------- | --------------------------- |
+| `next`           | `^15.0.0`                   |
+| `react`          | `^19.0.0`                   |
+| `react-dom`      | `^19.0.0`                   |
+| `tailwindcss`    | `^4.0.0` (optional)         |
+| `tw-animate-css` | `^1.0.0` (optional)         |
+| `next-auth`      | `>=5.0.0-beta.0` (optional) |

--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -146,6 +146,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "size": "size-limit",
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
@@ -187,6 +188,8 @@
     "vaul": "^1.1.2"
   },
   "devDependencies": {
+    "@size-limit/preset-small-lib": "^11.2.0",
+    "size-limit": "^11.2.0",
     "@tanstack/react-query": "^5.99.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
+      '@size-limit/preset-small-lib':
+        specifier: ^11.2.0
+        version: 11.2.0(size-limit@11.2.0)
       '@tanstack/react-query':
         specifier: ^5.99.0
         version: 5.99.0(react@19.2.5)
@@ -251,6 +254,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      size-limit:
+        specifier: ^11.2.0
+        version: 11.2.0
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.2
@@ -1758,6 +1764,23 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@size-limit/esbuild@11.2.0':
+    resolution: {integrity: sha512-vSg9H0WxGQPRzDnBzeDyD9XT0Zdq0L+AI3+77/JhxznbSCMJMMr8ndaWVQRhOsixl97N0oD4pRFw2+R1Lcvi6A==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      size-limit: 11.2.0
+
+  '@size-limit/file@11.2.0':
+    resolution: {integrity: sha512-OZHE3putEkQ/fgzz3Tp/0hSmfVo3wyTpOJSRNm6AmcwX4Nm9YtTfbQQ/hZRwbBFR23S7x2Sd9EbqYzngKwbRoA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      size-limit: 11.2.0
+
+  '@size-limit/preset-small-lib@11.2.0':
+    resolution: {integrity: sha512-RFbbIVfv8/QDgTPyXzjo5NKO6CYyK5Uq5xtNLHLbw5RgSKrgo8WpiB/fNivZuNd/5Wk0s91PtaJ9ThNcnFuI3g==}
+    peerDependencies:
+      size-limit: 11.2.0
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2224,6 +2247,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.25.0'
+
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -3602,6 +3629,14 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.9:
+    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -4250,6 +4285,11 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  size-limit@11.2.0:
+    resolution: {integrity: sha512-2kpQq2DD/pRpx3Tal/qRW1SYwcIeQ0iq8li5CJHQgOC+FtPn2BVmuDtzUCgNnpCrbgtfEHqh+iWzxK+Tq6C+RQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -6236,6 +6276,22 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@size-limit/esbuild@11.2.0(size-limit@11.2.0)':
+    dependencies:
+      esbuild: 0.27.7
+      nanoid: 5.1.9
+      size-limit: 11.2.0
+
+  '@size-limit/file@11.2.0(size-limit@11.2.0)':
+    dependencies:
+      size-limit: 11.2.0
+
+  '@size-limit/preset-small-lib@11.2.0(size-limit@11.2.0)':
+    dependencies:
+      '@size-limit/esbuild': 11.2.0(size-limit@11.2.0)
+      '@size-limit/file': 11.2.0(size-limit@11.2.0)
+      size-limit: 11.2.0
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -6718,6 +6774,8 @@ snapshots:
     dependencies:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
+
+  bytes-iec@3.1.1: {}
 
   cac@6.7.14: {}
 
@@ -8526,6 +8584,12 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.9: {}
+
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
+
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
@@ -9282,6 +9346,16 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  size-limit@11.2.0:
+    dependencies:
+      bytes-iec: 3.1.1
+      chokidar: 4.0.3
+      jiti: 2.6.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.16
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
## Summary

6 more issues from epic #54. Closes #56, #61, #63, #68, #84, #86.

## Changes

- **#56** Recipes docs page: DatePicker, DataTable, Combobox, Typography — complete copy-pasteable patterns
- **#61** Density + elevation token documentation in design-system docs
- **#63** 16 primitive usage examples: Accordion, Alert, AlertDialog, Avatar, Badge, Checkbox, DropdownMenu, Input, Popover, Select, Sheet, Switch, Table, Tabs, Textarea, Tooltip
- **#68** Fix stale phase numbering in CLAUDE.md, contributor skill, shadcn-next-shell skill + fix brand.ts/tokens.css paths
- **#84** Bundle size tracking: size-limit config with budgets per subpath + CI step
- **#86** MIGRATION.md with v0.1.0 baseline + docs migration page + breaking changes section in CONTRIBUTING.md

## Verification

```
pnpm format     ok
pnpm lint       ok (0 warnings)
pnpm typecheck  ok
pnpm test       ok — 27 files, 613 tests
```

https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4

---
_Generated by [Claude Code](https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4)_