### PR TITLE
fix(docs): remove search API route incompatible with static export

### DIFF
--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -1,8 +1,0 @@
-import { source } from '@/app/source';
-import { createFromSource } from 'fumadocs-core/search/server';
-
-// Provides the GET handler for fumadocs built-in search.
-// Note: API routes are not available in static export mode (GITHUB_PAGES=true).
-// For static deployments, search will be unavailable unless switched to
-// type: 'static' in the RootProvider search config.
-export const { GET } = createFromSource(source);


### PR DESCRIPTION
## Summary

Fix the docs deploy workflow failure. The `/api/search` route added in #91 uses a dynamic server handler that's incompatible with `output: 'export'` (used for GitHub Pages static deployment).

## Fix

Remove `apps/docs/app/api/search/route.ts`. Search will need a static-compatible implementation (fumadocs `type: 'static'`) in a future PR if needed.

## Verification

```
GITHUB_PAGES=true npx next build   ok — static export succeeds
```

https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4

---
_Generated by [Claude Code](https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4)_