### PR TITLE
feat: WCAG contrast fixes, theme generator CLI, polished example app

### DIFF
--- a/apps/example/app/(shell)/dashboard/page.tsx
+++ b/apps/example/app/(shell)/dashboard/page.tsx
@@ -7,19 +7,113 @@ import {
   EmptyState,
   LoadingState,
 } from '@jonmatum/next-shell/layout';
-import { Button, Card, CardContent, CardHeader, CardTitle } from '@jonmatum/next-shell/primitives';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Badge,
+  Progress,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Avatar,
+  AvatarFallback,
+  Separator,
+} from '@jonmatum/next-shell/primitives';
 import { useUser, SignedIn } from '@jonmatum/next-shell/auth';
-import { TrendingUp, Users, DollarSign, Activity, Plus, RefreshCw } from 'lucide-react';
+import {
+  TrendingUp,
+  TrendingDown,
+  Users,
+  DollarSign,
+  Activity,
+  ShoppingCart,
+  Plus,
+  RefreshCw,
+  ArrowUpRight,
+} from 'lucide-react';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Data
+ * ──────────────────────────────────────────────────────────────────────── */
 
 const stats = [
-  { label: 'Total Revenue', value: '$48,295', change: '+12%', icon: DollarSign },
-  { label: 'Active Users', value: '2,841', change: '+4%', icon: Users },
-  { label: 'Conversions', value: '1,023', change: '+8%', icon: TrendingUp },
-  { label: 'System Health', value: '99.9%', change: '0%', icon: Activity },
+  {
+    label: 'Total Revenue',
+    value: '$48,295',
+    change: '+12.5%',
+    trend: 'up' as const,
+    description: 'vs. last month',
+    icon: DollarSign,
+  },
+  {
+    label: 'Active Users',
+    value: '2,841',
+    change: '+4.3%',
+    trend: 'up' as const,
+    description: 'vs. last month',
+    icon: Users,
+  },
+  {
+    label: 'Orders',
+    value: '1,023',
+    change: '-2.1%',
+    trend: 'down' as const,
+    description: 'vs. last month',
+    icon: ShoppingCart,
+  },
+  {
+    label: 'Conversion Rate',
+    value: '3.24%',
+    change: '+0.8%',
+    trend: 'up' as const,
+    description: 'vs. last month',
+    icon: Activity,
+  },
 ];
+
+const revenueByChannel = [
+  { label: 'Direct Sales', value: 62, amount: '$29,943' },
+  { label: 'Affiliate', value: 21, amount: '$10,142' },
+  { label: 'Organic Search', value: 11, amount: '$5,312' },
+  { label: 'Social Media', value: 6, amount: '$2,898' },
+];
+
+const monthlyRevenue = [
+  { month: 'Jan', revenue: 18200 },
+  { month: 'Feb', revenue: 21400 },
+  { month: 'Mar', revenue: 19800 },
+  { month: 'Apr', revenue: 24100 },
+  { month: 'May', revenue: 28900 },
+  { month: 'Jun', revenue: 32400 },
+  { month: 'Jul', revenue: 29600 },
+  { month: 'Aug', revenue: 35100 },
+  { month: 'Sep', revenue: 38700 },
+  { month: 'Oct', revenue: 42300 },
+  { month: 'Nov', revenue: 45100 },
+  { month: 'Dec', revenue: 48295 },
+];
+
+const recentActivity = [
+  { user: 'Alice Chen', action: 'placed an order', amount: '$249.00', time: '2m ago' },
+  { user: 'Bob Smith', action: 'subscribed to Pro', amount: '$29/mo', time: '5m ago' },
+  { user: 'Carol Davis', action: 'left a review', amount: null, time: '12m ago' },
+  { user: 'Dan Wilson', action: 'upgraded plan', amount: '$99/mo', time: '18m ago' },
+  { user: 'Eve Martinez', action: 'placed an order', amount: '$512.00', time: '24m ago' },
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Page
+ * ──────────────────────────────────────────────────────────────────────── */
 
 export default function DashboardPage() {
   const user = useUser();
+
+  const maxRevenue = Math.max(...monthlyRevenue.map((m) => m.revenue));
 
   return (
     <ContentContainer>
@@ -50,89 +144,242 @@ export default function DashboardPage() {
       />
 
       {/* Stats Grid */}
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {stats.map((stat) => (
           <Card key={stat.label} className="relative overflow-hidden">
             <CardHeader className="flex flex-row items-center justify-between pb-2">
               <CardTitle className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
                 {stat.label}
               </CardTitle>
-              <div className="bg-primary/10 text-primary flex size-7 items-center justify-center rounded-md">
-                <stat.icon className="size-3.5" />
+              <div className="bg-primary/10 text-primary flex size-8 items-center justify-center rounded-lg">
+                <stat.icon className="size-4" />
               </div>
             </CardHeader>
             <CardContent>
               <div className="text-foreground text-3xl font-bold tracking-tight">{stat.value}</div>
-              <p className="text-muted-foreground mt-1 text-xs">
-                <span className="text-primary font-medium">{stat.change}</span> from last month
-              </p>
+              <div className="mt-1 flex items-center gap-1 text-xs">
+                {stat.trend === 'up' ? (
+                  <TrendingUp className="text-primary size-3" />
+                ) : (
+                  <TrendingDown className="text-destructive size-3" />
+                )}
+                <span
+                  className={
+                    stat.trend === 'up'
+                      ? 'text-primary font-medium'
+                      : 'text-destructive font-medium'
+                  }
+                >
+                  {stat.change}
+                </span>
+                <span className="text-muted-foreground">{stat.description}</span>
+              </div>
             </CardContent>
           </Card>
         ))}
       </div>
 
-      {/* Status State Demo */}
-      <div className="grid gap-6 md:grid-cols-2">
-        <Card>
+      {/* Charts Section */}
+      <div className="grid gap-4 lg:grid-cols-7">
+        {/* Revenue Overview — bar chart using Progress bars */}
+        <Card className="lg:col-span-4">
           <CardHeader>
-            <CardTitle className="text-sm">Loading State</CardTitle>
+            <CardTitle className="text-base">Revenue Overview</CardTitle>
+            <CardDescription>Monthly revenue for the current year</CardDescription>
           </CardHeader>
           <CardContent>
-            <LoadingState description="Fetching analytics…" />
+            <div className="flex items-end gap-2" style={{ height: '200px' }}>
+              {monthlyRevenue.map((m) => {
+                const height = Math.round((m.revenue / maxRevenue) * 100);
+                return (
+                  <div key={m.month} className="flex flex-1 flex-col items-center gap-1">
+                    <span className="text-muted-foreground text-[10px] font-medium tabular-nums">
+                      {Math.round(m.revenue / 1000)}k
+                    </span>
+                    <div className="relative w-full flex-1">
+                      <div
+                        className="bg-primary/80 hover:bg-primary absolute bottom-0 w-full rounded-t-sm transition-colors"
+                        style={{ height: `${height}%` }}
+                      />
+                    </div>
+                    <span className="text-muted-foreground text-[10px]">{m.month}</span>
+                  </div>
+                );
+              })}
+            </div>
           </CardContent>
         </Card>
-        <Card>
+
+        {/* Revenue by Channel */}
+        <Card className="lg:col-span-3">
           <CardHeader>
-            <CardTitle className="text-sm">Empty State</CardTitle>
+            <CardTitle className="text-base">Revenue by Channel</CardTitle>
+            <CardDescription>Distribution across acquisition channels</CardDescription>
           </CardHeader>
           <CardContent>
-            <EmptyState
-              title="No recent activity"
-              description="Activity will appear here once events are recorded."
-              action={
-                <Button variant="outline" size="sm">
-                  <Plus className="size-4" />
-                  Add first item
-                </Button>
-              }
-            />
+            <div className="space-y-4">
+              {revenueByChannel.map((channel) => (
+                <div key={channel.label} className="space-y-2">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-medium">{channel.label}</span>
+                    <span className="text-muted-foreground tabular-nums">{channel.amount}</span>
+                  </div>
+                  <Progress value={channel.value} className="h-2" />
+                </div>
+              ))}
+            </div>
           </CardContent>
         </Card>
       </div>
 
-      {/* Toast Demo */}
-      <SignedIn>
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-sm">Toast Demos</CardTitle>
-          </CardHeader>
-          <CardContent className="flex flex-wrap gap-2">
-            <Button variant="outline" size="sm" onClick={() => toast.success('Success toast!')}>
-              Success
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => toast.error('Something went wrong.')}
-            >
-              Error
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                toast.promise(new Promise((r) => setTimeout(r, 2000)), {
-                  loading: 'Processing…',
-                  success: 'Done!',
-                  error: 'Failed.',
-                });
-              }}
-            >
-              Promise
-            </Button>
-          </CardContent>
-        </Card>
-      </SignedIn>
+      {/* Activity + States */}
+      <Tabs defaultValue="activity" className="w-full">
+        <TabsList>
+          <TabsTrigger value="activity">Recent Activity</TabsTrigger>
+          <TabsTrigger value="states">State Demos</TabsTrigger>
+          <TabsTrigger value="toasts">Toast Demos</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="activity">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Recent Activity</CardTitle>
+              <CardDescription>Latest transactions and user actions</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-0">
+                {recentActivity.map((item, i) => (
+                  <div key={i}>
+                    <div className="flex items-center gap-3 py-3">
+                      <Avatar className="size-8">
+                        <AvatarFallback className="text-xs">
+                          {item.user
+                            .split(' ')
+                            .map((n) => n[0])
+                            .join('')}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="flex-1 space-y-0.5">
+                        <p className="text-sm">
+                          <span className="font-medium">{item.user}</span>{' '}
+                          <span className="text-muted-foreground">{item.action}</span>
+                        </p>
+                        <p className="text-muted-foreground text-xs">{item.time}</p>
+                      </div>
+                      {item.amount && (
+                        <Badge variant="secondary" className="tabular-nums">
+                          {item.amount}
+                        </Badge>
+                      )}
+                      <Button variant="ghost" size="icon" className="size-7">
+                        <ArrowUpRight className="size-3.5" />
+                      </Button>
+                    </div>
+                    {i < recentActivity.length - 1 && <Separator />}
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="states">
+          <div className="grid gap-4 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm">Loading State</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <LoadingState description="Fetching analytics..." />
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm">Empty State</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <EmptyState
+                  title="No recent activity"
+                  description="Activity will appear here once events are recorded."
+                  action={
+                    <Button variant="outline" size="sm">
+                      <Plus className="size-4" />
+                      Add first item
+                    </Button>
+                  }
+                />
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="toasts">
+          <SignedIn>
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Toast Variants</CardTitle>
+                <CardDescription>
+                  Click each button to see different toast styles powered by Sonner.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                <Button variant="outline" size="sm" onClick={() => toast.success('Success toast!')}>
+                  Success
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => toast.error('Something went wrong.')}
+                >
+                  Error
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => toast.warning('This is a warning.')}
+                >
+                  Warning
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => toast.info('Here is some information.')}
+                >
+                  Info
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    toast.promise(new Promise((r) => setTimeout(r, 2000)), {
+                      loading: 'Processing...',
+                      success: 'Done!',
+                      error: 'Failed.',
+                    });
+                  }}
+                >
+                  Promise
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    toast('Event created', {
+                      description: 'Monday, January 3rd at 6:00 PM',
+                      action: {
+                        label: 'Undo',
+                        onClick: () => toast.info('Undone!'),
+                      },
+                    })
+                  }
+                >
+                  With Action
+                </Button>
+              </CardContent>
+            </Card>
+          </SignedIn>
+        </TabsContent>
+      </Tabs>
     </ContentContainer>
   );
 }

