### PR TITLE
fix: TaskFlow missing tailwindcss deps + update skill instructions

### DIFF
--- a/.claude/skills/next-shell-builder/SKILL.md
+++ b/.claude/skills/next-shell-builder/SKILL.md
@@ -25,6 +25,13 @@ Or manually:
 
 ```bash
 pnpm add @jonmatum/next-shell next@^15 react@^19 react-dom@^19 tailwindcss@^4
+pnpm add -D @tailwindcss/postcss@^4
+```
+
+### postcss.config.mjs (required)
+
+```js
+export default { plugins: { '@tailwindcss/postcss': {} } };
 ```
 
 ### globals.css (required)
@@ -34,6 +41,8 @@ pnpm add @jonmatum/next-shell next@^15 react@^19 react-dom@^19 tailwindcss@^4
 @source "node_modules/@jonmatum/next-shell/dist/**/*.{js,cjs}";
 @import '@jonmatum/next-shell/styles/preset.css';
 ```
+
+Both `tailwindcss` AND `@tailwindcss/postcss` are required dependencies. Without them, `@import 'tailwindcss'` in globals.css will fail with "Can't resolve 'tailwindcss'".
 
 The `@source` line is mandatory — Tailwind v4 skips node_modules by default.
 

--- a/apps/taskflow/package.json
+++ b/apps/taskflow/package.json
@@ -13,9 +13,11 @@
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "sonner": "^2.0.0"
+    "sonner": "^2.0.0",
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.2",
     "@types/react": "^19.0.0",
     "typescript": "^5.7.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,7 +178,13 @@ importers:
       sonner:
         specifier: ^2.0.0
         version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.2.2
     devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.2.2
+        version: 4.2.2
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14


### PR DESCRIPTION
## Summary

Fix TaskFlow app build failure — missing `tailwindcss` and `@tailwindcss/postcss` dependencies. Also update the `next-shell-builder` skill to include these deps in the setup instructions so this won't happen again.

## Changes

- `apps/taskflow/package.json` — add `tailwindcss: ^4.2.2` to dependencies, `@tailwindcss/postcss: ^4.2.2` to devDependencies
- `.claude/skills/next-shell-builder/SKILL.md` — add `@tailwindcss/postcss` to manual install command, add `postcss.config.mjs` example, add explanatory note

https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4

---
_Generated by [Claude Code](https://claude.ai/code/session_012jm3cqmXeTNn961PViqct4)_