### PR TITLE
docs: update both READMEs — accurate stats, new features, workspace layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Monorepo for [`@jonmatum/next-shell`](./packages/next-shell) — a reusable Next.js app shell built on **shadcn/ui** primitives with a strict **semantic-token** design system.
 
-> **Status:** All 11 phases complete — extraction finished. 508 tests, full docs site, release pipeline, and a working example app all on `main`.
+> **Status:** All 11 phases complete — extraction finished. Open-source readiness ([epic #54](https://github.com/jonmatum/next-shell/issues/54)) done. 712 tests, full docs site, release pipeline, starter template, and a working example app all on `main`.
 
 ## What's in the box today
 
@@ -17,13 +17,13 @@ Monorepo for [`@jonmatum/next-shell`](./packages/next-shell) — a reusable Next
 |     6 | Providers composer — `AppProviders`, `QueryProvider` (TanStack Query v5), `ToastProvider` (Sonner), `ErrorBoundary`, `I18nProvider`                                          | ✅ Landed |
 |     7 | Auth adapter pattern — `AuthProvider`, `useSession`, `useUser`, `useHasPermission`, `useRequireAuth`, `SignedIn`, `SignedOut`, `RoleGate`, `requireSession` (server)         | ✅ Landed |
 |     8 | Hooks + formatters — `useDisclosure`, `useLocalStorage`, `useDebounced*`, `useHotkey`, `useBreakpoint`, `useCopyToClipboard` + `formatDate`, `formatCurrency`, `truncate`, … | ✅ Landed |
-|     9 | Docs site (fumadocs v14) — 8 content pages covering all phases; Storybook deferred                                                                                           | ✅ Landed |
+|     9 | Docs site (fumadocs v14) — 10 content pages covering all phases + recipes & migration; Storybook deferred                                                                    | ✅ Landed |
 |    10 | Publishing + changeset release workflow — `changesets/action`, npm provenance, `release.yml`                                                                                 | ✅ Landed |
 |    11 | Example consumer app — dashboard, data table, auth guards, settings form, toast demos                                                                                        | ✅ Landed |
 
 **42 primitives** (Phase 3): Accordion, Alert, AlertDialog, AspectRatio, Avatar, Badge, Breadcrumb, Button, Calendar, Card, Carousel, Chart, Checkbox, Collapsible, Command, ContextMenu, Dialog, Drawer, DropdownMenu, Form, HoverCard, Input, InputOTP, Label, Menubar, NavigationMenu, Pagination, Popover, Progress, RadioGroup, Resizable, ScrollArea, Select, Separator, Sheet, Skeleton, Slider, Switch, Table, Tabs, Textarea, Toaster (Sonner), Toggle, ToggleGroup, Tooltip.
 
-**508 unit tests** across 21 test files cover render, interaction, SSR helpers, provider composition, auth adapter contracts, and export-surface completeness.
+**712 unit tests** across 29 test files cover render, interaction, SSR helpers, provider composition, auth adapter contracts, and export-surface completeness.
 
 Deliberately **not** vendored (composed patterns documented as consumer-side recipes): DatePicker (Popover + Calendar + Button), DataTable (Table + `@tanstack/react-table`), Typography (styling-guide h1/h2/p patterns).
 
@@ -41,12 +41,16 @@ Deliberately **not** vendored (composed patterns documented as consumer-side rec
 next-shell/
 ├── packages/
 │   └── next-shell/               # The published @jonmatum/next-shell package
+├── apps/
+│   ├── docs/                     # Documentation site (fumadocs v14)
+│   └── example/                  # Example consumer app
+├── templates/
+│   └── starter/                  # Starter template (degit-ready)
 ├── tools/
-│   └── eslint-plugin-next-shell/ # Custom ESLint rules (no-raw-colors)
+│   ├── eslint-plugin-next-shell/ # Custom ESLint rules (no-raw-colors)
+│   └── next-shell-mcp/           # MCP server for AI tools
 ├── .claude/skills/               # Repo-local Claude Code skills
 ├── CLAUDE.md                     # Session onboarding guide
-├── eslint.config.js              # Flat ESLint config
-├── tsconfig.base.json            # Shared TS compiler options
 └── pnpm-workspace.yaml
 ```
 
@@ -57,7 +61,7 @@ nvm use              # Node version from .nvmrc
 pnpm install
 pnpm lint            # eslint --max-warnings=0
 pnpm typecheck
-pnpm test            # vitest run (508 tests)
+pnpm test            # vitest run (712 tests)
 pnpm build           # tsup + tailwind preset + DTS
 ```
 
@@ -76,11 +80,19 @@ This repo is set up for Claude Code sessions with a handful of durable conventio
 
 New session picking up the work: `git pull`, read `CLAUDE.md`, check the most recently merged phase PR for the current state, then continue on a `claude/phase-N-<slug>` branch.
 
+## Resources
+
+- **[Documentation site](https://jonmatum.github.io/next-shell/)** — full guides for every phase (fumadocs v14)
+- **[Starter template](./templates/starter/)** — degit-ready scaffold: `npx degit jonmatum/next-shell/templates/starter my-app`
+- **[Example app](./apps/example/)** — dashboard, data table, auth guards, settings form, toast demos
+- **[MCP server](./tools/next-shell-mcp/)** — Model Context Protocol server for AI tools
+
 ## Links
 
 - Package README · [`packages/next-shell/README.md`](./packages/next-shell/README.md)
 - Session onboarding · [`CLAUDE.md`](./CLAUDE.md)
 - Extraction plan · [Epic #13](https://github.com/jonmatum/next-shell/issues/13)
+- Open-source readiness · [Epic #54](https://github.com/jonmatum/next-shell/issues/54)
 - Per-phase tracking issues · [#1](https://github.com/jonmatum/next-shell/issues/1) · [#2](https://github.com/jonmatum/next-shell/issues/2) · [#3](https://github.com/jonmatum/next-shell/issues/3) · [#4](https://github.com/jonmatum/next-shell/issues/4) · [#5](https://github.com/jonmatum/next-shell/issues/5) · [#6](https://github.com/jonmatum/next-shell/issues/6) · [#7](https://github.com/jonmatum/next-shell/issues/7) · [#8](https://github.com/jonmatum/next-shell/issues/8) · [#9](https://github.com/jonmatum/next-shell/issues/9) · [#10](https://github.com/jonmatum/next-shell/issues/10) · [#11](https://github.com/jonmatum/next-shell/issues/11) · [#12](https://github.com/jonmatum/next-shell/issues/12)
 
 ## License

--- a/packages/next-shell/README.md
+++ b/packages/next-shell/README.md
@@ -322,6 +322,50 @@ const brand: BrandOverrides = {
 
 Brand overrides cascade via CSS custom properties — zero JS re-render on theme switch.
 
+### Preset palettes
+
+Five ready-made palettes ship as importable CSS files — swap one line in `globals.css` to re-skin the entire app:
+
+| Preset  | Import                                            |
+| ------- | ------------------------------------------------- |
+| Neutral | `@jonmatum/next-shell/styles/presets/neutral.css` |
+| Green   | `@jonmatum/next-shell/styles/presets/green.css`   |
+| Orange  | `@jonmatum/next-shell/styles/presets/orange.css`  |
+| Red     | `@jonmatum/next-shell/styles/presets/red.css`     |
+| Violet  | `@jonmatum/next-shell/styles/presets/violet.css`  |
+
+```css
+/* app/globals.css */
+@import 'tailwindcss';
+@source "node_modules/@jonmatum/next-shell/dist/**/*.{js,cjs}";
+@import '@jonmatum/next-shell/styles/preset.css';
+@import '@jonmatum/next-shell/styles/presets/green.css';
+```
+
+### Theme generator
+
+Generate a fully custom token palette from any brand hex color:
+
+```bash
+npx next-shell-theme --color '#10b981'
+npx next-shell-theme --color '#10b981' --name my-brand --format css
+```
+
+The CLI outputs a CSS file (and/or JSON) with light + dark token values derived from the input color using OKLCH color math.
+
+## Starter template
+
+Scaffold a new app with the shell pre-wired:
+
+```bash
+npx degit jonmatum/next-shell/templates/starter my-app
+cd my-app
+pnpm install
+pnpm dev
+```
+
+The starter includes ThemeProvider, preset CSS, a minimal sidebar layout, and example pages.
+
 ## Contributing
 
 See the root [`CONTRIBUTING.md`](../../CONTRIBUTING.md) for day-to-day workflow, and the repo-local skills under [`.claude/skills/`](../../.claude/skills/) if you're iterating with Claude Code.

--- a/packages/next-shell/README.md
+++ b/packages/next-shell/README.md
@@ -9,7 +9,7 @@
 
 Reusable Next.js app shell built on **shadcn/ui** primitives with a strict **semantic-token** design system.
 
-> **Status:** All 11 phases complete. Published via Changesets. 508 tests, docs site, and a working example app all on `main`.
+> **Status:** All 11 phases complete. Published via Changesets. 712 tests, docs site, starter template, and a working example app all on `main`.
 
 ## Install
 
@@ -189,25 +189,30 @@ slugify('Hello World!'); // "hello-world"
 
 ## Subpath entry points
 
-| Import                                   | Surface                                                                                                             | Status |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------ |
-| `@jonmatum/next-shell`                   | Root barrel — `cn`, `packageVersion`, `tokenSchemaVersion`                                                          | ✅     |
-| `@jonmatum/next-shell/core`              | `cn`, `packageVersion`                                                                                              | ✅     |
-| `@jonmatum/next-shell/primitives`        | 42 shadcn/ui primitives (client)                                                                                    | ✅     |
-| `@jonmatum/next-shell/providers`         | `AppProviders`, `ThemeProvider`, `QueryProvider`, `ToastProvider`, `ErrorBoundary`, `I18nProvider` (client)         | ✅     |
-| `@jonmatum/next-shell/providers/server`  | SSR theme cookie helpers (server-safe)                                                                              | ✅     |
-| `@jonmatum/next-shell/layout`            | `AppShell`, `Sidebar`, `TopBar`, `CommandBar`, `ContentContainer`, `PageHeader`, `Footer`, nav + status helpers     | ✅     |
-| `@jonmatum/next-shell/layout/server`     | SSR sidebar-state cookie helpers (server-safe)                                                                      | ✅     |
-| `@jonmatum/next-shell/auth`              | `AuthProvider`, `useSession`, `useUser`, `useHasPermission`, `useRequireAuth`, `SignedIn`, `SignedOut`, `RoleGate`  | ✅     |
-| `@jonmatum/next-shell/auth/server`       | `requireSession` — throws `AuthRequiredError` (401) for Route Handlers (server-safe)                                | ✅     |
-| `@jonmatum/next-shell/auth/nextauth`     | `createNextAuthAdapter` — Auth.js v5 wrapper (optional peer: `next-auth >= 5`)                                      | ✅     |
-| `@jonmatum/next-shell/auth/mock`         | `createMockAuthAdapter` — zero-dep adapter for tests and Storybook                                                  | ✅     |
-| `@jonmatum/next-shell/tokens`            | TS view of the semantic-token contract — literal unions, `cssVar`, brand overrides                                  | ✅     |
-| `@jonmatum/next-shell/tailwind-preset`   | Tailwind v4 preset (maps tokens → `@theme` keys)                                                                    | ✅     |
-| `@jonmatum/next-shell/styles/tokens.css` | Token CSS (custom properties for `:root` + `[data-theme="dark"]`)                                                   | ✅     |
-| `@jonmatum/next-shell/styles/preset.css` | Combined preset (tokens + `tw-animate-css` + Tailwind `@theme` mappings)                                            | ✅     |
-| `@jonmatum/next-shell/hooks`             | `useDisclosure`, `useLocalStorage`, `useBreakpoint`, `useHotkey`, `useDebouncedValue`, `useMounted`, `useLocale`, … | ✅     |
-| `@jonmatum/next-shell/formatters`        | `formatDate`, `formatRelativeTime`, `formatCurrency`, `formatFileSize`, `truncate`, `slugify`, …                    | ✅     |
+| Import                                            | Surface                                                                                                                                                 | Status |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `@jonmatum/next-shell`                            | Root barrel — `cn`, `packageVersion`, `tokenSchemaVersion`                                                                                              | ✅     |
+| `@jonmatum/next-shell/core`                       | `cn`, `packageVersion`                                                                                                                                  | ✅     |
+| `@jonmatum/next-shell/primitives`                 | 42 shadcn/ui primitives (client)                                                                                                                        | ✅     |
+| `@jonmatum/next-shell/providers`                  | `AppProviders`, `ThemeProvider`, `QueryProvider`, `ToastProvider`, `ErrorBoundary`, `I18nProvider` (client)                                             | ✅     |
+| `@jonmatum/next-shell/providers/server`           | SSR theme cookie helpers (server-safe)                                                                                                                  | ✅     |
+| `@jonmatum/next-shell/layout`                     | `AppShell`, `Sidebar`, `TopBar`, `CommandBar`, `ContentContainer`, `PageHeader`, `Footer`, nav + status helpers                                         | ✅     |
+| `@jonmatum/next-shell/layout/server`              | SSR sidebar-state cookie helpers (server-safe)                                                                                                          | ✅     |
+| `@jonmatum/next-shell/auth`                       | `AuthProvider`, `useSession`, `useUser`, `useHasPermission`, `useRequireAuth`, `SignedIn`, `SignedOut`, `RoleGate`                                      | ✅     |
+| `@jonmatum/next-shell/auth/server`                | `requireSession` — throws `AuthRequiredError` (401) for Route Handlers (server-safe)                                                                    | ✅     |
+| `@jonmatum/next-shell/auth/nextauth`              | `createNextAuthAdapter` — Auth.js v5 wrapper (optional peer: `next-auth >= 5`)                                                                          | ✅     |
+| `@jonmatum/next-shell/auth/mock`                  | `createMockAuthAdapter` — zero-dep adapter for tests and Storybook                                                                                      | ✅     |
+| `@jonmatum/next-shell/tokens`                     | TS view of the semantic-token contract — literal unions, `cssVar`, `hexToOklch`, brand overrides, preset palettes (neutral, green, orange, red, violet) | ✅     |
+| `@jonmatum/next-shell/tailwind-preset`            | Tailwind v4 preset (maps tokens → `@theme` keys)                                                                                                        | ✅     |
+| `@jonmatum/next-shell/styles/tokens.css`          | Token CSS (custom properties for `:root` + `[data-theme="dark"]`)                                                                                       | ✅     |
+| `@jonmatum/next-shell/styles/preset.css`          | Combined preset (tokens + `tw-animate-css` + Tailwind `@theme` mappings)                                                                                | ✅     |
+| `@jonmatum/next-shell/styles/presets/neutral.css` | Preset palette — neutral (gray/slate tones)                                                                                                             | ✅     |
+| `@jonmatum/next-shell/styles/presets/green.css`   | Preset palette — green                                                                                                                                  | ✅     |
+| `@jonmatum/next-shell/styles/presets/orange.css`  | Preset palette — orange                                                                                                                                 | ✅     |
+| `@jonmatum/next-shell/styles/presets/red.css`     | Preset palette — red                                                                                                                                    | ✅     |
+| `@jonmatum/next-shell/styles/presets/violet.css`  | Preset palette — violet                                                                                                                                 | ✅     |
+| `@jonmatum/next-shell/hooks`                      | `useDisclosure`, `useLocalStorage`, `useBreakpoint`, `useHotkey`, `useDebouncedValue`, `useMounted`, `useLocale`, …                                     | ✅     |
+| `@jonmatum/next-shell/formatters`                 | `formatDate`, `formatRelativeTime`, `formatCurrency`, `formatFileSize`, `truncate`, `slugify`, …                                                        | ✅     |
 
 Subpath imports tree-shake cleanly — importing only `@jonmatum/next-shell/primitives` does not pull in providers, and vice versa.
 
@@ -294,6 +299,8 @@ chart-1..chart-5
 ```
 
 Plus radius (7 sizes on a single `--radius` base), typography (3 families, 9-step fluid type scale, leading, tracking), motion (5 durations + 4 easings), elevation (6 shadow sizes), and density (4 scalars).
+
+All token pairs (e.g. `primary` / `primary-foreground`) are tuned to meet **WCAG AA** contrast ratios in both light and dark themes.
 
 **No raw color literals** in library code — the `next-shell/no-raw-colors` ESLint rule fails CI on regressions. If a color concept doesn't fit an existing token, the token set grows; consumers never hardcode.
 


### PR DESCRIPTION
## Summary

Update both READMEs to reflect the current state of the project after epic #54 completion.

## Changes

- Test count: 508 → 712 tests across 29 files
- Workspace layout: add apps/docs, apps/example, templates/starter, tools/next-shell-mcp
- Docs site link added to both READMEs
- Starter template section with degit command
- Theme generator CLI section
- Preset palettes (5 color presets) mentioned
- WCAG AA compliance note in semantic tokens section
- Subpath table updated with hexToOklch, preset palettes, preset CSS entries

https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4

---
_Generated by [Claude Code](https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4)_