### PR TITLE
feat: TaskFlow example app — project management built with next-shell

### DIFF
--- a/apps/taskflow/app/(shell)/dashboard/page.tsx
+++ b/apps/taskflow/app/(shell)/dashboard/page.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import {
+  FolderKanbanIcon,
+  ListChecksIcon,
+  UsersIcon,
+  CheckCircle2Icon,
+  PlusIcon,
+} from 'lucide-react';
+
+import { PageHeader } from '@jonmatum/next-shell/layout';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Textarea,
+} from '@jonmatum/next-shell/primitives';
+import { formatNumber, formatPercent } from '@jonmatum/next-shell/formatters';
+import { formatRelativeTime } from '@jonmatum/next-shell/formatters';
+import { useDisclosure } from '@jonmatum/next-shell/hooks';
+import { SignedIn } from '@jonmatum/next-shell/auth';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Stat cards data
+ * ──────────────────────────────────────────────────────────────────────── */
+
+const STATS = [
+  {
+    label: 'Active Projects',
+    value: 12,
+    icon: <FolderKanbanIcon className="text-muted-foreground size-5" />,
+    change: 0.08,
+  },
+  {
+    label: 'Open Tasks',
+    value: 47,
+    icon: <ListChecksIcon className="text-muted-foreground size-5" />,
+    change: -0.03,
+  },
+  {
+    label: 'Team Members',
+    value: 8,
+    icon: <UsersIcon className="text-muted-foreground size-5" />,
+    change: 0.125,
+  },
+  {
+    label: 'Completed This Week',
+    value: 23,
+    icon: <CheckCircle2Icon className="text-muted-foreground size-5" />,
+    change: 0.15,
+  },
+] as const;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Recent activity data
+ * ──────────────────────────────────────────────────────────────────────── */
+
+const NOW = Date.now();
+
+const RECENT_ACTIVITY = [
+  {
+    id: '1',
+    description: 'Sarah Chen completed task "API integration tests"',
+    project: 'Backend Overhaul',
+    timestamp: new Date(NOW - 15 * 60 * 1000), // 15 min ago
+    type: 'completed' as const,
+  },
+  {
+    id: '2',
+    // eslint-disable-next-line next-shell/no-raw-colors -- PR number, not a color
+    description: 'Marcus Rivera opened PR #234 for auth refactor',
+    project: 'Auth Module',
+    timestamp: new Date(NOW - 2 * 60 * 60 * 1000), // 2 hours ago
+    type: 'created' as const,
+  },
+  {
+    id: '3',
+    description: 'Priya Patel moved "Design review" to In Progress',
+    project: 'Mobile App v2',
+    timestamp: new Date(NOW - 5 * 60 * 60 * 1000), // 5 hours ago
+    type: 'updated' as const,
+  },
+  {
+    id: '4',
+    description: 'Alex Kim added 3 new tasks to Sprint 14',
+    project: 'Dashboard Redesign',
+    timestamp: new Date(NOW - 24 * 60 * 60 * 1000), // 1 day ago
+    type: 'created' as const,
+  },
+  {
+    id: '5',
+    description: 'Jordan Lee archived project "Legacy Cleanup"',
+    project: 'Legacy Cleanup',
+    timestamp: new Date(NOW - 3 * 24 * 60 * 60 * 1000), // 3 days ago
+    type: 'archived' as const,
+  },
+];
+
+const ACTIVITY_BADGE_VARIANT: Record<string, 'default' | 'secondary' | 'outline' | 'destructive'> =
+  {
+    completed: 'default',
+    created: 'secondary',
+    updated: 'outline',
+    archived: 'outline',
+  };
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Dashboard page
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export default function DashboardPage() {
+  const createProject = useDisclosure();
+
+  return (
+    <div className="flex flex-col gap-8">
+      <PageHeader
+        title="Dashboard"
+        description="Overview of your projects and team activity."
+        actions={
+          <SignedIn>
+            <Button onClick={createProject.open}>
+              <PlusIcon className="size-4" />
+              Create Project
+            </Button>
+          </SignedIn>
+        }
+      />
+
+      {/* ── Stat cards ─────────────────────────────────────────────── */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {STATS.map((stat) => (
+          <Card key={stat.label}>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-muted-foreground text-sm font-medium">
+                {stat.label}
+              </CardTitle>
+              {stat.icon}
+            </CardHeader>
+            <CardContent>
+              <div className="text-foreground text-2xl font-bold">{formatNumber(stat.value)}</div>
+              <p className="text-muted-foreground mt-1 text-xs">
+                {stat.change >= 0 ? '+' : ''}
+                {formatPercent(stat.change)} from last week
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* ── Recent activity ────────────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Activity</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-4">
+            {RECENT_ACTIVITY.map((activity) => (
+              <div
+                key={activity.id}
+                className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="flex min-w-0 flex-col gap-1">
+                  <p className="text-foreground text-sm">{activity.description}</p>
+                  <div className="flex items-center gap-2">
+                    <Badge variant={ACTIVITY_BADGE_VARIANT[activity.type]}>{activity.type}</Badge>
+                    <span className="text-muted-foreground text-xs">{activity.project}</span>
+                  </div>
+                </div>
+                <span className="text-muted-foreground shrink-0 text-xs">
+                  {formatRelativeTime(activity.timestamp)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── Create project dialog ──────────────────────────────────── */}
+      <Dialog open={createProject.isOpen} onOpenChange={createProject.onOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create New Project</DialogTitle>
+            <DialogDescription>
+              Add a new project to your workspace. Fill in the details below.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-4 py-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="project-name">Project Name</Label>
+              <Input id="project-name" placeholder="e.g. Mobile App v3" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="project-description">Description</Label>
+              <Textarea
+                id="project-description"
+                placeholder="Briefly describe the project goals..."
+                rows={3}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={createProject.close}>
+              Cancel
+            </Button>
+            <Button onClick={createProject.close}>Create Project</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/taskflow/app/(shell)/layout.tsx
+++ b/apps/taskflow/app/(shell)/layout.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useRouter } from 'next/navigation';
+import { LayoutDashboardIcon, FolderKanbanIcon, UsersIcon, SettingsIcon } from 'lucide-react';
+
+import {
+  AppShell,
+  buildNav,
+  SidebarNav,
+  Breadcrumbs,
+  CommandBarActions,
+  TopBar,
+  Footer,
+  Sidebar,
+  SidebarContent,
+  SidebarHeader,
+  SidebarFooter,
+  SidebarTrigger,
+} from '@jonmatum/next-shell/layout';
+import type { NavConfig, ResolvedNavItem } from '@jonmatum/next-shell/layout';
+import { ThemeToggleDropdown } from '@jonmatum/next-shell/providers';
+import { useSession, useUser } from '@jonmatum/next-shell/auth';
+import { Avatar, AvatarFallback } from '@jonmatum/next-shell/primitives';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Navigation config
+ * ──────────────────────────────────────────────────────────────────────── */
+
+const NAV_CONFIG: NavConfig = [
+  {
+    id: 'dashboard',
+    label: 'Dashboard',
+    href: '/dashboard',
+    icon: <LayoutDashboardIcon className="size-4" />,
+    matcher: 'prefix',
+  },
+  {
+    id: 'projects',
+    label: 'Projects',
+    href: '/projects',
+    icon: <FolderKanbanIcon className="size-4" />,
+    matcher: 'prefix',
+  },
+  {
+    id: 'team',
+    label: 'Team',
+    href: '/team',
+    icon: <UsersIcon className="size-4" />,
+    requires: 'pm',
+    matcher: 'prefix',
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    href: '/settings',
+    icon: <SettingsIcon className="size-4" />,
+    matcher: 'prefix',
+  },
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Shell layout
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export default function ShellLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useSession();
+  const user = useUser();
+
+  const permissions = [...(user?.roles ?? []), ...(user?.scopes ?? [])];
+
+  const { items } = buildNav({
+    config: NAV_CONFIG,
+    pathname,
+    permissions,
+  });
+
+  const handleNavigate = (item: ResolvedNavItem) => {
+    if (item.href) router.push(item.href);
+  };
+
+  return (
+    <AppShell
+      commandBar
+      sidebar={
+        <Sidebar>
+          <SidebarHeader className="border-border border-b px-4 py-3">
+            <div className="flex items-center gap-2">
+              <div className="bg-primary text-primary-foreground flex size-8 items-center justify-center rounded-md text-sm font-bold">
+                TF
+              </div>
+              <div className="flex flex-col">
+                <span className="text-foreground text-sm font-semibold">TaskFlow</span>
+                <span className="text-muted-foreground text-xs">Project Management</span>
+              </div>
+            </div>
+          </SidebarHeader>
+
+          <SidebarContent>
+            <SidebarNav items={items} label="Navigation" onNavigate={handleNavigate} />
+          </SidebarContent>
+
+          <SidebarFooter className="border-border border-t px-4 py-3">
+            {user ? (
+              <div className="flex items-center gap-3">
+                <Avatar className="size-8">
+                  <AvatarFallback className="text-xs">
+                    {user.name
+                      ? user.name
+                          .split(' ')
+                          .map((n) => n[0])
+                          .join('')
+                          .toUpperCase()
+                      : '?'}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="flex min-w-0 flex-col">
+                  <span className="text-foreground truncate text-sm font-medium">{user.name}</span>
+                  <span className="text-muted-foreground truncate text-xs">{user.email}</span>
+                </div>
+              </div>
+            ) : null}
+          </SidebarFooter>
+        </Sidebar>
+      }
+      topBar={
+        <TopBar
+          left={
+            <>
+              <SidebarTrigger />
+              <Breadcrumbs config={NAV_CONFIG} pathname={pathname} permissions={permissions} />
+            </>
+          }
+          right={<ThemeToggleDropdown />}
+        />
+      }
+      footer={
+        <Footer>
+          <span>&copy; {new Date().getFullYear()} TaskFlow</span>
+          <span>Built with @jonmatum/next-shell</span>
+        </Footer>
+      }
+    >
+      <CommandBarActions
+        config={NAV_CONFIG}
+        pathname={pathname}
+        permissions={permissions}
+        onNavigate={handleNavigate}
+      />
+      <div className="p-4 sm:p-6 lg:p-8">{children}</div>
+    </AppShell>
+  );
+}

--- a/apps/taskflow/app/(shell)/projects/page.tsx
+++ b/apps/taskflow/app/(shell)/projects/page.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { FilterIcon } from 'lucide-react';
+
+import { PageHeader } from '@jonmatum/next-shell/layout';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Progress,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@jonmatum/next-shell/primitives';
+import { formatDate, formatRelativeTime } from '@jonmatum/next-shell/formatters';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Mock data
+ * ──────────────────────────────────────────────────────────────────────── */
+
+type ProjectStatus = 'active' | 'completed' | 'archived';
+
+interface Project {
+  id: string;
+  name: string;
+  status: ProjectStatus;
+  tasks: number;
+  completedTasks: number;
+  updatedAt: Date;
+}
+
+const NOW = Date.now();
+
+const PROJECTS: Project[] = [
+  {
+    id: 'p1',
+    name: 'Dashboard Redesign',
+    status: 'active',
+    tasks: 24,
+    completedTasks: 18,
+    updatedAt: new Date(NOW - 2 * 60 * 60 * 1000),
+  },
+  {
+    id: 'p2',
+    name: 'Backend Overhaul',
+    status: 'active',
+    tasks: 36,
+    completedTasks: 12,
+    updatedAt: new Date(NOW - 5 * 60 * 60 * 1000),
+  },
+  {
+    id: 'p3',
+    name: 'Mobile App v2',
+    status: 'active',
+    tasks: 42,
+    completedTasks: 31,
+    updatedAt: new Date(NOW - 24 * 60 * 60 * 1000),
+  },
+  {
+    id: 'p4',
+    name: 'Auth Module',
+    status: 'completed',
+    tasks: 18,
+    completedTasks: 18,
+    updatedAt: new Date(NOW - 3 * 24 * 60 * 60 * 1000),
+  },
+  {
+    id: 'p5',
+    name: 'Analytics Pipeline',
+    status: 'active',
+    tasks: 15,
+    completedTasks: 4,
+    updatedAt: new Date(NOW - 6 * 24 * 60 * 60 * 1000),
+  },
+  {
+    id: 'p6',
+    name: 'Legacy Cleanup',
+    status: 'archived',
+    tasks: 28,
+    completedTasks: 28,
+    updatedAt: new Date(NOW - 14 * 24 * 60 * 60 * 1000),
+  },
+];
+
+const STATUS_BADGE_VARIANT: Record<ProjectStatus, 'default' | 'secondary' | 'outline'> = {
+  active: 'default',
+  completed: 'secondary',
+  archived: 'outline',
+};
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Project table
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function ProjectTable({ projects }: { projects: Project[] }) {
+  if (projects.length === 0) {
+    return (
+      <p className="text-muted-foreground py-8 text-center text-sm">
+        No projects match the current filter.
+      </p>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="text-right">Tasks</TableHead>
+          <TableHead>Progress</TableHead>
+          <TableHead>Updated</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {projects.map((project) => {
+          const progressValue =
+            project.tasks > 0 ? Math.round((project.completedTasks / project.tasks) * 100) : 0;
+
+          return (
+            <TableRow key={project.id}>
+              <TableCell className="text-foreground font-medium">{project.name}</TableCell>
+              <TableCell>
+                <Badge variant={STATUS_BADGE_VARIANT[project.status]}>{project.status}</Badge>
+              </TableCell>
+              <TableCell className="text-right">
+                {project.completedTasks}/{project.tasks}
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center gap-2">
+                  <Progress value={progressValue} className="h-2 w-24" />
+                  <span className="text-muted-foreground text-xs">{progressValue}%</span>
+                </div>
+              </TableCell>
+              <TableCell className="text-muted-foreground text-sm">
+                <span title={formatDate(project.updatedAt, { dateStyle: 'medium' })}>
+                  {formatRelativeTime(project.updatedAt)}
+                </span>
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Projects page
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export default function ProjectsPage() {
+  const activeProjects = PROJECTS.filter((p) => p.status === 'active');
+  const completedProjects = PROJECTS.filter((p) => p.status === 'completed');
+  const archivedProjects = PROJECTS.filter((p) => p.status === 'archived');
+
+  return (
+    <div className="flex flex-col gap-8">
+      <PageHeader
+        title="Projects"
+        description="Manage and track all your team projects."
+        actions={
+          <Button variant="outline" size="sm">
+            <FilterIcon className="size-4" />
+            Filter
+          </Button>
+        }
+      />
+
+      <Card>
+        <CardContent className="pt-6">
+          <Tabs defaultValue="all">
+            <TabsList>
+              <TabsTrigger value="all">All ({PROJECTS.length})</TabsTrigger>
+              <TabsTrigger value="active">Active ({activeProjects.length})</TabsTrigger>
+              <TabsTrigger value="completed">Completed ({completedProjects.length})</TabsTrigger>
+              <TabsTrigger value="archived">Archived ({archivedProjects.length})</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="all" className="mt-4">
+              <ProjectTable projects={PROJECTS} />
+            </TabsContent>
+            <TabsContent value="active" className="mt-4">
+              <ProjectTable projects={activeProjects} />
+            </TabsContent>
+            <TabsContent value="completed" className="mt-4">
+              <ProjectTable projects={completedProjects} />
+            </TabsContent>
+            <TabsContent value="archived" className="mt-4">
+              <ProjectTable projects={archivedProjects} />
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/taskflow/app/(shell)/settings/page.tsx
+++ b/apps/taskflow/app/(shell)/settings/page.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { CopyIcon, CheckIcon } from 'lucide-react';
+
+import { PageHeader } from '@jonmatum/next-shell/layout';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Separator,
+  Switch,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Textarea,
+} from '@jonmatum/next-shell/primitives';
+import { ThemeToggleDropdown } from '@jonmatum/next-shell/providers';
+import { useUser } from '@jonmatum/next-shell/auth';
+import { useCopyToClipboard } from '@jonmatum/next-shell/hooks';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Settings page
+ * ──────────────────────────────────────────────────────────────────────── */
+
+const MOCK_API_KEY = 'tf_live_sk_a1b2c3d4e5f6g7h8i9j0klmnopqrstuv';
+
+export default function SettingsPage() {
+  const user = useUser();
+  const { isCopied, copy } = useCopyToClipboard();
+
+  return (
+    <div className="flex flex-col gap-8">
+      <PageHeader title="Settings" description="Manage your account settings and preferences." />
+
+      <Tabs defaultValue="profile" className="w-full">
+        <TabsList>
+          <TabsTrigger value="profile">Profile</TabsTrigger>
+          <TabsTrigger value="notifications">Notifications</TabsTrigger>
+          <TabsTrigger value="appearance">Appearance</TabsTrigger>
+        </TabsList>
+
+        {/* ── Profile tab ─────────────────────────────────────────── */}
+        <TabsContent value="profile" className="mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Profile Information</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-6">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="settings-name">Full Name</Label>
+                  <Input
+                    id="settings-name"
+                    defaultValue={user?.name ?? ''}
+                    placeholder="Your name"
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="settings-email">Email</Label>
+                  <Input
+                    id="settings-email"
+                    type="email"
+                    defaultValue={user?.email ?? ''}
+                    placeholder="your@email.com"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="settings-bio">Bio</Label>
+                <Textarea
+                  id="settings-bio"
+                  placeholder="Tell us a bit about yourself..."
+                  rows={4}
+                  defaultValue="Project manager and team lead with a passion for building great products."
+                />
+              </div>
+
+              <Separator />
+
+              {/* ── API key ─────────────────────────────────────────── */}
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="api-key">API Key</Label>
+                <div className="flex items-center gap-2">
+                  <Input id="api-key" readOnly value={MOCK_API_KEY} className="font-mono text-sm" />
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => copy(MOCK_API_KEY)}
+                    aria-label={isCopied ? 'Copied' : 'Copy API key'}
+                  >
+                    {isCopied ? <CheckIcon className="size-4" /> : <CopyIcon className="size-4" />}
+                  </Button>
+                </div>
+                <p className="text-muted-foreground text-xs">
+                  Use this key to authenticate API requests. Keep it secret.
+                </p>
+              </div>
+
+              <div className="flex justify-end">
+                <Button>Save Changes</Button>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* ── Notifications tab ───────────────────────────────────── */}
+        <TabsContent value="notifications" className="mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Notification Preferences</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-6">
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor="notif-email" className="text-sm font-medium">
+                    Email Notifications
+                  </Label>
+                  <p className="text-muted-foreground text-xs">
+                    Receive email updates about project activity.
+                  </p>
+                </div>
+                <Switch id="notif-email" defaultChecked />
+              </div>
+
+              <Separator />
+
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor="notif-push" className="text-sm font-medium">
+                    Push Notifications
+                  </Label>
+                  <p className="text-muted-foreground text-xs">
+                    Get real-time push notifications in your browser.
+                  </p>
+                </div>
+                <Switch id="notif-push" defaultChecked />
+              </div>
+
+              <Separator />
+
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor="notif-digest" className="text-sm font-medium">
+                    Weekly Digest
+                  </Label>
+                  <p className="text-muted-foreground text-xs">
+                    Receive a weekly summary of all project updates.
+                  </p>
+                </div>
+                <Switch id="notif-digest" />
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* ── Appearance tab ──────────────────────────────────────── */}
+        <TabsContent value="appearance" className="mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Appearance</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-6">
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-1">
+                  <span className="text-foreground text-sm font-medium">Theme</span>
+                  <p className="text-muted-foreground text-xs">
+                    Choose between light, dark, or system theme.
+                  </p>
+                </div>
+                <ThemeToggleDropdown />
+              </div>
+
+              <Separator />
+
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor="density" className="text-sm font-medium">
+                    Density
+                  </Label>
+                  <p className="text-muted-foreground text-xs">
+                    Adjust the visual density of the interface.
+                  </p>
+                </div>
+                <Select defaultValue="comfortable">
+                  <SelectTrigger id="density" className="w-40">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="compact">Compact</SelectItem>
+                    <SelectItem value="comfortable">Comfortable</SelectItem>
+                    <SelectItem value="spacious">Spacious</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/taskflow/app/(shell)/team/page.tsx
+++ b/apps/taskflow/app/(shell)/team/page.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { UserPlusIcon } from 'lucide-react';
+
+import { PageHeader } from '@jonmatum/next-shell/layout';
+import {
+  Avatar,
+  AvatarFallback,
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@jonmatum/next-shell/primitives';
+import { RoleGate } from '@jonmatum/next-shell/auth';
+import { useDisclosure } from '@jonmatum/next-shell/hooks';
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Mock data
+ * ──────────────────────────────────────────────────────────────────────── */
+
+interface TeamMember {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: 'active' | 'away' | 'offline';
+}
+
+const TEAM_MEMBERS: TeamMember[] = [
+  {
+    id: 't1',
+    name: 'Sarah Chen',
+    email: 'sarah@taskflow.dev',
+    role: 'Project Manager',
+    status: 'active',
+  },
+  {
+    id: 't2',
+    name: 'Marcus Rivera',
+    email: 'marcus@taskflow.dev',
+    role: 'Senior Developer',
+    status: 'active',
+  },
+  {
+    id: 't3',
+    name: 'Priya Patel',
+    email: 'priya@taskflow.dev',
+    role: 'UX Designer',
+    status: 'active',
+  },
+  {
+    id: 't4',
+    name: 'Alex Kim',
+    email: 'alex@taskflow.dev',
+    role: 'Frontend Developer',
+    status: 'away',
+  },
+  {
+    id: 't5',
+    name: 'Jordan Lee',
+    email: 'jordan@taskflow.dev',
+    role: 'Backend Developer',
+    status: 'active',
+  },
+  {
+    id: 't6',
+    name: 'Taylor Morgan',
+    email: 'taylor@taskflow.dev',
+    role: 'DevOps Engineer',
+    status: 'offline',
+  },
+  {
+    id: 't7',
+    name: 'Riley Brooks',
+    email: 'riley@taskflow.dev',
+    role: 'QA Lead',
+    status: 'active',
+  },
+  {
+    id: 't8',
+    name: 'Casey Nguyen',
+    email: 'casey@taskflow.dev',
+    role: 'Product Designer',
+    status: 'away',
+  },
+];
+
+const STATUS_BADGE_VARIANT: Record<TeamMember['status'], 'default' | 'secondary' | 'outline'> = {
+  active: 'default',
+  away: 'secondary',
+  offline: 'outline',
+};
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase();
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Team page
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export default function TeamPage() {
+  const inviteSheet = useDisclosure();
+
+  return (
+    <div className="flex flex-col gap-8">
+      <PageHeader
+        title="Team"
+        description="Manage your team members and roles."
+        actions={
+          <RoleGate role="pm">
+            <Button onClick={inviteSheet.open}>
+              <UserPlusIcon className="size-4" />
+              Invite Member
+            </Button>
+          </RoleGate>
+        }
+      />
+
+      {/* ── Team member grid ───────────────────────────────────────── */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {TEAM_MEMBERS.map((member) => (
+          <Card key={member.id}>
+            <CardContent className="flex flex-col items-center gap-3 pt-6 text-center">
+              <Avatar className="size-16">
+                <AvatarFallback className="text-lg">{getInitials(member.name)}</AvatarFallback>
+              </Avatar>
+              <div className="flex flex-col gap-1">
+                <h3 className="text-foreground text-sm font-semibold">{member.name}</h3>
+                <p className="text-muted-foreground text-xs">{member.role}</p>
+                <p className="text-muted-foreground text-xs">{member.email}</p>
+              </div>
+              <Badge variant={STATUS_BADGE_VARIANT[member.status]}>{member.status}</Badge>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* ── Invite member sheet ────────────────────────────────────── */}
+      <Sheet open={inviteSheet.isOpen} onOpenChange={inviteSheet.onOpenChange}>
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>Invite Team Member</SheetTitle>
+            <SheetDescription>Send an invitation to join your TaskFlow workspace.</SheetDescription>
+          </SheetHeader>
+          <div className="flex flex-col gap-4 py-6">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="invite-name">Full Name</Label>
+              <Input id="invite-name" placeholder="e.g. Jane Doe" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="invite-email">Email Address</Label>
+              <Input id="invite-email" type="email" placeholder="jane@company.com" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="invite-role">Role</Label>
+              <Select>
+                <SelectTrigger id="invite-role">
+                  <SelectValue placeholder="Select a role" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="developer">Developer</SelectItem>
+                  <SelectItem value="designer">Designer</SelectItem>
+                  <SelectItem value="pm">Project Manager</SelectItem>
+                  <SelectItem value="qa">QA Engineer</SelectItem>
+                  <SelectItem value="devops">DevOps Engineer</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <SheetFooter>
+            <Button variant="outline" onClick={inviteSheet.close}>
+              Cancel
+            </Button>
+            <Button onClick={inviteSheet.close}>Send Invitation</Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}

--- a/apps/taskflow/app/error.tsx
+++ b/apps/taskflow/app/error.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { ErrorPage } from '@jonmatum/next-shell/layout';
+import { Button } from '@jonmatum/next-shell/primitives';
+
+export default function ErrorBoundary({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <ErrorPage
+      statusCode={500}
+      title="Something went wrong"
+      description={error.message}
+      action={<Button onClick={reset}>Try again</Button>}
+    />
+  );
+}

--- a/apps/taskflow/app/globals.css
+++ b/apps/taskflow/app/globals.css
@@ -1,0 +1,4 @@
+@import 'tailwindcss';
+@source '../../../packages/next-shell/src/**/*.{ts,tsx}';
+@import '@jonmatum/next-shell/styles/preset.css';
+@import '@jonmatum/next-shell/styles/presets/violet.css';

--- a/apps/taskflow/app/layout.tsx
+++ b/apps/taskflow/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import { Inter } from 'next/font/google';
+import { Providers } from './providers';
+import './globals.css';
+
+const inter = Inter({ variable: '--font-sans', subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'TaskFlow',
+  description: 'Project management powered by next-shell',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${inter.variable} antialiased`}>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/apps/taskflow/app/not-found.tsx
+++ b/apps/taskflow/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+import { NotFound } from '@jonmatum/next-shell/layout/server';
+import { Button } from '@jonmatum/next-shell/primitives';
+
+export default function NotFoundPage() {
+  return (
+    <NotFound
+      description="The page you are looking for does not exist."
+      action={
+        <Button asChild>
+          <Link href="/">Go home</Link>
+        </Button>
+      }
+    />
+  );
+}

--- a/apps/taskflow/app/page.tsx
+++ b/apps/taskflow/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Home() {
+  redirect('/dashboard');
+}

--- a/apps/taskflow/app/providers.tsx
+++ b/apps/taskflow/app/providers.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { AppProviders } from '@jonmatum/next-shell/providers';
+import { AuthProvider } from '@jonmatum/next-shell/auth';
+import { createMockAuthAdapter } from '@jonmatum/next-shell/auth/mock';
+
+const authAdapter = createMockAuthAdapter({
+  user: {
+    id: '1',
+    name: 'Sarah Chen',
+    email: 'sarah@taskflow.dev',
+    roles: ['admin', 'pm'],
+  },
+});
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <AppProviders themeProps={{ defaultTheme: 'system', enableSystem: true }}>
+      <AuthProvider adapter={authAdapter}>{children}</AuthProvider>
+    </AppProviders>
+  );
+}

--- a/apps/taskflow/next.config.ts
+++ b/apps/taskflow/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const config: NextConfig = {};
+
+export default config;

--- a/apps/taskflow/package.json
+++ b/apps/taskflow/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@jonmatum/taskflow",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3002",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@jonmatum/next-shell": "workspace:*",
+    "lucide-react": "^0.468.0",
+    "next": "^15.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "sonner": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/taskflow/postcss.config.mjs
+++ b/apps/taskflow/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};

--- a/apps/taskflow/tsconfig.json
+++ b/apps/taskflow/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "preserve",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,34 @@ importers:
         specifier: ^5.6.3
         version: 5.9.3
 
+  apps/taskflow:
+    dependencies:
+      '@jonmatum/next-shell':
+        specifier: workspace:*
+        version: link:../../packages/next-shell
+      lucide-react:
+        specifier: ^0.468.0
+        version: 0.468.0(react@19.2.5)
+      next:
+        specifier: ^15.1.0
+        version: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+      sonner:
+        specifier: ^2.0.0
+        version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/next-shell:
     dependencies:
       class-variance-authority:
@@ -3539,6 +3567,11 @@ packages:
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
+
+  lucide-react@0.468.0:
+    resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
   lucide-react@0.473.0:
     resolution: {integrity: sha512-KW6u5AKeIjkvrxXZ6WuCu9zHE/gEYSXCay+Gre2ZoInD0Je/e3RBtP4OHpJVJ40nDklSvjVKjgH7VU8/e2dzRw==}
@@ -8507,6 +8540,10 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.3.5: {}
+
+  lucide-react@0.468.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   lucide-react@0.473.0(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## Summary

New "TaskFlow" example app at `apps/taskflow/` — a project management app built entirely using the `next-shell-builder` skill and library APIs. Uses the **violet preset** for a distinct look from the default example.

This validates the skill + MCP tools work end-to-end for building real apps.

## Pages

| Page | Features exercised |
|------|-------------------|
| Dashboard | formatNumber, formatPercent, formatRelativeTime, useDisclosure + Dialog, SignedIn, Card, Badge |
| Projects | Table, Tabs, Badge, Progress, formatDate, formatRelativeTime |
| Team | Avatar, Card grid, RoleGate, useDisclosure + Sheet, Select |
| Settings | Tabs (Profile/Notifications/Appearance), Input, Textarea, Switch, ThemeToggleDropdown, Select, useCopyToClipboard |

## Shell

- AppShell + Sidebar + TopBar + Footer + CommandBar
- buildNav + SidebarNav + Breadcrumbs + CommandBarActions
- Mock auth (Sarah Chen, roles: admin + pm)
- Theme: violet preset, system-default with user switching

## Verification

```
pnpm format     ok
pnpm lint       ok (0 warnings)
```

https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4

---
_Generated by [Claude Code](https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4)_