--- a/apps/example/app/(shell)/layout.tsx
+++ b/apps/example/app/(shell)/layout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import {
   AppShell,
   TopBar,
@@ -9,15 +9,22 @@ import {
   Sidebar,
   SidebarContent,
   SidebarHeader,
+  SidebarFooter,
   SidebarTrigger,
   SidebarNav,
+  SidebarSeparator,
   Breadcrumbs,
   buildNav,
+  CommandBarActions,
 } from '@jonmatum/next-shell/layout';
 import { useUser } from '@jonmatum/next-shell/auth';
-import { Button } from '@jonmatum/next-shell/primitives';
-import { LayoutDashboard, Settings, Shield, Database, Bell } from 'lucide-react';
-import type { NavConfig } from '@jonmatum/next-shell/layout';
+import { Button, Avatar, AvatarFallback, Separator } from '@jonmatum/next-shell/primitives';
+import { LayoutDashboard, Settings, Shield, Database, Bell, LogOut } from 'lucide-react';
+import type { NavConfig, ResolvedNavItem } from '@jonmatum/next-shell/layout';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Navigation config
+ * ──────────────────────────────────────────────────────────────────────── */
 
 const NAV_CONFIG: NavConfig = [
   { id: 'dashboard', label: 'Dashboard', href: '/dashboard', icon: <LayoutDashboard /> },
@@ -25,6 +32,10 @@ const NAV_CONFIG: NavConfig = [
   { id: 'admin', label: 'Admin', href: '/admin', icon: <Shield />, requires: ['admin'] },
   { id: 'settings', label: 'Settings', href: '/settings', icon: <Settings /> },
 ];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Sidebar
+ * ──────────────────────────────────────────────────────────────────────── */
 
 function ShellSidebar({ pathname }: { pathname: string }) {
   const user = useUser();
@@ -47,9 +58,44 @@ function ShellSidebar({ pathname }: { pathname: string }) {
       <SidebarContent>
         <SidebarNav items={items} />
       </SidebarContent>
+      <SidebarSeparator />
+      <SidebarFooter>
+        <div className="flex items-center gap-3 px-1 py-1">
+          <Avatar className="size-8">
+            <AvatarFallback className="text-xs">
+              {(user?.name ?? 'DU')
+                .split(' ')
+                .map((n) => n[0])
+                .join('')}
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex-1 truncate">
+            <p className="truncate text-sm font-medium">{user?.name ?? 'Demo User'}</p>
+            <p className="text-muted-foreground truncate text-xs">
+              {user?.email ?? 'demo@example.com'}
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            aria-label="Sign out"
+            onClick={() => {
+              /* mock sign-out */
+              window.location.href = '/';
+            }}
+          >
+            <LogOut className="size-3.5" />
+          </Button>
+        </div>
+      </SidebarFooter>
     </Sidebar>
   );
 }
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Top bar
+ * ──────────────────────────────────────────────────────────────────────── */
 
 function ShellTopBar({ pathname }: { pathname: string }) {
   const user = useUser();
@@ -57,10 +103,11 @@ function ShellTopBar({ pathname }: { pathname: string }) {
     <TopBar
       left={<Breadcrumbs config={NAV_CONFIG} pathname={pathname} />}
       right={
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           <span className="text-muted-foreground hidden text-sm sm:block">
             {user?.name ?? 'Demo User'}
           </span>
+          <Separator orientation="vertical" className="mx-1 h-4" />
           <Button variant="ghost" size="icon" className="size-7" aria-label="Notifications">
             <Bell className="size-4" />
           </Button>
@@ -70,8 +117,14 @@ function ShellTopBar({ pathname }: { pathname: string }) {
   );
 }
 
+/* ────────────────────────────────────────────────────────────────────────
+ * Shell layout
+ * ──────────────────────────────────────────────────────────────────────── */
+
 export default function ShellLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
+  const router = useRouter();
+
   return (
     <AppShell
       commandBar
@@ -79,6 +132,14 @@ export default function ShellLayout({ children }: { children: ReactNode }) {
       topBar={<ShellTopBar pathname={pathname} />}
       footer={<Footer>next-shell example app</Footer>}
     >
+      <CommandBarActions
+        config={NAV_CONFIG}
+        pathname={pathname}
+        permissions={['admin']}
+        onNavigate={(item: ResolvedNavItem) => {
+          if (item.href) router.push(item.href);
+        }}
+      />
       {children}
     </AppShell>
   );

--- a/apps/example/app/(shell)/settings/page.tsx
+++ b/apps/example/app/(shell)/settings/page.tsx
@@ -13,69 +13,396 @@ import {
   Input,
   Label,
   Separator,
+  Switch,
+  Checkbox,
+  Textarea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Badge,
 } from '@jonmatum/next-shell/primitives';
 import { ThemeToggleDropdown } from '@jonmatum/next-shell/providers';
 import { useUser } from '@jonmatum/next-shell/auth';
+import { User, Bell, Shield, Palette } from 'lucide-react';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Types
+ * ──────────────────────────────────────────────────────────────────────── */
 
 interface ProfileForm {
   name: string;
   email: string;
+  bio: string;
 }
 
-export default function SettingsPage() {
+/* ────────────────────────────────────────────────────────────────────────
+ * Profile Section
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function ProfileSection() {
   const user = useUser();
-  const { register, handleSubmit } = useForm<ProfileForm>({
-    defaultValues: { name: user?.name ?? '', email: user?.email ?? '' },
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ProfileForm>({
+    defaultValues: {
+      name: user?.name ?? '',
+      email: user?.email ?? '',
+      bio: 'Product designer and developer based in San Francisco.',
+    },
   });
 
   function onSubmit(data: ProfileForm) {
     toast.promise(new Promise((r) => setTimeout(r, 1200)), {
-      loading: 'Saving profile…',
+      loading: 'Saving profile...',
       success: `Profile updated for ${data.name}`,
       error: 'Failed to save.',
     });
   }
 
   return (
-    <ContentContainer size="sm">
-      <PageHeader title="Settings" description="Manage your profile and preferences." />
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Profile</CardTitle>
-          <CardDescription>Update your display name and email address.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+    <Card>
+      <CardHeader>
+        <CardTitle>Profile</CardTitle>
+        <CardDescription>Update your personal information and public profile.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
+          <div className="grid gap-4 sm:grid-cols-2">
             <div className="grid gap-2">
               <Label htmlFor="name">Display name</Label>
-              <Input id="name" {...register('name')} />
+              <Input
+                id="name"
+                placeholder="Your display name"
+                {...register('name', {
+                  required: 'Display name is required',
+                  minLength: { value: 2, message: 'Must be at least 2 characters' },
+                })}
+              />
+              {errors.name && <p className="text-destructive text-sm">{errors.name.message}</p>}
             </div>
             <div className="grid gap-2">
               <Label htmlFor="email">Email</Label>
-              <Input id="email" type="email" {...register('email')} />
+              <Input
+                id="email"
+                type="email"
+                placeholder="you@example.com"
+                {...register('email', {
+                  required: 'Email is required',
+                  pattern: { value: /^\S+@\S+\.\S+$/, message: 'Invalid email address' },
+                })}
+              />
+              {errors.email && <p className="text-destructive text-sm">{errors.email.message}</p>}
             </div>
-            <div className="flex justify-end">
-              <Button type="submit" size="sm">
-                Save changes
-              </Button>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="role">Role</Label>
+            <Select defaultValue="admin">
+              <SelectTrigger id="role">
+                <SelectValue placeholder="Select a role" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="admin">Admin</SelectItem>
+                <SelectItem value="editor">Editor</SelectItem>
+                <SelectItem value="viewer">Viewer</SelectItem>
+                <SelectItem value="billing">Billing</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-muted-foreground text-sm">
+              This controls your access level across the platform.
+            </p>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="bio">Bio</Label>
+            <Textarea
+              id="bio"
+              placeholder="Tell us about yourself..."
+              rows={3}
+              {...register('bio', {
+                maxLength: { value: 300, message: 'Bio must be under 300 characters' },
+              })}
+            />
+            {errors.bio && <p className="text-destructive text-sm">{errors.bio.message}</p>}
+            <p className="text-muted-foreground text-sm">
+              Brief description for your profile. Max 300 characters.
+            </p>
+          </div>
+
+          <div className="flex justify-end">
+            <Button type="submit" size="sm">
+              Save changes
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Notifications Section
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function NotificationsSection() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Notifications</CardTitle>
+        <CardDescription>Choose how and when you want to be notified.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-5">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label>Email notifications</Label>
+                <p className="text-muted-foreground text-sm">
+                  Receive email updates about your account activity.
+                </p>
+              </div>
+              <Switch defaultChecked />
             </div>
-          </form>
-        </CardContent>
-      </Card>
+            <Separator />
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label>Push notifications</Label>
+                <p className="text-muted-foreground text-sm">
+                  Get notified in your browser when something happens.
+                </p>
+              </div>
+              <Switch defaultChecked />
+            </div>
+            <Separator />
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <div className="flex items-center gap-2">
+                  <Label>Security alerts</Label>
+                  <Badge variant="secondary" className="text-xs">
+                    Recommended
+                  </Badge>
+                </div>
+                <p className="text-muted-foreground text-sm">
+                  Critical alerts about your account security.
+                </p>
+              </div>
+              <Switch defaultChecked />
+            </div>
+            <Separator />
+            <div className="space-y-3">
+              <Label className="text-base">Communication preferences</Label>
+              <div className="flex items-start gap-2">
+                <Checkbox id="marketing" />
+                <div className="grid gap-0.5 leading-none">
+                  <Label htmlFor="marketing" className="font-normal">
+                    Marketing emails
+                  </Label>
+                  <p className="text-muted-foreground text-sm">
+                    Receive emails about new features and product updates.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start gap-2">
+                <Checkbox id="digest" defaultChecked />
+                <div className="grid gap-0.5 leading-none">
+                  <Label htmlFor="digest" className="font-normal">
+                    Weekly digest
+                  </Label>
+                  <p className="text-muted-foreground text-sm">
+                    Get a weekly summary of your account activity.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
 
-      <Separator />
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              onClick={() =>
+                toast.promise(new Promise((r) => setTimeout(r, 800)), {
+                  loading: 'Updating preferences...',
+                  success: 'Notification preferences saved',
+                  error: 'Failed to update.',
+                })
+              }
+            >
+              Save preferences
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Appearance</CardTitle>
-          <CardDescription>Toggle between light, dark, and system theme.</CardDescription>
-        </CardHeader>
-        <CardContent className="flex items-center justify-between">
-          <span className="text-sm">Color scheme</span>
+/* ────────────────────────────────────────────────────────────────────────
+ * Appearance Section
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function AppearanceSection() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Appearance</CardTitle>
+        <CardDescription>Customize the look and feel of the application.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label>Color scheme</Label>
+            <p className="text-muted-foreground text-sm">
+              Toggle between light, dark, and system theme.
+            </p>
+          </div>
           <ThemeToggleDropdown />
-        </CardContent>
-      </Card>
+        </div>
+        <Separator />
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label>Sidebar position</Label>
+            <p className="text-muted-foreground text-sm">
+              Choose where the navigation sidebar appears.
+            </p>
+          </div>
+          <Select defaultValue="left">
+            <SelectTrigger className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="left">Left</SelectItem>
+              <SelectItem value="right">Right</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <Separator />
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label>Compact mode</Label>
+            <p className="text-muted-foreground text-sm">
+              Reduce spacing and padding for a denser layout.
+            </p>
+          </div>
+          <Switch />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Page
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export default function SettingsPage() {
+  return (
+    <ContentContainer size="sm">
+      <PageHeader
+        title="Settings"
+        description="Manage your profile, notifications, and preferences."
+      />
+
+      <Tabs defaultValue="profile" className="w-full">
+        <TabsList>
+          <TabsTrigger value="profile">
+            <User className="size-4" />
+            Profile
+          </TabsTrigger>
+          <TabsTrigger value="notifications">
+            <Bell className="size-4" />
+            Notifications
+          </TabsTrigger>
+          <TabsTrigger value="appearance">
+            <Palette className="size-4" />
+            Appearance
+          </TabsTrigger>
+          <TabsTrigger value="security">
+            <Shield className="size-4" />
+            Security
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="profile">
+          <ProfileSection />
+        </TabsContent>
+
+        <TabsContent value="notifications">
+          <NotificationsSection />
+        </TabsContent>
+
+        <TabsContent value="appearance">
+          <AppearanceSection />
+        </TabsContent>
+
+        <TabsContent value="security">
+          <Card>
+            <CardHeader>
+              <CardTitle>Security</CardTitle>
+              <CardDescription>Manage your password and two-factor authentication.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label>Password</Label>
+                  <p className="text-muted-foreground text-sm">Last changed 30 days ago.</p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => toast.info('Password change dialog would open here.')}
+                >
+                  Change password
+                </Button>
+              </div>
+              <Separator />
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <div className="flex items-center gap-2">
+                    <Label>Two-factor authentication</Label>
+                    <Badge variant="outline" className="text-xs">
+                      Off
+                    </Badge>
+                  </div>
+                  <p className="text-muted-foreground text-sm">
+                    Add an extra layer of security to your account.
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => toast.info('2FA setup wizard would open here.')}
+                >
+                  Enable
+                </Button>
+              </div>
+              <Separator />
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label>Active sessions</Label>
+                  <p className="text-muted-foreground text-sm">
+                    You are currently signed in on 1 device.
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => toast.warning('This would sign out all other sessions.')}
+                >
+                  Sign out all
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
     </ContentContainer>
   );
 }

--- a/packages/next-shell/package.json
+++ b/packages/next-shell/package.json
@@ -28,6 +28,9 @@
     "node": ">=20"
   },
   "type": "module",
+  "bin": {
+    "next-shell-theme": "./dist/cli/generate-theme.js"
+  },
   "sideEffects": [
     "**/*.css"
   ],
@@ -127,6 +130,12 @@
     "./styles/presets/red.css": "./src/styles/presets/red.css",
     "./styles/presets/violet.css": "./src/styles/presets/violet.css",
     "./fonts/BigBlueTerminal.woff2": "./dist/fonts/BigBlueTerminal.woff2",
+    "./cli/generate-theme": {
+      "source": "./src/cli/generate-theme.ts",
+      "types": "./dist/cli/generate-theme.d.ts",
+      "import": "./dist/cli/generate-theme.js",
+      "require": "./dist/cli/generate-theme.cjs"
+    },
     "./tailwind-preset": {
       "source": "./src/tailwind-preset/index.ts",
       "types": "./dist/tailwind-preset/index.d.ts",

--- a/packages/next-shell/src/cli/generate-theme.ts
+++ b/packages/next-shell/src/cli/generate-theme.ts
@@ -1,0 +1,415 @@
+#!/usr/bin/env node
+/* eslint-disable next-shell/no-raw-colors -- This module generates OKLCH color values by design. */
+
+/**
+ * @jonmatum/next-shell — theme generator CLI
+ *
+ * Takes a brand hex color and generates a complete BrandOverrides object + CSS
+ * file. Uses the existing `hexToOklch()` utility for color conversion, then
+ * derives a full semantic palette via hue rotation and lightness shifts.
+ *
+ * Usage:
+ *   next-shell-theme --color '#10b981'
+ *   next-shell-theme --color '#10b981' --name my-brand --format both
+ *
+ * Options:
+ *   --color   Required. Brand hex color (3- or 6-digit, with or without #).
+ *   --name    Optional. Theme name used in output filenames. Defaults to "custom".
+ *   --format  Optional. Output format: "css", "json", or "both". Defaults to "both".
+ */
+
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { hexToOklch, brandOverridesCss, type BrandOverrides } from '../tokens/index.js';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * OKLCH parsing and formatting helpers
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export interface OklchComponents {
+  L: number;
+  C: number;
+  H: number;
+}
+
+/**
+ * Parse an OKLCH CSS string like `oklch(0.627 0.194 163.1)` into numeric
+ * components. L is 0-1, C is a positive decimal, H is degrees [0, 360).
+ */
+export function parseOklch(oklchStr: string): OklchComponents {
+  const match = oklchStr.match(/oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)\s*\)/);
+  if (!match) {
+    throw new Error(`parseOklch: invalid OKLCH string "${oklchStr}"`);
+  }
+  return {
+    L: parseFloat(match[1]!),
+    C: parseFloat(match[2]!),
+    H: parseFloat(match[3]!),
+  };
+}
+
+/**
+ * Format OKLCH components back into a CSS string. Matches the precision
+ * used by `hexToOklch`: L to 3 decimals, C to 3 decimals, H to 1 decimal.
+ */
+export function formatOklch(components: OklchComponents): string {
+  return `oklch(${components.L.toFixed(3)} ${components.C.toFixed(3)} ${components.H.toFixed(1)})`;
+}
+
+/**
+ * Clamp a number between min and max.
+ */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Normalize a hue to the [0, 360) range.
+ */
+function normalizeHue(hue: number): number {
+  return ((hue % 360) + 360) % 360;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * OKLCH → sRGB → WCAG luminance (correct pipeline)
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** OKLCH → OKLab: L stays, a = C*cos(H in rad), b = C*sin(H in rad) */
+function oklchToOklab(L: number, C: number, H: number) {
+  const hRad = (H * Math.PI) / 180;
+  return { L, a: C * Math.cos(hRad), b: C * Math.sin(hRad) };
+}
+
+/** OKLab → linear sRGB via Ottosson inverse matrices */
+function oklabToLinearRGB(L: number, a: number, b: number) {
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+  const l = l_ * l_ * l_;
+  const m = m_ * m_ * m_;
+  const s = s_ * s_ * s_;
+  return {
+    R: +4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    G: -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    B: -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  };
+}
+
+/** Linear sRGB → gamma-encoded sRGB */
+function linearToSrgb(c: number): number {
+  const v = Math.max(0, c);
+  if (v <= 0.0031308) return 12.92 * v;
+  return 1.055 * Math.pow(v, 1 / 2.4) - 0.055;
+}
+
+/** Gamma-encoded sRGB → linear for WCAG */
+function srgbToLinear(c: number): number {
+  if (c <= 0.04045) return c / 12.92;
+  return Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/** WCAG 2.1 relative luminance from OKLCH components */
+function oklchLuminance(L: number, C: number, H: number): number {
+  const lab = oklchToOklab(L, C, H);
+  const lin = oklabToLinearRGB(lab.L, lab.a, lab.b);
+  const r = Math.max(0, Math.min(1, linearToSrgb(lin.R)));
+  const g = Math.max(0, Math.min(1, linearToSrgb(lin.G)));
+  const b = Math.max(0, Math.min(1, linearToSrgb(lin.B)));
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+
+/** WCAG contrast ratio */
+function wcagContrastRatio(lum1: number, lum2: number): number {
+  const lighter = Math.max(lum1, lum2);
+  const darker = Math.min(lum1, lum2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Binary search for OKLCH L that achieves the target WCAG luminance,
+ * keeping C and H constant.
+ */
+function findLForLuminance(C: number, H: number, targetLum: number): number {
+  let lo = 0;
+  let hi = 1;
+  for (let i = 0; i < 64; i++) {
+    const mid = (lo + hi) / 2;
+    const lum = oklchLuminance(mid, C, H);
+    if (lum < targetLum) lo = mid;
+    else hi = mid;
+  }
+  return (lo + hi) / 2;
+}
+
+/**
+ * Ensure a background OKLCH color has at least `minRatio`:1 contrast
+ * against a given foreground. Adjusts L (darkens) if needed.
+ */
+function ensureContrast(bg: OklchComponents, fgLum: number, minRatio: number): OklchComponents {
+  const bgLum = oklchLuminance(bg.L, bg.C, bg.H);
+  const ratio = wcagContrastRatio(fgLum, bgLum);
+  if (ratio >= minRatio) return bg;
+
+  // fg is lighter → darken bg: fgLum+0.05 >= minRatio*(bgLum+0.05)
+  // bgLum <= (fgLum+0.05)/minRatio - 0.05
+  if (fgLum >= bgLum) {
+    const maxBgLum = (fgLum + 0.05) / minRatio - 0.05;
+    const newL = findLForLuminance(bg.C, bg.H, Math.max(0, maxBgLum));
+    return { L: Math.round(newL * 1000) / 1000, C: bg.C, H: bg.H };
+  }
+  // fg is darker → lighten bg
+  const minBgLum = minRatio * (fgLum + 0.05) - 0.05;
+  const newL = findLForLuminance(bg.C, bg.H, Math.min(1, minBgLum));
+  return { L: Math.round(newL * 1000) / 1000, C: bg.C, H: bg.H };
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Palette derivation — generate a complete theme from a single brand color
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Derive a complete BrandOverrides from a single hex brand color.
+ *
+ * The algorithm:
+ * - primary: the input color (light: as-is or clamped; dark: lightened)
+ * - primary-foreground: white for dark primaries, near-black for light
+ * - accent: same hue, reduced chroma, shifted lightness
+ * - accent-foreground: contrasting text for accent surface
+ * - destructive: hue rotated toward red (~25°), similar L/C
+ * - destructive-foreground: white
+ * - ring: same as primary
+ * - chart-1..5: hue rotations at 0°, 72°, 144°, 216°, 288°
+ */
+export function generateTheme(hex: string): BrandOverrides {
+  const oklchStr = hexToOklch(hex);
+  const base = parseOklch(oklchStr);
+
+  return {
+    light: generateLightPalette(base),
+    dark: generateDarkPalette(base),
+  };
+}
+
+function generateLightPalette(base: OklchComponents): NonNullable<BrandOverrides['light']> {
+  const { C, H } = base;
+  const primaryC = clamp(C, 0.05, 0.25);
+
+  // White foreground luminance (oklch 0.985 0 0)
+  const whiteFgLum = oklchLuminance(0.985, 0, 0);
+
+  // Start with a reasonable L, then use ensureContrast to guarantee WCAG AA.
+  const primaryInitial: OklchComponents = { L: clamp(base.L, 0.35, 0.55), C: primaryC, H };
+  const primary = ensureContrast(primaryInitial, whiteFgLum, 4.6);
+
+  const destructiveH = 25;
+  const destructiveC = clamp(primaryC * 1.2, 0.15, 0.245);
+  const destructiveInitial: OklchComponents = { L: 0.5, C: destructiveC, H: destructiveH };
+  const destructive = ensureContrast(destructiveInitial, whiteFgLum, 4.6);
+
+  return {
+    primary: formatOklch(primary),
+    'primary-foreground': 'oklch(0.985 0 0)',
+    accent: formatOklch({ L: 0.95, C: clamp(primaryC * 0.15, 0.005, 0.03), H }),
+    'accent-foreground': formatOklch({ L: 0.25, C: clamp(primaryC * 0.25, 0.01, 0.06), H }),
+    destructive: formatOklch(destructive),
+    'destructive-foreground': 'oklch(0.985 0 0)',
+    ring: formatOklch(primary),
+    'chart-1': formatOklch({ L: primary.L, C: primaryC, H: normalizeHue(H) }),
+    'chart-2': formatOklch({
+      L: clamp(primary.L + 0.1, 0.45, 0.75),
+      C: clamp(primaryC * 0.85, 0.04, 0.2),
+      H: normalizeHue(H + 72),
+    }),
+    'chart-3': formatOklch({
+      L: clamp(primary.L - 0.1, 0.35, 0.6),
+      C: clamp(primaryC * 0.75, 0.04, 0.2),
+      H: normalizeHue(H + 144),
+    }),
+    'chart-4': formatOklch({
+      L: clamp(primary.L + 0.15, 0.5, 0.8),
+      C: clamp(primaryC * 0.8, 0.04, 0.2),
+      H: normalizeHue(H + 216),
+    }),
+    'chart-5': formatOklch({
+      L: clamp(primary.L + 0.05, 0.45, 0.7),
+      C: clamp(primaryC * 0.7, 0.04, 0.2),
+      H: normalizeHue(H + 288),
+    }),
+  };
+}
+
+function generateDarkPalette(base: OklchComponents): NonNullable<BrandOverrides['dark']> {
+  const { C, H } = base;
+  const primaryC = clamp(C, 0.05, 0.25);
+
+  // Dark mode foreground luminances
+  const darkPrimaryFg: OklchComponents = { L: 0.13, C: 0.02, H };
+  const darkPrimaryFgLum = oklchLuminance(darkPrimaryFg.L, darkPrimaryFg.C, darkPrimaryFg.H);
+
+  // Start with lightened L, then ensure contrast with dark fg.
+  const primaryInitial: OklchComponents = {
+    L: clamp(base.L + 0.15, 0.7, 0.85),
+    C: primaryC,
+    H,
+  };
+  const primary = ensureContrast(primaryInitial, darkPrimaryFgLum, 4.6);
+
+  const destructiveH = 22;
+  const destructiveC = clamp(primaryC * 1.0, 0.12, 0.191);
+  const darkDestructiveFg: OklchComponents = { L: 0.13, C: 0.02, H: destructiveH };
+  const darkDestructiveFgLum = oklchLuminance(
+    darkDestructiveFg.L,
+    darkDestructiveFg.C,
+    darkDestructiveFg.H,
+  );
+  const destructiveInitial: OklchComponents = { L: 0.75, C: destructiveC, H: destructiveH };
+  const destructive = ensureContrast(destructiveInitial, darkDestructiveFgLum, 4.6);
+
+  return {
+    primary: formatOklch(primary),
+    'primary-foreground': formatOklch(darkPrimaryFg),
+    accent: formatOklch({ L: 0.2, C: clamp(primaryC * 0.18, 0.005, 0.04), H }),
+    'accent-foreground': formatOklch({ L: 0.92, C: clamp(primaryC * 0.12, 0.005, 0.03), H }),
+    destructive: formatOklch(destructive),
+    'destructive-foreground': formatOklch(darkDestructiveFg),
+    ring: formatOklch(primary),
+    'chart-1': formatOklch({ L: primary.L, C: primaryC, H: normalizeHue(H) }),
+    'chart-2': formatOklch({
+      L: clamp(primary.L + 0.05, 0.7, 0.85),
+      C: clamp(primaryC * 0.8, 0.04, 0.18),
+      H: normalizeHue(H + 72),
+    }),
+    'chart-3': formatOklch({
+      L: clamp(primary.L - 0.15, 0.5, 0.7),
+      C: clamp(primaryC * 0.7, 0.04, 0.18),
+      H: normalizeHue(H + 144),
+    }),
+    'chart-4': formatOklch({
+      L: clamp(primary.L + 0.1, 0.75, 0.9),
+      C: clamp(primaryC * 0.75, 0.04, 0.18),
+      H: normalizeHue(H + 216),
+    }),
+    'chart-5': formatOklch({
+      L: clamp(primary.L + 0.02, 0.65, 0.8),
+      C: clamp(primaryC * 0.65, 0.04, 0.18),
+      H: normalizeHue(H + 288),
+    }),
+  };
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * CSS output — generates a standalone CSS file like the preset files
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Build a CSS preset file from a BrandOverrides and a theme name.
+ */
+export function generateCss(overrides: BrandOverrides, name: string): string {
+  const header = [
+    '/*!',
+    ` * @jonmatum/next-shell — ${name} color palette (auto-generated)`,
+    ' *',
+    ' * Import after the base preset:',
+    ' *',
+    ' *   @import "@jonmatum/next-shell/styles/preset.css";',
+    ` *   @import "./${name}.css";`,
+    ' */',
+    '',
+  ].join('\n');
+
+  return header + brandOverridesCss(overrides) + '\n';
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * CLI argument parsing and main
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export interface CliOptions {
+  color: string;
+  name: string;
+  format: 'css' | 'json' | 'both';
+}
+
+/**
+ * Parse CLI arguments from argv. Expects `--color`, `--name`, `--format`.
+ * Throws on missing required `--color`.
+ */
+export function parseArgs(argv: string[]): CliOptions {
+  let color: string | undefined;
+  let name = 'custom';
+  let format: 'css' | 'json' | 'both' = 'both';
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--color' && i + 1 < argv.length) {
+      color = argv[++i]!;
+    } else if (arg === '--name' && i + 1 < argv.length) {
+      name = argv[++i]!;
+    } else if (arg === '--format' && i + 1 < argv.length) {
+      const val = argv[++i]!;
+      if (val !== 'css' && val !== 'json' && val !== 'both') {
+        throw new Error(`Invalid --format "${val}". Expected "css", "json", or "both".`);
+      }
+      format = val;
+    }
+  }
+
+  if (!color) {
+    throw new Error(
+      'Missing required --color argument.\n' +
+        "Usage: next-shell-theme --color '#10b981' [--name my-brand] [--format css|json|both]",
+    );
+  }
+
+  return { color, name, format };
+}
+
+/**
+ * Main entry point for the CLI. Returns the generated BrandOverrides and
+ * CSS string (for testability), and optionally writes files to disk.
+ */
+export function main(
+  argv: string[],
+  options: { writeToDisk?: boolean; cwd?: string } = {},
+): { overrides: BrandOverrides; css: string } {
+  const { writeToDisk = true, cwd = process.cwd() } = options;
+  const opts = parseArgs(argv);
+
+  const overrides = generateTheme(opts.color);
+  const css = generateCss(overrides, opts.name);
+
+  if (writeToDisk) {
+    if (opts.format === 'css' || opts.format === 'both') {
+      const cssPath = resolve(cwd, `${opts.name}.css`);
+      writeFileSync(cssPath, css, 'utf8');
+      console.log(`✓ CSS written to ${cssPath}`);
+    }
+    if (opts.format === 'json' || opts.format === 'both') {
+      const jsonPath = resolve(cwd, `${opts.name}.json`);
+      writeFileSync(jsonPath, JSON.stringify(overrides, null, 2) + '\n', 'utf8');
+      console.log(`✓ JSON written to ${jsonPath}`);
+    }
+  }
+
+  return { overrides, css };
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Run when invoked as a script
+ * ──────────────────────────────────────────────────────────────────────── */
+
+// Only execute when run directly (not when imported as a module).
+// Node populates `process.argv` as [node, script, ...args].
+const isDirectRun =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  (process.argv[1].endsWith('generate-theme.js') || process.argv[1].endsWith('generate-theme.cjs'));
+
+if (isDirectRun) {
+  try {
+    main(process.argv.slice(2));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}

--- a/packages/next-shell/src/styles/tokens.css
+++ b/packages/next-shell/src/styles/tokens.css
@@ -61,7 +61,7 @@
   --popover-foreground: oklch(0.22 0.012 263);
 
   --muted: oklch(0.96 0.005 258);
-  --muted-foreground: oklch(0.55 0.01 258);
+  --muted-foreground: oklch(0.535 0.01 258);
 
   --accent: oklch(0.955 0.008 258);
   --accent-foreground: oklch(0.22 0.012 263);
@@ -75,13 +75,13 @@
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
 
-  --success: oklch(0.65 0.17 145);
+  --success: oklch(0.535 0.17 145);
   --success-foreground: oklch(0.985 0 0);
 
   --warning: oklch(0.78 0.17 85);
   --warning-foreground: oklch(0.22 0.012 263);
 
-  --info: oklch(0.7 0.13 230);
+  --info: oklch(0.539 0.13 230);
   --info-foreground: oklch(0.985 0 0);
 
   --border: oklch(0.93 0.005 258);
@@ -220,43 +220,43 @@
   --accent-foreground: oklch(0.94 0.006 258);
 
   /* Primary: #3b82f6 from jonmatum.dev brand blue. */
-  --primary: oklch(0.6 0.19 258);
+  --primary: oklch(0.558 0.19 258);
   --primary-foreground: oklch(0.985 0 0);
 
   --secondary: oklch(0.2 0.018 253);
   --secondary-foreground: oklch(0.94 0.006 258);
 
-  --destructive: oklch(0.704 0.191 22.216);
+  --destructive: oklch(0.576 0.191 22.216);
   --destructive-foreground: oklch(0.985 0 0);
 
-  --success: oklch(0.72 0.15 145);
+  --success: oklch(0.537 0.15 145);
   --success-foreground: oklch(0.985 0 0);
 
   --warning: oklch(0.82 0.16 85);
   --warning-foreground: oklch(0.12 0.015 263);
 
-  --info: oklch(0.78 0.12 230);
+  --info: oklch(0.542 0.12 230);
   --info-foreground: oklch(0.985 0 0);
 
   --border: oklch(0.24 0.022 253);
   --input: oklch(0.27 0.022 253);
-  --ring: oklch(0.6 0.19 258);
+  --ring: oklch(0.558 0.19 258);
 
   /* Scrim stays dark in both themes. */
   --overlay: oklch(0 0 0 / 0.6);
 
   --sidebar: oklch(0.12 0.018 263);
   --sidebar-foreground: oklch(0.94 0.006 258);
-  --sidebar-primary: oklch(0.6 0.19 258);
+  --sidebar-primary: oklch(0.558 0.19 258);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.2 0.02 258);
   --sidebar-accent-foreground: oklch(0.94 0.006 258);
   --sidebar-border: oklch(0.24 0.022 253);
-  --sidebar-ring: oklch(0.6 0.19 258);
+  --sidebar-ring: oklch(0.558 0.19 258);
 
   /* Chart palette: brand blue → cyan → soft blue → soft cyan → success green
      matching jonmatum.dev chart tokens: #3b82f6, #22d3ee, #60a5fa, #67e8f9, #86efac */
-  --chart-1: oklch(0.6 0.19 258);
+  --chart-1: oklch(0.558 0.19 258);
   --chart-2: oklch(0.83 0.14 201);
   --chart-3: oklch(0.67 0.15 258);
   --chart-4: oklch(0.87 0.1 198);

--- a/packages/next-shell/tests/generate-theme.test.ts
+++ b/packages/next-shell/tests/generate-theme.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateTheme,
+  generateCss,
+  parseOklch,
+  formatOklch,
+  parseArgs,
+  main,
+} from '../src/cli/generate-theme.js';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * OKLCH helpers
+ * ──────────────────────────────────────────────────────────────────────── */
+
+describe('parseOklch', () => {
+  it('parses a valid OKLCH string', () => {
+    const result = parseOklch('oklch(0.696 0.149 162.5)');
+    expect(result).toEqual({ L: 0.696, C: 0.149, H: 162.5 });
+  });
+
+  it('throws on invalid input', () => {
+    expect(() => parseOklch('rgb(255, 0, 0)')).toThrow('invalid OKLCH');
+    expect(() => parseOklch('')).toThrow('invalid OKLCH');
+  });
+});
+
+describe('formatOklch', () => {
+  it('formats components to CSS string', () => {
+    const result = formatOklch({ L: 0.696, C: 0.149, H: 162.5 });
+    expect(result).toBe('oklch(0.696 0.149 162.5)');
+  });
+
+  it('rounds to correct precision', () => {
+    const result = formatOklch({ L: 0.6963, C: 0.14856, H: 162.49 });
+    expect(result).toBe('oklch(0.696 0.149 162.5)');
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Theme generation — valid OKLCH from hex
+ * ──────────────────────────────────────────────────────────────────────── */
+
+describe('generateTheme', () => {
+  const OKLCH_RE = /^oklch\(\d+(?:\.\d+)? \d+(?:\.\d+)? \d+(?:\.\d+)?\)$/;
+
+  describe('generates valid OKLCH values from hex input', () => {
+    const testCases: [string, string][] = [
+      ['#10b981', 'emerald'],
+      ['#3b82f6', 'blue'],
+      ['#ef4444', 'red'],
+      ['#8b5cf6', 'violet'],
+      ['#f97316', 'orange'],
+    ];
+
+    for (const [hex, label] of testCases) {
+      it(`${label} (${hex})`, () => {
+        const theme = generateTheme(hex);
+
+        // All light values must be valid OKLCH
+        for (const [key, value] of Object.entries(theme.light!)) {
+          expect(value, `light.${key}`).toMatch(OKLCH_RE);
+        }
+
+        // All dark values must be valid OKLCH
+        for (const [key, value] of Object.entries(theme.dark!)) {
+          expect(value, `dark.${key}`).toMatch(OKLCH_RE);
+        }
+      });
+    }
+  });
+
+  describe('produces both light and dark variants', () => {
+    it('has light and dark keys', () => {
+      const theme = generateTheme('#10b981');
+      expect(theme.light).toBeDefined();
+      expect(theme.dark).toBeDefined();
+    });
+
+    it('light and dark each have all required tokens', () => {
+      const theme = generateTheme('#10b981');
+      const requiredTokens = [
+        'primary',
+        'primary-foreground',
+        'accent',
+        'accent-foreground',
+        'destructive',
+        'destructive-foreground',
+        'ring',
+        'chart-1',
+        'chart-2',
+        'chart-3',
+        'chart-4',
+        'chart-5',
+      ];
+
+      const lightKeys = Object.keys(theme.light!);
+      const darkKeys = Object.keys(theme.dark!);
+
+      for (const token of requiredTokens) {
+        expect(lightKeys, `light missing ${token}`).toContain(token);
+        expect(darkKeys, `dark missing ${token}`).toContain(token);
+      }
+    });
+
+    it('dark primary is lighter than light primary', () => {
+      const theme = generateTheme('#10b981');
+      const lightPrimary = parseOklch(theme.light!.primary!);
+      const darkPrimary = parseOklch(theme.dark!.primary!);
+      expect(darkPrimary.L).toBeGreaterThan(lightPrimary.L);
+    });
+  });
+
+  describe('foreground/background WCAG AA contrast', () => {
+    /**
+     * Correct OKLCH → sRGB → WCAG 2.1 relative luminance pipeline.
+     */
+    function oklchLuminance(L: number, C: number, H: number): number {
+      const hRad = (H * Math.PI) / 180;
+      const a = C * Math.cos(hRad);
+      const b = C * Math.sin(hRad);
+      const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+      const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+      const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+      const l = l_ * l_ * l_;
+      const m = m_ * m_ * m_;
+      const s = s_ * s_ * s_;
+      const R = +4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+      const G = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+      const B = -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s;
+      function toSrgb(c: number) {
+        const v = Math.max(0, c);
+        return v <= 0.0031308 ? 12.92 * v : 1.055 * Math.pow(v, 1 / 2.4) - 0.055;
+      }
+      function toLin(c: number) {
+        const v = Math.max(0, Math.min(1, c));
+        return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+      }
+      return 0.2126 * toLin(toSrgb(R)) + 0.7152 * toLin(toSrgb(G)) + 0.0722 * toLin(toSrgb(B));
+    }
+
+    /**
+     * WCAG 2.x contrast ratio between two relative luminance values.
+     */
+    function contrastRatio(y1: number, y2: number): number {
+      const lighter = Math.max(y1, y2);
+      const darker = Math.min(y1, y2);
+      return (lighter + 0.05) / (darker + 0.05);
+    }
+
+    /**
+     * Check WCAG AA contrast (>= 4.5:1) for a bg/fg OKLCH pair.
+     * Uses correct OKLCH → sRGB → WCAG luminance pipeline.
+     */
+    function checkContrast(bgStr: string, fgStr: string): number {
+      const bg = parseOklch(bgStr);
+      const fg = parseOklch(fgStr);
+      const bgY = oklchLuminance(bg.L, bg.C, bg.H);
+      const fgY = oklchLuminance(fg.L, fg.C, fg.H);
+      return contrastRatio(bgY, fgY);
+    }
+
+    const contrastPairs: [string, string][] = [
+      ['primary', 'primary-foreground'],
+      ['accent', 'accent-foreground'],
+      ['destructive', 'destructive-foreground'],
+    ];
+
+    const hexColors = ['#10b981', '#3b82f6', '#ef4444', '#8b5cf6', '#f97316'];
+
+    for (const hex of hexColors) {
+      describe(`contrast for ${hex}`, () => {
+        const theme = generateTheme(hex);
+
+        for (const [bgToken, fgToken] of contrastPairs) {
+          it(`light: ${bgToken} / ${fgToken} >= 4.5:1`, () => {
+            const ratio = checkContrast(
+              theme.light![bgToken as keyof typeof theme.light]!,
+              theme.light![fgToken as keyof typeof theme.light]!,
+            );
+            expect(ratio).toBeGreaterThanOrEqual(4.5);
+          });
+
+          it(`dark: ${bgToken} / ${fgToken} >= 4.5:1`, () => {
+            const ratio = checkContrast(
+              theme.dark![bgToken as keyof typeof theme.dark]!,
+              theme.dark![fgToken as keyof typeof theme.dark]!,
+            );
+            expect(ratio).toBeGreaterThanOrEqual(4.5);
+          });
+        }
+      });
+    }
+  });
+
+  describe('handles 3-digit and 6-digit hex', () => {
+    it('3-digit hex (#f00)', () => {
+      const theme = generateTheme('#f00');
+      expect(theme.light).toBeDefined();
+      expect(theme.dark).toBeDefined();
+      expect(theme.light!.primary).toMatch(/^oklch\(/);
+    });
+
+    it('6-digit hex (#ff0000)', () => {
+      const theme = generateTheme('#ff0000');
+      expect(theme.light).toBeDefined();
+      expect(theme.dark).toBeDefined();
+      expect(theme.light!.primary).toMatch(/^oklch\(/);
+    });
+
+    it('3-digit and 6-digit equivalent produce same result', () => {
+      const theme3 = generateTheme('#f00');
+      const theme6 = generateTheme('#ff0000');
+      expect(theme3.light!.primary).toBe(theme6.light!.primary);
+      expect(theme3.dark!.primary).toBe(theme6.dark!.primary);
+    });
+
+    it('hex without # prefix', () => {
+      const withHash = generateTheme('#10b981');
+      const withoutHash = generateTheme('10b981');
+      expect(withHash.light!.primary).toBe(withoutHash.light!.primary);
+    });
+  });
+
+  describe('throws on invalid input', () => {
+    it('throws on empty string', () => {
+      expect(() => generateTheme('')).toThrow();
+    });
+
+    it('throws on non-hex string', () => {
+      expect(() => generateTheme('not-a-color')).toThrow();
+    });
+
+    it('throws on invalid hex length', () => {
+      expect(() => generateTheme('#1234')).toThrow();
+    });
+
+    it('throws on non-hex characters', () => {
+      expect(() => generateTheme('#gggggg')).toThrow();
+    });
+  });
+
+  describe('hue rotation for chart colors', () => {
+    it('chart colors span distinct hues', () => {
+      const theme = generateTheme('#10b981');
+      const charts = [
+        theme.light!['chart-1']!,
+        theme.light!['chart-2']!,
+        theme.light!['chart-3']!,
+        theme.light!['chart-4']!,
+        theme.light!['chart-5']!,
+      ];
+
+      const hues = charts.map((c) => parseOklch(c).H);
+
+      // All 5 hues should be distinct (at least 30° apart on average)
+      for (let i = 0; i < hues.length; i++) {
+        for (let j = i + 1; j < hues.length; j++) {
+          const diff = Math.abs(hues[i]! - hues[j]!);
+          const angularDiff = Math.min(diff, 360 - diff);
+          expect(angularDiff).toBeGreaterThan(20);
+        }
+      }
+    });
+  });
+
+  describe('destructive hue points toward red', () => {
+    it('light destructive hue is near 25°', () => {
+      const theme = generateTheme('#10b981');
+      const destructive = parseOklch(theme.light!.destructive!);
+      expect(destructive.H).toBeGreaterThanOrEqual(20);
+      expect(destructive.H).toBeLessThanOrEqual(30);
+    });
+
+    it('dark destructive hue is near 22°', () => {
+      const theme = generateTheme('#10b981');
+      const destructive = parseOklch(theme.dark!.destructive!);
+      expect(destructive.H).toBeGreaterThanOrEqual(18);
+      expect(destructive.H).toBeLessThanOrEqual(26);
+    });
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * CSS generation
+ * ──────────────────────────────────────────────────────────────────────── */
+
+describe('generateCss', () => {
+  it('produces valid CSS with light and dark blocks', () => {
+    const theme = generateTheme('#10b981');
+    const css = generateCss(theme, 'test-brand');
+
+    expect(css).toContain(":root, [data-theme='light']");
+    expect(css).toContain("[data-theme='dark']");
+    expect(css).toContain('--primary:');
+    expect(css).toContain('--chart-5:');
+  });
+
+  it('includes the theme name in the header comment', () => {
+    const theme = generateTheme('#10b981');
+    const css = generateCss(theme, 'emerald-brand');
+    expect(css).toContain('emerald-brand');
+  });
+
+  it('all values in the CSS are OKLCH', () => {
+    const theme = generateTheme('#3b82f6');
+    const css = generateCss(theme, 'blue');
+
+    const valueLines = css
+      .split('\n')
+      .filter((line) => {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('/*') || trimmed.startsWith('*')) return false;
+        return trimmed.startsWith('--') && trimmed.includes(':');
+      })
+      .map((line) => line.trim());
+
+    for (const line of valueLines) {
+      expect(line).toMatch(/oklch\(/);
+    }
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * CLI argument parsing
+ * ──────────────────────────────────────────────────────────────────────── */
+
+describe('parseArgs', () => {
+  it('parses --color', () => {
+    const opts = parseArgs(['--color', '#10b981']);
+    expect(opts.color).toBe('#10b981');
+    expect(opts.name).toBe('custom');
+    expect(opts.format).toBe('both');
+  });
+
+  it('parses --name', () => {
+    const opts = parseArgs(['--color', '#10b981', '--name', 'emerald']);
+    expect(opts.name).toBe('emerald');
+  });
+
+  it('parses --format css', () => {
+    const opts = parseArgs(['--color', '#10b981', '--format', 'css']);
+    expect(opts.format).toBe('css');
+  });
+
+  it('parses --format json', () => {
+    const opts = parseArgs(['--color', '#10b981', '--format', 'json']);
+    expect(opts.format).toBe('json');
+  });
+
+  it('throws on missing --color', () => {
+    expect(() => parseArgs([])).toThrow('Missing required --color');
+  });
+
+  it('throws on invalid --format', () => {
+    expect(() => parseArgs(['--color', '#fff', '--format', 'xml'])).toThrow('Invalid --format');
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * main() integration — runs without writing to disk
+ * ──────────────────────────────────────────────────────────────────────── */
+
+describe('main', () => {
+  it('returns overrides and css when writeToDisk is false', () => {
+    const result = main(['--color', '#10b981', '--name', 'test'], { writeToDisk: false });
+    expect(result.overrides).toBeDefined();
+    expect(result.overrides.light).toBeDefined();
+    expect(result.overrides.dark).toBeDefined();
+    expect(result.css).toContain('--primary:');
+  });
+
+  it('works with all formats without disk writes', () => {
+    for (const format of ['css', 'json', 'both'] as const) {
+      const result = main(['--color', '#3b82f6', '--format', format], { writeToDisk: false });
+      expect(result.overrides.light!.primary).toMatch(/^oklch\(/);
+    }
+  });
+});

--- a/packages/next-shell/tests/wcag-contrast.test.ts
+++ b/packages/next-shell/tests/wcag-contrast.test.ts
@@ -1,0 +1,216 @@
+/**
+ * WCAG AA contrast-ratio verification for every semantic foreground/background
+ * token pair in tokens.css.
+ *
+ * The conversion pipeline:
+ *   OKLCH → OKLab → linear LMS (cube) → linear sRGB → gamma sRGB → WCAG luminance
+ *
+ * Runs in CI so regressions in token lightness are caught before merge.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TOKENS_CSS = readFileSync(resolve(HERE, '../src/styles/tokens.css'), 'utf8');
+
+// ─── OKLCH → sRGB conversion ────────────────────────────────────────────────
+
+/** OKLCH → OKLab: L stays, a = C·cos(H°), b = C·sin(H°) */
+function oklchToOklab(L: number, C: number, H: number) {
+  const hRad = (H * Math.PI) / 180;
+  return { L, a: C * Math.cos(hRad), b: C * Math.sin(hRad) };
+}
+
+/**
+ * OKLab → linear sRGB via Ottosson's inverse matrices.
+ *
+ * OKLab → LMS (cube-root) → LMS (cube) → linear sRGB
+ */
+function oklabToLinearRGB(L: number, a: number, b: number) {
+  // OKLab → cube-root LMS
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+
+  // Cube to recover linear LMS
+  const l = l_ * l_ * l_;
+  const m = m_ * m_ * m_;
+  const s = s_ * s_ * s_;
+
+  // Linear LMS → linear sRGB
+  return {
+    R: +4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    G: -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    B: -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  };
+}
+
+/** Linear sRGB → gamma-encoded sRGB (0–1) */
+function linearToSrgb(c: number): number {
+  const clamped = Math.max(0, c);
+  if (clamped <= 0.0031308) return 12.92 * clamped;
+  return 1.055 * Math.pow(clamped, 1 / 2.4) - 0.055;
+}
+
+/** Gamma-encoded sRGB (0–1) → linear for luminance */
+function srgbToLinear(c: number): number {
+  if (c <= 0.04045) return c / 12.92;
+  return Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/** Full pipeline: OKLCH → sRGB (each channel clamped to 0–1) */
+function oklchToSrgb(L: number, C: number, H: number) {
+  const lab = oklchToOklab(L, C, H);
+  const lin = oklabToLinearRGB(lab.L, lab.a, lab.b);
+  return {
+    r: Math.max(0, Math.min(1, linearToSrgb(lin.R))),
+    g: Math.max(0, Math.min(1, linearToSrgb(lin.G))),
+    b: Math.max(0, Math.min(1, linearToSrgb(lin.B))),
+  };
+}
+
+/** WCAG 2.1 relative luminance */
+function wcagLuminance(r: number, g: number, b: number): number {
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+
+/** WCAG contrast ratio (always >= 1) */
+function contrastRatio(lum1: number, lum2: number): number {
+  const lighter = Math.max(lum1, lum2);
+  const darker = Math.min(lum1, lum2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// ─── CSS parsing ─────────────────────────────────────────────────────────────
+
+interface OklchValue {
+  L: number;
+  C: number;
+  H: number;
+}
+
+/** Extract the content between the first `{` and its matching `}` after startIdx */
+function extractBlock(css: string, startIdx: number): string {
+  const braceIdx = css.indexOf('{', startIdx);
+  if (braceIdx === -1) return '';
+  let depth = 1;
+  let i = braceIdx + 1;
+  const chars: string[] = [];
+  while (i < css.length && depth > 0) {
+    if (css[i] === '{') depth++;
+    if (css[i] === '}') depth--;
+    if (depth > 0) chars.push(css[i]!);
+    i++;
+  }
+  return chars.join('');
+}
+
+/** Parse `--name: oklch(L C H);` declarations (skip alpha variants like overlays/shadows) */
+function parseOklchTokens(block: string): Record<string, OklchValue> {
+  const tokens: Record<string, OklchValue> = {};
+  const re = /--([\w-]+):\s*oklch\((\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(block)) !== null) {
+    tokens[m[1]!] = { L: parseFloat(m[2]!), C: parseFloat(m[3]!), H: parseFloat(m[4]!) };
+  }
+  return tokens;
+}
+
+const lightBlock = extractBlock(TOKENS_CSS, TOKENS_CSS.indexOf(':root,'));
+const darkBlock = extractBlock(TOKENS_CSS, TOKENS_CSS.indexOf("[data-theme='dark']"));
+
+const lightTokens = parseOklchTokens(lightBlock);
+const darkTokens = parseOklchTokens(darkBlock);
+
+// ─── Pair definitions ────────────────────────────────────────────────────────
+
+const PAIRS: Array<[fg: string, bg: string]> = [
+  ['foreground', 'background'],
+  ['primary-foreground', 'primary'],
+  ['destructive-foreground', 'destructive'],
+  ['success-foreground', 'success'],
+  ['warning-foreground', 'warning'],
+  ['info-foreground', 'info'],
+  ['muted-foreground', 'background'],
+  ['muted-foreground', 'card'],
+  ['muted-foreground', 'muted'],
+  ['card-foreground', 'card'],
+  ['popover-foreground', 'popover'],
+  ['accent-foreground', 'accent'],
+  ['secondary-foreground', 'secondary'],
+  ['sidebar-foreground', 'sidebar'],
+  ['sidebar-accent-foreground', 'sidebar-accent'],
+];
+
+const AA_NORMAL_TEXT = 4.5;
+
+// ─── Helper: compute ratio for an OKLCH pair ────────────────────────────────
+
+function ratioForPair(
+  tokens: Record<string, OklchValue>,
+  fgName: string,
+  bgName: string,
+): number | null {
+  const fg = tokens[fgName];
+  const bg = tokens[bgName];
+  if (!fg || !bg) return null;
+
+  const fgSrgb = oklchToSrgb(fg.L, fg.C, fg.H);
+  const bgSrgb = oklchToSrgb(bg.L, bg.C, bg.H);
+  const fgLum = wcagLuminance(fgSrgb.r, fgSrgb.g, fgSrgb.b);
+  const bgLum = wcagLuminance(bgSrgb.r, bgSrgb.g, bgSrgb.b);
+  return contrastRatio(fgLum, bgLum);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('WCAG AA contrast — light theme', () => {
+  for (const [fgName, bgName] of PAIRS) {
+    if (!lightTokens[fgName] || !lightTokens[bgName]) continue;
+    it(`${fgName} on ${bgName} ≥ ${AA_NORMAL_TEXT}:1`, () => {
+      const ratio = ratioForPair(lightTokens, fgName, bgName)!;
+      expect(ratio).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+    });
+  }
+});
+
+describe('WCAG AA contrast — dark theme', () => {
+  for (const [fgName, bgName] of PAIRS) {
+    if (!darkTokens[fgName] || !darkTokens[bgName]) continue;
+    it(`${fgName} on ${bgName} ≥ ${AA_NORMAL_TEXT}:1`, () => {
+      const ratio = ratioForPair(darkTokens, fgName, bgName)!;
+      expect(ratio).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+    });
+  }
+});
+
+describe('OKLCH → sRGB conversion sanity checks', () => {
+  it('pure black (L=0) produces 0,0,0', () => {
+    const { r, g, b } = oklchToSrgb(0, 0, 0);
+    expect(r).toBeCloseTo(0, 3);
+    expect(g).toBeCloseTo(0, 3);
+    expect(b).toBeCloseTo(0, 3);
+  });
+
+  it('pure white (L=1, C=0) produces 1,1,1', () => {
+    const { r, g, b } = oklchToSrgb(1, 0, 0);
+    expect(r).toBeCloseTo(1, 2);
+    expect(g).toBeCloseTo(1, 2);
+    expect(b).toBeCloseTo(1, 2);
+  });
+
+  it('WCAG luminance of white ≈ 1', () => {
+    expect(wcagLuminance(1, 1, 1)).toBeCloseTo(1, 3);
+  });
+
+  it('WCAG luminance of black = 0', () => {
+    expect(wcagLuminance(0, 0, 0)).toBe(0);
+  });
+
+  it('contrast ratio of white on black = 21:1', () => {
+    expect(contrastRatio(1, 0)).toBeCloseTo(21, 1);
+  });
+});

--- a/packages/next-shell/tsup.config.ts
+++ b/packages/next-shell/tsup.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
     'formatters/index': 'src/formatters/index.ts',
     'tokens/index': 'src/tokens/index.ts',
     'tailwind-preset/index': 'src/tailwind-preset/index.ts',
+    'cli/generate-theme': 'src/cli/generate-theme.ts',
   },
   format: ['esm', 'cjs'],
   dts: true,


### PR DESCRIPTION
## Summary

Three high-impact issues: WCAG accessibility fixes, theme generator CLI, and polished example app.

Closes #59, #74, #82.

## Changes

### #74 — WCAG AA contrast audit + fixes
Fixed 7 failing foreground/background token pairs in `tokens.css` by adjusting OKLCH lightness while preserving hue and chroma:
- Light: muted-foreground on muted (4.32 -> 4.60), success (2.90 -> 4.60), info (2.49 -> 4.60)
- Dark: primary (3.86 -> 4.61), destructive (2.77 -> 4.60), success (2.25 -> 4.61), info (1.87 -> 4.61)
- New `wcag-contrast.test.ts` verifies all 30 token pairs in CI

### #59 — Theme generator CLI
`npx next-shell-theme --color '#10b981'` generates a complete BrandOverrides + CSS preset from a single hex input:
- Derives primary, accent, destructive, ring, and 5 chart colors via OKLCH hue rotation
- Binary search ensures all foreground/background pairs pass WCAG AA (4.5:1)
- Outputs JSON and/or CSS (`--format css|json|both`)
- 64 tests covering 5 brand colors, contrast validation, edge cases

### #82 — Polished example app
- **Dashboard**: stat cards with trends, CSS-driven revenue chart, channel breakdown with Progress bars, recent activity feed, toast demos
- **Settings**: 4-tab layout (Profile/Notifications/Appearance/Security) showcasing all form controls
- **Shell**: CommandBar actions registered, sidebar footer with user avatar, separator + notifications in topbar

## Verification

```
pnpm format     ok
pnpm lint       ok (0 warnings)
pnpm typecheck  ok
pnpm test       ok — 29 files, 712 tests
pnpm build      ok
```

https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4

---
_Generated by [Claude Code](https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4)_